### PR TITLE
Querystring extract

### DIFF
--- a/sdk/python/.gitignore
+++ b/sdk/python/.gitignore
@@ -136,3 +136,6 @@ __pypackages__/
 flet/bin/
 
 /playground
+
+# Testing area
+tests

--- a/sdk/python/flet/__init__.py
+++ b/sdk/python/flet/__init__.py
@@ -54,3 +54,4 @@ from flet.user_control import UserControl
 from flet.vertical_divider import VerticalDivider
 from flet.view import View
 from flet.window_drag_area import WindowDragArea
+from flet.querystring import QueryString

--- a/sdk/python/flet/querystring.py
+++ b/sdk/python/flet/querystring.py
@@ -1,0 +1,38 @@
+import re
+from flet import Page
+
+
+class QueryString:
+    """
+    Note:
+            `QueryString must be inside of url on change function`\n
+
+    Constructor:
+            If `page` argument is passed, `QueryString` takes url out automatically of `page` object\n
+            If `url` (customly specified url) is specified, then `QueryString` will work on `url` argument\n
+
+    Methods:
+            `get()` method takes `key` an an argument and returns value according to key. (Ex: .../?name=Joe) -> `get('name')` -> `Joe`\n
+            `to_dict()` returns all the key-value pairs of querystring as a `dict`\n
+
+    """
+
+    def __init__(self, page: Page = None, url: str = None):
+        self.url = page.url + page.route if url is None else url
+
+    def get(self, key: str) -> str:
+        self._pattern = re.compile(f"{key}=[\w\+?]+")
+        self._res = self._pattern.search(self.url)
+        self._res = self.url[self._res.start() + len(key) + 1 : self._res.end()]
+        return self._res if "+" not in self._res else self._res.replace("+", " ")
+
+    def to_dict(self) -> dict:
+        self._key_pattern = re.compile(r"[\w]+=")
+        self._keys = [i[:-1] for i in self._key_pattern.findall(self.url)]
+
+        self._value_pattern = re.compile(r"=[\w\+?]+")
+        self._values = [
+            i[1:].replace("+", " ") for i in self._value_pattern.findall(self.url)
+        ]
+
+        return {i: j for i, j in zip(self._keys, self._values)}


### PR DESCRIPTION
Well, when doing some project with flet, I found I needed to get query string data as key-value pairs to send it to the backend and since there was no way to extract data from the query string, I wrote the code myself, so I think it's helpful and must be merged with flet. Moreover, it's needed when dealing with web.

QueryString class consists of 2 methods, one of them is called `get()` which takes `key` as an argument and returns its value accordingly, and another is `to_dict()` which converts querystring into a python dictionary. 

Also, there is docstring description in the class.