### PR TITLE
Fix Container on_click callback

### DIFF
--- a/sdk/python/flet/container.py
+++ b/sdk/python/flet/container.py
@@ -181,7 +181,7 @@ class Container(ConstrainedControl):
     # on_click
     @property
     def on_click(self):
-        return self._get_event_handler("on_click")
+        return self._get_event_handler("click")
 
     @on_click.setter
     def on_click(self, handler):


### PR DESCRIPTION
Setter and getter event names did not match, causing `on_click` callbacks not to work.