### PR TITLE
Bugfix: Image control attribute src_base64 accepts str now

### DIFF
--- a/sdk/python/flet/image.py
+++ b/sdk/python/flet/image.py
@@ -56,7 +56,7 @@ class Image(ConstrainedControl):
         #
         # Specific
         #
-        src_base64: bool = None,
+        src_base64: str = None,
         repeat: ImageRepeat = None,
         fit: ImageFit = None,
         border_radius: BorderRadiusValue = None,


### PR DESCRIPTION
The Dart component for Image accepts either `src` (path as string), or `srcBase64` (Base64-encoded image as string).
See https://github.com/flet-dev/flet/blob/main/client/lib/controls/image.dart#L27-L28

This doesn't match Image control constructor on the Python library side:
See https://github.com/flet-dev/flet/blob/main/sdk/python/flet/image.py#L59

This PR aligns the Python component interface to the Dart one.