### PR TITLE
Fixed on_close event handling

### DIFF
--- a/sdk/python/flet/flet.py
+++ b/sdk/python/flet/flet.py
@@ -186,7 +186,7 @@ def _connect_internal(
             conn.sessions[e.sessionID].on_event(
                 Event(e.eventTarget, e.eventName, e.eventData)
             )
-            if e.eventTarget == "page" and e.eventName == "close":
+            if e.eventTarget == "page" and (e.eventName in {"close", "disconnect"}):
                 print("Session closed:", e.sessionID)
                 del conn.sessions[e.sessionID]
 


### PR DESCRIPTION
There is an issue with "on close" event which leads to wrong behavior and to a memory leak.
`on_event` receives 'disconnect' instead of 'close' on both browser tab close and an app window close.

Reproduces on version: 0.1.54 from PyPi
OS: Windows 10