### PR TITLE
Window manager racing fix

### DIFF
--- a/client/linux/my_application.cc
+++ b/client/linux/my_application.cc
@@ -49,6 +49,7 @@ static void my_application_activate(GApplication* application) {
 
   gtk_window_set_default_size(window, 1280, 720);
   gtk_widget_show(GTK_WIDGET(window));
+  gtk_widget_hide(GTK_WIDGET(window));
 
   g_autoptr(FlDartProject) project = fl_dart_project_new();
   fl_dart_project_set_dart_entrypoint_arguments(project, self->dart_entrypoint_arguments);

--- a/client/macos/Runner/MainFlutterWindow.swift
+++ b/client/macos/Runner/MainFlutterWindow.swift
@@ -12,4 +12,9 @@ class MainFlutterWindow: NSWindow {
 
     super.awakeFromNib()
   }
+
+  override public func order(_ place: NSWindow.OrderingMode, relativeTo otherWin: Int) {
+    super.order(place, relativeTo: otherWin)
+    hiddenWindowAtLaunch()
+  }
 }

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -363,7 +363,7 @@ packages:
       name: window_manager
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.5"
+    version: "0.2.6"
   xml:
     dependency: transitive
     description:

--- a/client/windows/runner/win32_window.cpp
+++ b/client/windows/runner/win32_window.cpp
@@ -117,7 +117,7 @@ bool Win32Window::CreateAndShow(const std::wstring& title,
   double scale_factor = dpi / 96.0;
 
   HWND window = CreateWindow(
-      window_class, title.c_str(), WS_OVERLAPPEDWINDOW | WS_VISIBLE,
+      window_class, title.c_str(), WS_OVERLAPPEDWINDOW,
       Scale(origin.x, scale_factor), Scale(origin.y, scale_factor),
       Scale(size.width, scale_factor), Scale(size.height, scale_factor),
       nullptr, nullptr, GetModuleHandle(nullptr), this);

--- a/package/lib/src/controls/create_control.dart
+++ b/package/lib/src/controls/create_control.dart
@@ -472,7 +472,7 @@ Widget _expandable(Widget widget, Control? parent, Control control) {
       (parent.type == ControlType.view ||
           parent.type == ControlType.column ||
           parent.type == ControlType.row)) {
-    debugPrint("Expandable ${control.id}");
+    //debugPrint("Expandable ${control.id}");
     int? expand = control.attrInt("expand");
     return expand != null ? Expanded(child: widget, flex: expand) : widget;
   }

--- a/package/lib/src/controls/create_control.dart
+++ b/package/lib/src/controls/create_control.dart
@@ -52,6 +52,7 @@ import 'text.dart';
 import 'text_button.dart';
 import 'textfield.dart';
 import 'vertical_divider.dart';
+import 'window_drag_area.dart';
 
 Widget createControl(Control? parent, String id, bool parentDisabled) {
   //debugPrint("createControl(): $id");
@@ -283,6 +284,12 @@ Widget createControl(Control? parent, String id, bool parentDisabled) {
               parentDisabled: parentDisabled);
         case ControlType.navigationRail:
           return NavigationRailControl(
+              parent: parent,
+              control: controlView.control,
+              children: controlView.children,
+              parentDisabled: parentDisabled);
+        case ControlType.windowDragArea:
+          return WindowDragAreaControl(
               parent: parent,
               control: controlView.control,
               children: controlView.children,

--- a/package/lib/src/controls/page.dart
+++ b/package/lib/src/controls/page.dart
@@ -177,7 +177,7 @@ class _PageControlState extends State<PageControl> {
     var focused = widget.control.attrBool("windowFocused");
     var destroy = widget.control.attrBool("windowDestroy");
 
-    WidgetsBinding.instance.addPostFrameCallback((_) async {
+    updateWindow() async {
       // window title
       if (_windowTitle != windowTitle) {
         setWindowTitle(windowTitle);
@@ -276,9 +276,7 @@ class _PageControlState extends State<PageControl> {
       }
 
       // window center
-      if (windowCenter != _windowCenter) {
-        debugPrint(
-            "windowCenter: $windowCenter, _windowCenter: $_windowCenter");
+      if (windowCenter != _windowCenter && fullScreen != true) {
         await centerWindow();
         _windowCenter = windowCenter;
       }
@@ -287,7 +285,9 @@ class _PageControlState extends State<PageControl> {
       if (destroy == true) {
         await destroyWindow();
       }
-    });
+    }
+
+    updateWindow();
 
     return StoreConnector<AppState, Uri?>(
         distinct: true,

--- a/package/lib/src/controls/page.dart
+++ b/package/lib/src/controls/page.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_redux/flutter_redux.dart';
@@ -51,6 +52,7 @@ class PageControl extends StatefulWidget {
 }
 
 class _PageControlState extends State<PageControl> {
+  String? _windowTitle;
   String? _windowCenter;
   final _navigatorKey = GlobalKey<NavigatorState>();
   late final RouteState _routeState;
@@ -152,124 +154,140 @@ class _PageControlState extends State<PageControl> {
       _keyboardHandlerSubscribed = true;
     }
 
-    // window title
-    String title = widget.control.attrString("title", "")!;
-    setWindowTitle(title);
-
     // window params
-    var windowCenter = widget.control.attrString("windowCenter");
-    var fullScreen = widget.control.attrBool("windowFullScreen");
-
-    // window size
+    var windowTitle = widget.control.attrString("title", "")!;
     var windowWidth = widget.control.attrDouble("windowWidth");
     var windowHeight = widget.control.attrDouble("windowHeight");
-    if ((windowWidth != null || windowHeight != null) && fullScreen != true) {
-      debugPrint("setWindowSize: $windowWidth, $windowHeight");
-      setWindowSize(windowWidth, windowHeight);
-    }
-
-    // window min size
     var windowMinWidth = widget.control.attrDouble("windowMinWidth");
     var windowMinHeight = widget.control.attrDouble("windowMinHeight");
-    if (windowMinWidth != null || windowMinHeight != null) {
-      debugPrint("setWindowMinSize: $windowMinWidth, $windowMinHeight");
-      setWindowMinSize(windowMinWidth, windowMinHeight);
-    }
-
-    // window max size
     var windowMaxWidth = widget.control.attrDouble("windowMaxWidth");
     var windowMaxHeight = widget.control.attrDouble("windowMaxHeight");
-    if (windowMaxWidth != null || windowMaxHeight != null) {
-      debugPrint("setWindowMaxSize: $windowMaxWidth, $windowMaxHeight");
-      setWindowMaxSize(windowMaxWidth, windowMaxHeight);
-    }
-
-    // window position
     var windowTop = widget.control.attrDouble("windowTop");
     var windowLeft = widget.control.attrDouble("windowLeft");
-    if ((windowTop != null || windowLeft != null) &&
-        fullScreen != true &&
-        (windowCenter == null || windowCenter == "")) {
-      debugPrint("setWindowPosition: $windowTop, $windowLeft");
-      setWindowPosition(windowTop, windowLeft);
-    }
-
-    // window opacity
-    var opacity = widget.control.attrDouble("windowOpacity");
-    if (opacity != null) {
-      setWindowOpacity(opacity);
-    }
-
-    // window minimizable
-    var minimizable = widget.control.attrBool("windowMinimizable");
-    if (minimizable != null) {
-      setWindowMinimizability(minimizable);
-    }
-
-    // window minimize
+    var windowCenter = widget.control.attrString("windowCenter");
+    var fullScreen = widget.control.attrBool("windowFullScreen");
     var minimized = widget.control.attrBool("windowMinimized");
-    if (minimized == true) {
-      minimizeWindow();
-    } else if (minimized == false) {
-      restoreWindow();
-    }
-
-    // window maximize
     var maximized = widget.control.attrBool("windowMaximized");
-    if (maximized == true) {
-      maximizeWindow();
-    } else if (maximized == false) {
-      unmaximizeWindow();
-    }
-
-    // window resizable
-    var resizable = widget.control.attrBool("windowResizable");
-    if (resizable != null) {
-      setWindowResizability(resizable);
-    }
-
-    // window movable
-    var movable = widget.control.attrBool("windowMovable");
-    if (movable != null) {
-      setWindowMovability(movable);
-    }
-
-    // window fullScreen
-    if (fullScreen != null) {
-      setWindowFullScreen(fullScreen);
-    }
-
-    // window alwaysOnTop
+    var opacity = widget.control.attrDouble("windowOpacity");
+    var minimizable = widget.control.attrBool("windowMinimizable");
     var alwaysOnTop = widget.control.attrBool("windowAlwaysOnTop");
-    if (alwaysOnTop != null) {
-      setWindowAlwaysOnTop(alwaysOnTop);
-    }
-
-    // window preventClose
+    var resizable = widget.control.attrBool("windowResizable");
+    var movable = widget.control.attrBool("windowMovable");
     var preventClose = widget.control.attrBool("windowPreventClose");
-    if (preventClose != null) {
-      setWindowPreventClose(preventClose);
-    }
-
-    // window focus
     var focused = widget.control.attrBool("windowFocused");
-    if (focused == true) {
-      focusWindow();
-    } else if (focused == false) {
-      blurWindow();
-    }
-
-    // window center
-    if (windowCenter != _windowCenter) {
-      centerWindow();
-      _windowCenter = windowCenter;
-    }
-
-    // window destroy
     var destroy = widget.control.attrBool("windowDestroy");
-    if (destroy == true) {
-      destroyWindow();
-    }
+
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      // window title
+      if (_windowTitle != windowTitle) {
+        setWindowTitle(windowTitle);
+        _windowTitle = windowTitle;
+      }
+
+      // window size
+      if ((windowWidth != null || windowHeight != null) &&
+          fullScreen != true &&
+          (defaultTargetPlatform != TargetPlatform.macOS ||
+              (defaultTargetPlatform == TargetPlatform.macOS &&
+                  maximized == false &&
+                  minimized == false))) {
+        debugPrint("setWindowSize: $windowWidth, $windowHeight");
+        await setWindowSize(windowWidth, windowHeight);
+      }
+
+      // window min size
+      if (windowMinWidth != null || windowMinHeight != null) {
+        debugPrint("setWindowMinSize: $windowMinWidth, $windowMinHeight");
+        await setWindowMinSize(windowMinWidth, windowMinHeight);
+      }
+
+      // window max size
+      if (windowMaxWidth != null || windowMaxHeight != null) {
+        debugPrint("setWindowMaxSize: $windowMaxWidth, $windowMaxHeight");
+        await setWindowMaxSize(windowMaxWidth, windowMaxHeight);
+      }
+
+      // window position
+      if ((windowTop != null || windowLeft != null) &&
+          fullScreen != true &&
+          (windowCenter == null || windowCenter == "") &&
+          (defaultTargetPlatform != TargetPlatform.macOS ||
+              (defaultTargetPlatform == TargetPlatform.macOS &&
+                  maximized == false &&
+                  minimized == false))) {
+        debugPrint("setWindowPosition: $windowTop, $windowLeft");
+        await setWindowPosition(windowTop, windowLeft);
+      }
+
+      // window opacity
+      if (opacity != null) {
+        await setWindowOpacity(opacity);
+      }
+
+      // window minimizable
+      if (minimizable != null) {
+        await setWindowMinimizability(minimizable);
+      }
+
+      // window minimize
+      if (minimized == true) {
+        await minimizeWindow();
+      } else if (minimized == false && maximized == false) {
+        await restoreWindow();
+      }
+
+      // window maximize
+      if (maximized == true) {
+        await maximizeWindow();
+      } else if (maximized == false) {
+        await unmaximizeWindow();
+      }
+
+      // window resizable
+      if (resizable != null) {
+        await setWindowResizability(resizable);
+      }
+
+      // window movable
+      if (movable != null) {
+        await setWindowMovability(movable);
+      }
+
+      // window fullScreen
+      if (fullScreen != null) {
+        await setWindowFullScreen(fullScreen);
+      }
+
+      // window alwaysOnTop
+      if (alwaysOnTop != null) {
+        await setWindowAlwaysOnTop(alwaysOnTop);
+      }
+
+      // window preventClose
+      if (preventClose != null) {
+        await setWindowPreventClose(preventClose);
+      }
+
+      // window focus
+      if (focused == true) {
+        await focusWindow();
+      } else if (focused == false) {
+        await blurWindow();
+      }
+
+      // window center
+      if (windowCenter != _windowCenter) {
+        debugPrint(
+            "windowCenter: $windowCenter, _windowCenter: $_windowCenter");
+        await centerWindow();
+        _windowCenter = windowCenter;
+      }
+
+      // window destroy
+      if (destroy == true) {
+        await destroyWindow();
+      }
+    });
 
     return StoreConnector<AppState, Uri?>(
         distinct: true,
@@ -298,7 +316,7 @@ class _PageControlState extends State<PageControl> {
                       widget.control.attrBool("showSemanticsDebugger", false)!,
                   routerDelegate: _routerDelegate,
                   routeInformationParser: _routeParser,
-                  title: title,
+                  title: windowTitle,
                   theme: lightTheme,
                   darkTheme: darkTheme,
                   themeMode: themeMode,
@@ -330,7 +348,7 @@ class _PageControlState extends State<PageControl> {
             )));
           } else {
             // offstage
-            _overlayWidgets(String viewId) {
+            overlayWidgets(String viewId) {
               List<Widget> overlayWidgets = [];
 
               if (viewId == routesView.viewIds.last) {
@@ -350,7 +368,7 @@ class _PageControlState extends State<PageControl> {
             pages = routesView.viewIds.map((viewId) {
               var key = ValueKey(viewId);
               var child = _buildViewWidget(
-                  routesView.page, viewId, _overlayWidgets(viewId));
+                  routesView.page, viewId, overlayWidgets(viewId));
               return _routeChanges > 0
                   ? FadeTransitionPage(key: key, child: child)
                   : MaterialPage(key: key, child: child);

--- a/package/lib/src/controls/page.dart
+++ b/package/lib/src/controls/page.dart
@@ -54,6 +54,11 @@ class PageControl extends StatefulWidget {
 class _PageControlState extends State<PageControl> {
   String? _windowTitle;
   String? _windowCenter;
+  String? _windowClose;
+  bool? _windowFrameless;
+  bool? _windowTitleBarHidden;
+  bool? _windowSkipTaskBar;
+  double? _windowProgressBar;
   final _navigatorKey = GlobalKey<NavigatorState>();
   late final RouteState _routeState;
   late final SimpleRouterDelegate _routerDelegate;
@@ -165,6 +170,7 @@ class _PageControlState extends State<PageControl> {
     var windowTop = widget.control.attrDouble("windowTop");
     var windowLeft = widget.control.attrDouble("windowLeft");
     var windowCenter = widget.control.attrString("windowCenter");
+    var windowClose = widget.control.attrString("windowClose");
     var windowFullScreen = widget.control.attrBool("windowFullScreen");
     var windowMinimized = widget.control.attrBool("windowMinimized");
     var windowMaximized = widget.control.attrBool("windowMaximized");
@@ -180,6 +186,9 @@ class _PageControlState extends State<PageControl> {
     var windowVisible = widget.control.attrBool("windowVisible");
     var windowFocused = widget.control.attrBool("windowFocused");
     var windowDestroy = widget.control.attrBool("windowDestroy");
+    var windowSkipTaskBar = widget.control.attrBool("windowSkipTaskBar");
+    var windowFrameless = widget.control.attrBool("windowFrameless");
+    var windowProgressBar = widget.control.attrDouble("windowProgressBar");
 
     updateWindow() async {
       // window title
@@ -272,9 +281,11 @@ class _PageControlState extends State<PageControl> {
         await setWindowPreventClose(windowPreventClose);
       }
 
-      if (windowTitleBarHidden != null) {
+      if (windowTitleBarHidden != null &&
+          windowTitleBarHidden != _windowTitleBarHidden) {
         await setWindowTitleBarVisibility(
             windowTitleBarHidden, windowTitleBarButtonsHidden);
+        _windowTitleBarHidden = windowTitleBarHidden;
       }
 
       // window visible
@@ -295,6 +306,31 @@ class _PageControlState extends State<PageControl> {
       if (windowCenter != _windowCenter && windowFullScreen != true) {
         await centerWindow();
         _windowCenter = windowCenter;
+      }
+
+      // window frameless
+      if (windowFrameless != _windowFrameless && windowFrameless == true) {
+        await setWindowFrameless();
+        _windowFrameless = windowFrameless;
+      }
+
+      // window progress
+      if (windowProgressBar != _windowProgressBar &&
+          windowProgressBar != null) {
+        await setWindowProgressBar(windowProgressBar);
+        _windowProgressBar = windowProgressBar;
+      }
+
+      if (windowSkipTaskBar != null &&
+          windowSkipTaskBar != _windowSkipTaskBar) {
+        await setWindowSkipTaskBar(windowSkipTaskBar);
+        _windowSkipTaskBar = windowSkipTaskBar;
+      }
+
+      // window close
+      if (windowClose != _windowClose) {
+        await closeWindow();
+        _windowClose = windowClose;
       }
 
       // window destroy

--- a/package/lib/src/controls/page.dart
+++ b/package/lib/src/controls/page.dart
@@ -165,17 +165,21 @@ class _PageControlState extends State<PageControl> {
     var windowTop = widget.control.attrDouble("windowTop");
     var windowLeft = widget.control.attrDouble("windowLeft");
     var windowCenter = widget.control.attrString("windowCenter");
-    var fullScreen = widget.control.attrBool("windowFullScreen");
-    var minimized = widget.control.attrBool("windowMinimized");
-    var maximized = widget.control.attrBool("windowMaximized");
-    var opacity = widget.control.attrDouble("windowOpacity");
+    var windowFullScreen = widget.control.attrBool("windowFullScreen");
+    var windowMinimized = widget.control.attrBool("windowMinimized");
+    var windowMaximized = widget.control.attrBool("windowMaximized");
+    var windowOpacity = widget.control.attrDouble("windowOpacity");
     var minimizable = widget.control.attrBool("windowMinimizable");
-    var alwaysOnTop = widget.control.attrBool("windowAlwaysOnTop");
-    var resizable = widget.control.attrBool("windowResizable");
-    var movable = widget.control.attrBool("windowMovable");
-    var preventClose = widget.control.attrBool("windowPreventClose");
-    var focused = widget.control.attrBool("windowFocused");
-    var destroy = widget.control.attrBool("windowDestroy");
+    var windowAlwaysOnTop = widget.control.attrBool("windowAlwaysOnTop");
+    var windowResizable = widget.control.attrBool("windowResizable");
+    var windowMovable = widget.control.attrBool("windowMovable");
+    var windowPreventClose = widget.control.attrBool("windowPreventClose");
+    var windowTitleBarHidden = widget.control.attrBool("windowTitleBarHidden");
+    var windowTitleBarButtonsHidden =
+        widget.control.attrBool("windowTitleBarButtonsHidden", false)!;
+    var windowVisible = widget.control.attrBool("windowVisible");
+    var windowFocused = widget.control.attrBool("windowFocused");
+    var windowDestroy = widget.control.attrBool("windowDestroy");
 
     updateWindow() async {
       // window title
@@ -186,11 +190,11 @@ class _PageControlState extends State<PageControl> {
 
       // window size
       if ((windowWidth != null || windowHeight != null) &&
-          fullScreen != true &&
+          windowFullScreen != true &&
           (defaultTargetPlatform != TargetPlatform.macOS ||
               (defaultTargetPlatform == TargetPlatform.macOS &&
-                  maximized == false &&
-                  minimized == false))) {
+                  windowMaximized == false &&
+                  windowMinimized == false))) {
         debugPrint("setWindowSize: $windowWidth, $windowHeight");
         await setWindowSize(windowWidth, windowHeight);
       }
@@ -209,19 +213,19 @@ class _PageControlState extends State<PageControl> {
 
       // window position
       if ((windowTop != null || windowLeft != null) &&
-          fullScreen != true &&
+          windowFullScreen != true &&
           (windowCenter == null || windowCenter == "") &&
           (defaultTargetPlatform != TargetPlatform.macOS ||
               (defaultTargetPlatform == TargetPlatform.macOS &&
-                  maximized == false &&
-                  minimized == false))) {
+                  windowMaximized == false &&
+                  windowMinimized == false))) {
         debugPrint("setWindowPosition: $windowTop, $windowLeft");
         await setWindowPosition(windowTop, windowLeft);
       }
 
       // window opacity
-      if (opacity != null) {
-        await setWindowOpacity(opacity);
+      if (windowOpacity != null) {
+        await setWindowOpacity(windowOpacity);
       }
 
       // window minimizable
@@ -230,59 +234,71 @@ class _PageControlState extends State<PageControl> {
       }
 
       // window minimize
-      if (minimized == true) {
+      if (windowMinimized == true) {
         await minimizeWindow();
-      } else if (minimized == false && maximized == false) {
+      } else if (windowMinimized == false && windowMaximized == false) {
         await restoreWindow();
       }
 
       // window maximize
-      if (maximized == true) {
+      if (windowMaximized == true) {
         await maximizeWindow();
-      } else if (maximized == false) {
+      } else if (windowMaximized == false) {
         await unmaximizeWindow();
       }
 
       // window resizable
-      if (resizable != null) {
-        await setWindowResizability(resizable);
+      if (windowResizable != null) {
+        await setWindowResizability(windowResizable);
       }
 
       // window movable
-      if (movable != null) {
-        await setWindowMovability(movable);
+      if (windowMovable != null) {
+        await setWindowMovability(windowMovable);
       }
 
       // window fullScreen
-      if (fullScreen != null) {
-        await setWindowFullScreen(fullScreen);
+      if (windowFullScreen != null) {
+        await setWindowFullScreen(windowFullScreen);
       }
 
       // window alwaysOnTop
-      if (alwaysOnTop != null) {
-        await setWindowAlwaysOnTop(alwaysOnTop);
+      if (windowAlwaysOnTop != null) {
+        await setWindowAlwaysOnTop(windowAlwaysOnTop);
       }
 
       // window preventClose
-      if (preventClose != null) {
-        await setWindowPreventClose(preventClose);
+      if (windowPreventClose != null) {
+        await setWindowPreventClose(windowPreventClose);
+      }
+
+      if (windowTitleBarHidden != null) {
+        await setWindowTitleBarVisibility(
+            windowTitleBarHidden, windowTitleBarButtonsHidden);
+      }
+
+      // window visible
+      if (windowVisible == true) {
+        await showWindow();
+      } else if (windowVisible == false) {
+        await hideWindow();
       }
 
       // window focus
-      if (focused == true) {
+      if (windowFocused == true) {
         await focusWindow();
-      } else if (focused == false) {
+      } else if (windowFocused == false) {
         await blurWindow();
       }
 
       // window center
-      if (windowCenter != _windowCenter && fullScreen != true) {
+      if (windowCenter != _windowCenter && windowFullScreen != true) {
         await centerWindow();
         _windowCenter = windowCenter;
       }
 
       // window destroy
-      if (destroy == true) {
+      if (windowDestroy == true) {
         await destroyWindow();
       }
     }

--- a/package/lib/src/controls/stack.dart
+++ b/package/lib/src/controls/stack.dart
@@ -21,10 +21,17 @@ class StackControl extends StatelessWidget {
   Widget build(BuildContext context) {
     debugPrint("Stack build: ${control.id}");
 
+    var clipBehavior = Clip.values.firstWhere(
+        (e) =>
+            e.name.toLowerCase() ==
+            control.attrString("clipBehavior", "")!.toLowerCase(),
+        orElse: () => Clip.hardEdge);
+
     bool disabled = control.isDisabled || parentDisabled;
 
     return constrainedControl(
         Stack(
+          clipBehavior: clipBehavior,
           children: children
               .where((c) => c.isVisible)
               .map((c) => createControl(control, c.id, disabled))

--- a/package/lib/src/controls/window_drag_area.dart
+++ b/package/lib/src/controls/window_drag_area.dart
@@ -1,0 +1,37 @@
+import 'package:flet/src/controls/error.dart';
+import 'package:flutter/material.dart';
+import 'package:window_manager/window_manager.dart';
+
+import '../models/control.dart';
+import 'create_control.dart';
+
+class WindowDragAreaControl extends StatelessWidget {
+  final Control? parent;
+  final Control control;
+  final List<Control> children;
+  final bool parentDisabled;
+
+  const WindowDragAreaControl(
+      {Key? key,
+      this.parent,
+      required this.control,
+      required this.children,
+      required this.parentDisabled})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    debugPrint("WindowDragArea build: ${control.id}");
+
+    var contentCtrls =
+        children.where((c) => c.name == "content" && c.isVisible);
+    bool disabled = control.isDisabled || parentDisabled;
+
+    if (contentCtrls.isEmpty) {
+      return const ErrorControl("WindowDragArea should have content.");
+    }
+
+    return DragToMoveArea(
+        child: createControl(control, contentCtrls.first.id, disabled));
+  }
+}

--- a/package/lib/src/controls/window_drag_area.dart
+++ b/package/lib/src/controls/window_drag_area.dart
@@ -31,7 +31,10 @@ class WindowDragAreaControl extends StatelessWidget {
       return const ErrorControl("WindowDragArea should have content.");
     }
 
-    return DragToMoveArea(
-        child: createControl(control, contentCtrls.first.id, disabled));
+    return constrainedControl(
+        DragToMoveArea(
+            child: createControl(control, contentCtrls.first.id, disabled)),
+        parent,
+        control);
   }
 }

--- a/package/lib/src/models/control_type.dart
+++ b/package/lib/src/models/control_type.dart
@@ -49,5 +49,6 @@ enum ControlType {
   textButton,
   textField,
   verticalDivider,
-  view
+  view,
+  windowDragArea
 }

--- a/package/lib/src/models/window_media_data.dart
+++ b/package/lib/src/models/window_media_data.dart
@@ -8,8 +8,8 @@ class WindowMediaData {
   bool? isClosable;
   bool? isAlwaysOnTop;
   bool? isFocused;
-  bool? isTitleBarHidden;
   bool? isPreventClose;
+  bool? isVisible;
   double? width;
   double? height;
   double? top;

--- a/package/lib/src/reducers.dart
+++ b/package/lib/src/reducers.dart
@@ -280,6 +280,7 @@ addWindowMediaEventProps(WindowMediaData wmd, Map<String, String> pageAttrs,
   pageAttrs["windowminimized"] = wmd.isMinimized.toString();
   pageAttrs["windowmaximized"] = wmd.isMaximized.toString();
   pageAttrs["windowfocused"] = wmd.isFocused.toString();
+  pageAttrs["windowfullscreen"] = wmd.isFullScreen.toString();
 
   props.addAll([
     {"i": "page", "windowwidth": wmd.width.toString()},
@@ -289,6 +290,7 @@ addWindowMediaEventProps(WindowMediaData wmd, Map<String, String> pageAttrs,
     {"i": "page", "windowminimized": wmd.isMinimized.toString()},
     {"i": "page", "windowmaximized": wmd.isMaximized.toString()},
     {"i": "page", "windowfocused": wmd.isFocused.toString()},
+    {"i": "page", "windowfullscreen": wmd.isFullScreen.toString()},
   ]);
 }
 

--- a/package/lib/src/utils.dart
+++ b/package/lib/src/utils.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:window_manager/window_manager.dart';
 
@@ -6,7 +7,25 @@ import 'utils/desktop.dart';
 Future setupDesktop() async {
   if (isDesktop()) {
     WidgetsFlutterBinding.ensureInitialized();
-    // Must add this line.
     await windowManager.ensureInitialized();
+
+    WindowOptions windowOptions = WindowOptions(
+      size: Size(800, 600),
+      center: true,
+      backgroundColor: Colors.transparent,
+      skipTaskbar: false,
+      titleBarStyle: TitleBarStyle.hidden,
+    );
+
+    await windowManager.waitUntilReadyToShow(null, () async {
+      //await windowManager.show();
+      //await windowManager.focus();
+      Future.delayed(Duration(seconds: 5)).then((value) async {
+        await windowManager.setTitleBarStyle(TitleBarStyle.hidden,
+            windowButtonVisibility: false);
+        await windowManager.show();
+        await windowManager.focus();
+      });
+    });
   }
 }

--- a/package/lib/src/utils.dart
+++ b/package/lib/src/utils.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:window_manager/window_manager.dart';
@@ -9,23 +11,15 @@ Future setupDesktop() async {
     WidgetsFlutterBinding.ensureInitialized();
     await windowManager.ensureInitialized();
 
-    WindowOptions windowOptions = WindowOptions(
-      size: Size(800, 600),
-      center: true,
-      backgroundColor: Colors.transparent,
-      skipTaskbar: false,
-      titleBarStyle: TitleBarStyle.hidden,
-    );
+    Map<String, String> env = Platform.environment;
+    var hideWindowOnStart = env["FLET_HIDE_WINDOW_ON_START"];
+    debugPrint("hideWindowOnStart: $hideWindowOnStart");
 
     await windowManager.waitUntilReadyToShow(null, () async {
-      //await windowManager.show();
-      //await windowManager.focus();
-      Future.delayed(Duration(seconds: 5)).then((value) async {
-        await windowManager.setTitleBarStyle(TitleBarStyle.hidden,
-            windowButtonVisibility: false);
+      if (hideWindowOnStart == null) {
         await windowManager.show();
         await windowManager.focus();
-      });
+      }
     });
   }
 }

--- a/package/lib/src/utils/desktop.dart
+++ b/package/lib/src/utils/desktop.dart
@@ -104,6 +104,27 @@ Future setWindowTitleBarVisibility(
   }
 }
 
+Future setWindowSkipTaskBar(bool skipTaskBar) async {
+  if (isDesktop()) {
+    debugPrint("setWindowSkipTaskBar()");
+    await windowManager.setSkipTaskbar(skipTaskBar);
+  }
+}
+
+Future setWindowFrameless() async {
+  if (isDesktop()) {
+    debugPrint("setWindowFrameless()");
+    await windowManager.setAsFrameless();
+  }
+}
+
+Future setWindowProgressBar(double progress) async {
+  if (isDesktop()) {
+    debugPrint("setWindowProgressBar()");
+    await windowManager.setProgressBar(progress);
+  }
+}
+
 Future minimizeWindow() async {
   if (isDesktop() && !await windowManager.isMinimized()) {
     debugPrint("minimizeWindow()");
@@ -176,6 +197,13 @@ Future centerWindow() async {
   if (isDesktop()) {
     debugPrint("centerWindow()");
     await windowManager.center();
+  }
+}
+
+Future closeWindow() async {
+  if (isDesktop()) {
+    debugPrint("closeWindow()");
+    await windowManager.close();
   }
 }
 

--- a/package/lib/src/utils/desktop.dart
+++ b/package/lib/src/utils/desktop.dart
@@ -3,17 +3,16 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:window_manager/window_manager.dart';
 
-const double windowWidth = 480;
-const double windowHeight = 854;
-
 Future setWindowTitle(String title) async {
   if (isDesktop()) {
+    debugPrint("setWindowTitle()");
     await windowManager.setTitle(title);
   }
 }
 
 Future setWindowSize(double? width, double? height) async {
   if (isDesktop()) {
+    debugPrint("setWindowSize()");
     var currentSize = await windowManager.getSize();
     await windowManager.setSize(
         Size(width ?? currentSize.width, height ?? currentSize.height),
@@ -23,18 +22,21 @@ Future setWindowSize(double? width, double? height) async {
 
 Future setWindowMinSize(double? minWidth, double? minHeight) async {
   if (isDesktop()) {
+    debugPrint("setWindowMinSize()");
     await windowManager.setMinimumSize(Size(minWidth ?? 0, minHeight ?? 0));
   }
 }
 
 Future setWindowMaxSize(double? maxWidth, double? maxHeight) async {
   if (isDesktop()) {
+    debugPrint("setWindowMaxSize()");
     await windowManager.setMaximumSize(Size(maxWidth ?? -1, maxHeight ?? -1));
   }
 }
 
 Future setWindowPosition(double? top, double? left) async {
   if (isDesktop()) {
+    debugPrint("setWindowPosition()");
     var currentPos = await windowManager.getPosition();
     await windowManager.setPosition(
         Offset(left ?? currentPos.dx, top ?? currentPos.dy),
@@ -44,66 +46,77 @@ Future setWindowPosition(double? top, double? left) async {
 
 Future setWindowOpacity(double opacity) async {
   if (isDesktop()) {
+    debugPrint("setWindowOpacity()");
     await windowManager.setOpacity(opacity);
   }
 }
 
 Future setWindowMinimizability(bool minimizable) async {
   if (isDesktop()) {
+    debugPrint("setWindowMinimizability()");
     await windowManager.setMinimizable(minimizable);
   }
 }
 
 Future setWindowResizability(bool resizable) async {
   if (isDesktop()) {
+    debugPrint("setWindowResizability()");
     await windowManager.setResizable(resizable);
   }
 }
 
 Future setWindowMovability(bool movable) async {
   if (isDesktop()) {
+    debugPrint("setWindowMovability()");
     await windowManager.setMovable(movable);
   }
 }
 
 Future setWindowFullScreen(bool fullScreen) async {
   if (isDesktop()) {
+    debugPrint("setWindowFullScreen()");
     await windowManager.setFullScreen(fullScreen);
   }
 }
 
 Future setWindowAlwaysOnTop(bool alwaysOnTop) async {
-  if (isDesktop()) {
+  if (isDesktop() && !await windowManager.isAlwaysOnTop()) {
+    debugPrint("setWindowAlwaysOnTop()");
     await windowManager.setAlwaysOnTop(alwaysOnTop);
   }
 }
 
 Future setWindowPreventClose(bool preventClose) async {
   if (isDesktop()) {
+    debugPrint("setWindowPreventClose()");
     await windowManager.setPreventClose(preventClose);
   }
 }
 
 Future minimizeWindow() async {
   if (isDesktop() && !await windowManager.isMinimized()) {
+    debugPrint("minimizeWindow()");
     await windowManager.minimize();
   }
 }
 
 Future restoreWindow() async {
-  if (isDesktop() && await windowManager.isMinimized()) {
+  if (isDesktop() && !await windowManager.isMinimized()) {
+    debugPrint("restoreWindow()");
     await windowManager.restore();
   }
 }
 
 Future maximizeWindow() async {
   if (isDesktop() && !await windowManager.isMaximized()) {
+    debugPrint("maximizeWindow()");
     await windowManager.maximize();
   }
 }
 
 Future unmaximizeWindow() async {
   if (isDesktop() && await windowManager.isMaximized()) {
+    debugPrint("unmaximizeWindow()");
     await windowManager.unmaximize();
   }
 }
@@ -113,6 +126,7 @@ Future focusWindow() async {
       (defaultTargetPlatform == TargetPlatform.windows ||
           defaultTargetPlatform == TargetPlatform.macOS) &&
       !await windowManager.isFocused()) {
+    debugPrint("focusWindow()");
     await windowManager.focus();
   }
 }
@@ -122,18 +136,21 @@ Future blurWindow() async {
       (defaultTargetPlatform == TargetPlatform.windows ||
           defaultTargetPlatform == TargetPlatform.macOS) &&
       await windowManager.isFocused()) {
+    debugPrint("blurWindow()");
     await windowManager.blur();
   }
 }
 
 Future destroyWindow() async {
   if (isDesktop()) {
+    debugPrint("destroyWindow()");
     await windowManager.destroy();
   }
 }
 
 Future centerWindow() async {
   if (isDesktop()) {
+    debugPrint("centerWindow()");
     await windowManager.center();
   }
 }

--- a/package/lib/src/utils/desktop.dart
+++ b/package/lib/src/utils/desktop.dart
@@ -73,14 +73,14 @@ Future setWindowMovability(bool movable) async {
 }
 
 Future setWindowFullScreen(bool fullScreen) async {
-  if (isDesktop()) {
+  if (isDesktop() && await windowManager.isFullScreen() != fullScreen) {
     debugPrint("setWindowFullScreen()");
     await windowManager.setFullScreen(fullScreen);
   }
 }
 
 Future setWindowAlwaysOnTop(bool alwaysOnTop) async {
-  if (isDesktop() && !await windowManager.isAlwaysOnTop()) {
+  if (isDesktop() && await windowManager.isAlwaysOnTop() != alwaysOnTop) {
     debugPrint("setWindowAlwaysOnTop()");
     await windowManager.setAlwaysOnTop(alwaysOnTop);
   }
@@ -101,7 +101,7 @@ Future minimizeWindow() async {
 }
 
 Future restoreWindow() async {
-  if (isDesktop() && !await windowManager.isMinimized()) {
+  if (isDesktop() && await windowManager.isMinimized()) {
     debugPrint("restoreWindow()");
     await windowManager.restore();
   }
@@ -125,7 +125,8 @@ Future focusWindow() async {
   if (isDesktop() &&
       (defaultTargetPlatform == TargetPlatform.windows ||
           defaultTargetPlatform == TargetPlatform.macOS) &&
-      !await windowManager.isFocused()) {
+      !await windowManager.isFocused() &&
+      !await windowManager.isMinimized()) {
     debugPrint("focusWindow()");
     await windowManager.focus();
   }
@@ -171,6 +172,7 @@ Future<WindowMediaData> getWindowMediaData() async {
     m.isMaximized = await windowManager.isMaximized();
     m.isMinimized = await windowManager.isMinimized();
     m.isFocused = await isFocused();
+    m.isFullScreen = await windowManager.isFullScreen();
     m.isTitleBarHidden = false;
     var size = await windowManager.getSize();
     m.width = size.width;

--- a/package/lib/src/utils/desktop.dart
+++ b/package/lib/src/utils/desktop.dart
@@ -1,7 +1,8 @@
-import '../models/window_media_data.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:window_manager/window_manager.dart';
+
+import '../models/window_media_data.dart';
 
 Future setWindowTitle(String title) async {
   if (isDesktop()) {
@@ -93,6 +94,16 @@ Future setWindowPreventClose(bool preventClose) async {
   }
 }
 
+Future setWindowTitleBarVisibility(
+    bool titleBarHidden, bool titleBarButtonsHidden) async {
+  if (isDesktop()) {
+    debugPrint("setWindowTitleBarVisibility()");
+    await windowManager.setTitleBarStyle(
+        titleBarHidden ? TitleBarStyle.hidden : TitleBarStyle.normal,
+        windowButtonVisibility: !titleBarButtonsHidden);
+  }
+}
+
 Future minimizeWindow() async {
   if (isDesktop() && !await windowManager.isMinimized()) {
     debugPrint("minimizeWindow()");
@@ -121,10 +132,22 @@ Future unmaximizeWindow() async {
   }
 }
 
+Future showWindow() async {
+  if (isDesktop() && !await windowManager.isVisible()) {
+    debugPrint("showWindow()");
+    await windowManager.show();
+  }
+}
+
+Future hideWindow() async {
+  if (isDesktop() && await windowManager.isVisible()) {
+    debugPrint("hideWindow()");
+    await windowManager.hide();
+  }
+}
+
 Future focusWindow() async {
   if (isDesktop() &&
-      (defaultTargetPlatform == TargetPlatform.windows ||
-          defaultTargetPlatform == TargetPlatform.macOS) &&
       !await windowManager.isFocused() &&
       !await windowManager.isMinimized()) {
     debugPrint("focusWindow()");
@@ -173,7 +196,7 @@ Future<WindowMediaData> getWindowMediaData() async {
     m.isMinimized = await windowManager.isMinimized();
     m.isFocused = await isFocused();
     m.isFullScreen = await windowManager.isFullScreen();
-    m.isTitleBarHidden = false;
+    m.isVisible = await windowManager.isVisible();
     var size = await windowManager.getSize();
     m.width = size.width;
     m.height = size.height;

--- a/package/lib/src/widgets/page_media.dart
+++ b/package/lib/src/widgets/page_media.dart
@@ -28,7 +28,7 @@ class _PageMediaState extends State<PageMedia> {
   _onScreenSizeChanged(bool isRegistered, Size newSize, Function dispatch) {
     if (isRegistered) {
       if (_debounce?.isActive ?? false) _debounce!.cancel();
-      _debounce = Timer(const Duration(milliseconds: 200), () {
+      _debounce = Timer(const Duration(milliseconds: 300), () {
         debugPrint("Send current size to reducer: $newSize");
         getWindowMediaData().then((wmd) {
           dispatch(PageSizeChangeAction(

--- a/package/lib/src/widgets/window_media.dart
+++ b/package/lib/src/widgets/window_media.dart
@@ -46,14 +46,18 @@ class _WindowMediaState extends State<WindowMedia> with WindowListener {
 
   @override
   void onWindowEvent(String eventName) {
-    if (_debounce?.isActive ?? false) _debounce!.cancel();
-    _debounce = Timer(const Duration(milliseconds: 200), () {
-      debugPrint('[WindowManager] onWindowEvent: $eventName');
-      getWindowMediaData().then((wmd) {
-        debugPrint("WindowMediaData: $wmd");
-        _dispatch!(
-            WindowEventAction(eventName, wmd, FletAppServices.of(context).ws));
+    //debugPrint('START [WindowManager] onWindowEvent: $eventName');
+
+    if (eventName != "resize" && eventName != "move") {
+      if (_debounce?.isActive ?? false) _debounce!.cancel();
+      _debounce = Timer(const Duration(milliseconds: 200), () {
+        debugPrint('[WindowManager] onWindowEvent: $eventName');
+        getWindowMediaData().then((wmd) {
+          debugPrint("WindowMediaData: $wmd");
+          _dispatch!(WindowEventAction(
+              eventName, wmd, FletAppServices.of(context).ws));
+        });
       });
-    });
+    }
   }
 }

--- a/package/lib/src/widgets/window_media.dart
+++ b/package/lib/src/widgets/window_media.dart
@@ -48,16 +48,26 @@ class _WindowMediaState extends State<WindowMedia> with WindowListener {
   void onWindowEvent(String eventName) {
     //debugPrint('START [WindowManager] onWindowEvent: $eventName');
 
-    if (eventName != "resize" && eventName != "move") {
-      if (_debounce?.isActive ?? false) _debounce!.cancel();
-      _debounce = Timer(const Duration(milliseconds: 200), () {
-        debugPrint('[WindowManager] onWindowEvent: $eventName');
-        getWindowMediaData().then((wmd) {
-          debugPrint("WindowMediaData: $wmd");
-          _dispatch!(WindowEventAction(
-              eventName, wmd, FletAppServices.of(context).ws));
-        });
+    if (eventName == "resize" || eventName == "move") {
+      return;
+    }
+
+    send() {
+      debugPrint('[WindowManager] onWindowEvent: $eventName');
+      getWindowMediaData().then((wmd) {
+        debugPrint("WindowMediaData: $wmd");
+        _dispatch!(
+            WindowEventAction(eventName, wmd, FletAppServices.of(context).ws));
       });
+    }
+
+    if (eventName == "resized" || eventName == "moved") {
+      if (_debounce?.isActive ?? false) _debounce!.cancel();
+      _debounce = Timer(const Duration(milliseconds: 300), () {
+        send();
+      });
+    } else {
+      send();
     }
   }
 }

--- a/package/pubspec.yaml
+++ b/package/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter_redux: ^0.10.0
   equatable: ^2.0.3
   web_socket_channel: ^2.1.0
-  window_manager: ^0.2.5
+  window_manager: ^0.2.6
   http: ^0.13.3
   collection: ^1.16.0
   url_launcher: ^6.1.5

--- a/sdk/python/flet/__init__.py
+++ b/sdk/python/flet/__init__.py
@@ -53,3 +53,4 @@ from flet.theme import PageTransitionsTheme, Theme
 from flet.user_control import UserControl
 from flet.vertical_divider import VerticalDivider
 from flet.view import View
+from flet.window_drag_area import WindowDragArea

--- a/sdk/python/flet/page.py
+++ b/sdk/python/flet/page.py
@@ -811,6 +811,28 @@ class Page(Control):
     def window_prevent_close(self, value: Optional[bool]):
         self._set_attr("windowPreventClose", value)
 
+    # window_title_bar_hidden
+    @property
+    def window_title_bar_hidden(self) -> Optional[bool]:
+        return self._get_attr("windowTitleBarHidden", data_type="bool", def_value=False)
+
+    @window_title_bar_hidden.setter
+    @beartype
+    def window_title_bar_hidden(self, value: Optional[bool]):
+        self._set_attr("windowTitleBarHidden", value)
+
+    # window_title_bar_buttons_hidden
+    @property
+    def window_title_bar_buttons_hidden(self) -> Optional[bool]:
+        return self._get_attr(
+            "windowTitleBarButtonsHidden", data_type="bool", def_value=False
+        )
+
+    @window_title_bar_buttons_hidden.setter
+    @beartype
+    def window_title_bar_buttons_hidden(self, value: Optional[bool]):
+        self._set_attr("windowTitleBarButtonsHidden", value)
+
     # window_focused
     @property
     def window_focused(self) -> Optional[bool]:
@@ -820,6 +842,16 @@ class Page(Control):
     @beartype
     def window_focused(self, value: Optional[bool]):
         self._set_attr("windowFocused", value)
+
+    # window_visible
+    @property
+    def window_visible(self) -> Optional[bool]:
+        return self._get_attr("windowVisible", data_type="bool")
+
+    @window_visible.setter
+    @beartype
+    def window_visible(self, value: Optional[bool]):
+        self._set_attr("windowVisible", value)
 
     # on_close
     @property

--- a/sdk/python/flet/page.py
+++ b/sdk/python/flet/page.py
@@ -336,6 +336,10 @@ class Page(Control):
         self._set_attr("windowCenter", str(time.time()))
         self.update()
 
+    def window_close(self):
+        self._set_attr("windowClose", str(time.time()))
+        self.update()
+
     # url
     @property
     def url(self):
@@ -832,6 +836,36 @@ class Page(Control):
     @beartype
     def window_title_bar_buttons_hidden(self, value: Optional[bool]):
         self._set_attr("windowTitleBarButtonsHidden", value)
+
+    # window_skip_task_bar
+    @property
+    def window_skip_task_bar(self) -> Optional[bool]:
+        return self._get_attr("windowSkipTaskBar", data_type="bool", def_value=False)
+
+    @window_skip_task_bar.setter
+    @beartype
+    def window_skip_task_bar(self, value: Optional[bool]):
+        self._set_attr("windowSkipTaskBar", value)
+
+    # window_frameless
+    @property
+    def window_frameless(self) -> Optional[bool]:
+        return self._get_attr("windowFrameless", data_type="bool", def_value=False)
+
+    @window_frameless.setter
+    @beartype
+    def window_frameless(self, value: Optional[bool]):
+        self._set_attr("windowFrameless", value)
+
+    # window_progress_bar
+    @property
+    def window_progress_bar(self) -> OptionalNumber:
+        return self._get_attr("windowProgressBar")
+
+    @window_progress_bar.setter
+    @beartype
+    def window_progress_bar(self, value: OptionalNumber):
+        self._set_attr("windowProgressBar", value)
 
     # window_focused
     @property

--- a/sdk/python/flet/stack.py
+++ b/sdk/python/flet/stack.py
@@ -1,9 +1,18 @@
 from typing import Any, List, Optional, Union
 
+from beartype import beartype
+
 from flet.constrained_control import ConstrainedControl
 from flet.control import Control, OptionalNumber
 from flet.ref import Ref
 from flet.types import AnimationValue, OffsetValue, RotateValue, ScaleValue
+
+try:
+    from typing import Literal
+except:
+    from typing_extensions import Literal
+
+ClipBehavior = Literal[None, "none", "antiAlias", "antiAliasWithSaveLayer", "hardEdge"]
 
 
 class Stack(ConstrainedControl):
@@ -31,6 +40,10 @@ class Stack(ConstrainedControl):
         visible: Optional[bool] = None,
         disabled: Optional[bool] = None,
         data: Any = None,
+        #
+        # Stack-specific
+        #
+        clip_behavior: ClipBehavior = None,
     ):
         ConstrainedControl.__init__(
             self,
@@ -59,6 +72,7 @@ class Stack(ConstrainedControl):
 
         self.__controls: List[Control] = []
         self.controls = controls
+        self.clip_behavior = clip_behavior
 
     def _get_control_name(self):
         return "stack"
@@ -74,3 +88,13 @@ class Stack(ConstrainedControl):
     @controls.setter
     def controls(self, value):
         self.__controls = value or []
+
+    # clip_behavior
+    @property
+    def clip_behavior(self) -> Optional[ClipBehavior]:
+        return self._get_attr("clipBehavior")
+
+    @clip_behavior.setter
+    @beartype
+    def clip_behavior(self, value: Optional[ClipBehavior]):
+        self._set_attr("clipBehavior", value)

--- a/sdk/python/flet/window_drag_area.py
+++ b/sdk/python/flet/window_drag_area.py
@@ -1,0 +1,48 @@
+from typing import Any, Optional
+
+from beartype import beartype
+
+from flet.control import Control
+from flet.ref import Ref
+
+
+class WindowDragArea(Control):
+    def __init__(
+        self,
+        content: Optional[Control] = None,
+        ref: Optional[Ref] = None,
+        disabled: Optional[bool] = None,
+        visible: Optional[bool] = None,
+        data: Any = None,
+    ):
+
+        Control.__init__(
+            self,
+            ref=ref,
+            disabled=disabled,
+            visible=visible,
+            data=data,
+        )
+
+        self.__content: Optional[Control] = None
+
+        self.content = content
+
+    def _get_control_name(self):
+        return "windowDragArea"
+
+    def _get_children(self):
+        children = []
+        if self.__content:
+            self.__content._set_attr_internal("n", "content")
+            children.append(self.__content)
+        return children
+
+    # content
+    @property
+    def content(self):
+        return self.__content
+
+    @content.setter
+    def content(self, value):
+        self.__content = value

--- a/sdk/python/flet/window_drag_area.py
+++ b/sdk/python/flet/window_drag_area.py
@@ -1,26 +1,64 @@
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from beartype import beartype
 
-from flet.control import Control
+from flet.constrained_control import ConstrainedControl
+from flet.control import Control, OptionalNumber
 from flet.ref import Ref
+from flet.types import AnimationValue, OffsetValue, RotateValue, ScaleValue
 
 
-class WindowDragArea(Control):
+class WindowDragArea(ConstrainedControl):
     def __init__(
         self,
         content: Optional[Control] = None,
         ref: Optional[Ref] = None,
-        disabled: Optional[bool] = None,
+        width: OptionalNumber = None,
+        height: OptionalNumber = None,
+        left: OptionalNumber = None,
+        top: OptionalNumber = None,
+        right: OptionalNumber = None,
+        bottom: OptionalNumber = None,
+        expand: Union[None, bool, int] = None,
+        opacity: OptionalNumber = None,
+        rotate: RotateValue = None,
+        scale: ScaleValue = None,
+        offset: OffsetValue = None,
+        animate_opacity: AnimationValue = None,
+        animate_size: AnimationValue = None,
+        animate_position: AnimationValue = None,
+        animate_rotation: AnimationValue = None,
+        animate_scale: AnimationValue = None,
+        animate_offset: AnimationValue = None,
+        tooltip: Optional[str] = None,
         visible: Optional[bool] = None,
+        disabled: Optional[bool] = None,
         data: Any = None,
     ):
 
-        Control.__init__(
+        ConstrainedControl.__init__(
             self,
             ref=ref,
-            disabled=disabled,
+            width=width,
+            height=height,
+            left=left,
+            top=top,
+            right=right,
+            bottom=bottom,
+            expand=expand,
+            opacity=opacity,
+            rotate=rotate,
+            scale=scale,
+            offset=offset,
+            animate_opacity=animate_opacity,
+            animate_size=animate_size,
+            animate_position=animate_position,
+            animate_rotation=animate_rotation,
+            animate_scale=animate_scale,
+            animate_offset=animate_offset,
+            tooltip=tooltip,
             visible=visible,
+            disabled=disabled,
             data=data,
         )
 


### PR DESCRIPTION
## Desktop Flet app can be started with a hidden window

New `view=flet.FLET_APP_HIDDEN` argument - run app with a hidden window on the startup. Window could be made visible from a user code:

```python
import flet
from flet import Container, IconButton, Page, Row, Text, WindowDragArea, icons

def main(page: Page):
    page.add(
        Row(
            [
                WindowDragArea(
                    Container(
                        Text("This is a window move drag area."),
                        bgcolor="yellow",
                        padding=10,
                    ),
                    expand=1,
                ),
                IconButton(icon=icons.CLOSE, on_click=lambda _: page.window_close()),
            ]
        )
    )

    page.window_width = 600
    page.window_height = 400
    page.window_title_bar_hidden = True
    page.window_frameless = True
    page.window_visible = True
    page.window_center()

flet.app(target=main, view=flet.FLET_APP_HIDDEN)
```

## New `page` properties to control window appearance and behavior

* `page.window_close()`
* `page.window_title_bar_hidden`
* `page.window_title_bar_buttons_hidden` (macOS only)
* `page.window_skip_task_bar`
* `page.window_frameless`
* `page.window_progress_bar`
* `page.window_visible`

New `WindowDragArea` class to enable dragging/maximizing/restoring window without a title bar.

## Other changes

New `Stack` properties:

* `Stack.clip_behavior` - `none`, `antiAlias`, `antiAliasWithSaveLayer`, `hardEdge`.