### PR TITLE
open url in web browser

### DIFF
--- a/sdk/python/flet/flet.py
+++ b/sdk/python/flet/flet.py
@@ -3,6 +3,7 @@ import logging
 import os
 import signal
 import socket
+import subprocess
 import tarfile
 import tempfile
 import threading

--- a/sdk/python/flet/utils.py
+++ b/sdk/python/flet/utils.py
@@ -1,7 +1,7 @@
 import os
 import platform
-import subprocess
 import sys
+import webbrowser
 
 
 def is_windows():
@@ -47,10 +47,7 @@ def get_arch():
 
 
 def open_in_browser(url):
-    if is_windows():
-        subprocess.run(["explorer.exe", url])
-    elif is_macos():
-        subprocess.run(["open", url])
+    webbrowser.open(url)
 
 
 # https://stackoverflow.com/questions/377017/test-if-executable-exists-in-python


### PR DESCRIPTION
In Linux, the URL does not open in the browser automatically, so I removed the `subprocess` module and added the Python standard `webbrowser` module.

Ref: https://docs.python.org/3/library/webbrowser.html