### PR TITLE
Use False instead of None as `ink` default value

### DIFF
--- a/sdk/python/flet/container.py
+++ b/sdk/python/flet/container.py
@@ -80,7 +80,7 @@ class Container(ConstrainedControl):
         image_repeat: ImageRepeat = None,
         image_fit: ImageFit = None,
         image_opacity: OptionalNumber = None,
-        ink: Optional[bool] = None,
+        ink: bool = False,
         animate: AnimationValue = None,
         on_click=None,
         on_long_press=None,


### PR DESCRIPTION
Align with documentation
> `True` to produce ink ripples effect when user clicks the container. Default is `False`.

No three-valued logic is needed here, using `Optional[bool]` doesn't make sense.