### PR TITLE
add data prop to PopupMenuItem

### DIFF
--- a/sdk/python/flet/popup_menu_button.py
+++ b/sdk/python/flet/popup_menu_button.py
@@ -18,6 +18,7 @@ class PopupMenuItem(Control):
         text: Optional[str] = None,
         content: Optional[Control] = None,
         on_click=None,
+        data: Any = None
     ):
         Control.__init__(self, ref=ref)
 
@@ -27,6 +28,7 @@ class PopupMenuItem(Control):
         self.__content: Optional[Control] = None
         self.content = content
         self.on_click = on_click
+        self.data = data
 
     def _get_control_name(self):
         return "popupmenuitem"


### PR DESCRIPTION
I'm not sure if this has other implications, or was omitted from other controls embedded in larger controls (radio button, dropdown option, for example), but I know that I was in need of this data property on this control and adding these lines fixed the error I got trying to use it. 