### PR TITLE
Fix some general syntax warnings

### DIFF
--- a/sdk/python/flet/client_storage.py
+++ b/sdk/python/flet/client_storage.py
@@ -1,11 +1,7 @@
 import dataclasses
 import json
 import threading
-from multiprocessing import Event
 from typing import Any, Dict, List, Optional
-from unittest.main import main
-
-from beartype import beartype
 
 from flet.control import Control
 from flet.ref import Ref

--- a/sdk/python/flet/column.py
+++ b/sdk/python/flet/column.py
@@ -167,9 +167,9 @@ class Column(ConstrainedControl):
     @beartype
     def scroll(self, value: ScrollMode):
         self.__scroll = value
-        if value == True:
+        if value is True:
             value = "auto"
-        elif value == False:
+        elif value is False:
             value = "none"
         self._set_attr("scroll", value)
 

--- a/sdk/python/flet/connection.py
+++ b/sdk/python/flet/connection.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import threading
 import uuid

--- a/sdk/python/flet/control.py
+++ b/sdk/python/flet/control.py
@@ -13,7 +13,7 @@ from flet.ref import Ref
 
 try:
     from typing import Literal
-except:
+except ImportError:
     from typing_extensions import Literal
 
 
@@ -144,7 +144,7 @@ class Control:
 
     def _get_attr(self, name, def_value=None, data_type="string"):
         name = name.lower()
-        if not name in self.__attrs:
+        if name not in self.__attrs:
             return def_value
 
         s_val = self.__attrs[name][0]

--- a/sdk/python/flet/file_picker.py
+++ b/sdk/python/flet/file_picker.py
@@ -13,7 +13,7 @@ from flet.ref import Ref
 
 try:
     from typing import Literal
-except:
+except ImportError:
     from typing_extensions import Literal
 
 FileType = Literal["any", "media", "image", "video", "audio", "custom"]

--- a/sdk/python/flet/flet.py
+++ b/sdk/python/flet/flet.py
@@ -1,7 +1,6 @@
 import argparse
 import json
 import logging
-import os
 import signal
 import socket
 import subprocess
@@ -14,9 +13,8 @@ import urllib.request
 import zipfile
 from pathlib import Path
 from time import sleep
-from typing import Sequence
 
-from watchdog.events import FileSystemEventHandler, PatternMatchingEventHandler
+from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 
 from flet import constants, version

--- a/sdk/python/flet/gradients.py
+++ b/sdk/python/flet/gradients.py
@@ -8,7 +8,7 @@ from flet.alignment import Alignment
 
 try:
     from typing import Literal
-except:
+except ImportError:
     from typing_extensions import Literal
 
 TileMode = Literal["clamp", "decal", "mirror", "repeated"]

--- a/sdk/python/flet/image.py
+++ b/sdk/python/flet/image.py
@@ -1,10 +1,9 @@
-from sys import version
 from typing import Any, Optional, Union
 
 from beartype import beartype
 
 from flet.constrained_control import ConstrainedControl
-from flet.control import Control, OptionalNumber
+from flet.control import OptionalNumber
 from flet.ref import Ref
 from flet.types import (
     AnimationValue,
@@ -16,7 +15,7 @@ from flet.types import (
 
 try:
     from typing import Literal
-except:
+except ImportError:
     from typing_extensions import Literal
 
 

--- a/sdk/python/flet/list_tile.py
+++ b/sdk/python/flet/list_tile.py
@@ -1,4 +1,3 @@
-from marshal import version
 from typing import Any, Optional, Union
 
 from beartype import beartype

--- a/sdk/python/flet/markdown.py
+++ b/sdk/python/flet/markdown.py
@@ -9,7 +9,7 @@ from flet.types import AnimationValue, OffsetValue, RotateValue, ScaleValue
 
 try:
     from typing import Literal
-except:
+except ImportError:
     from typing_extensions import Literal
 
 MarkdownExtensionSet = Literal[

--- a/sdk/python/flet/navigation_rail.py
+++ b/sdk/python/flet/navigation_rail.py
@@ -16,7 +16,7 @@ from flet.types import (
 
 try:
     from typing import Literal
-except:
+except ImportError:
     from typing_extensions import Literal
 
 NavigationRailLabelType = Literal[None, "none", "all", "selected"]

--- a/sdk/python/flet/radio.py
+++ b/sdk/python/flet/radio.py
@@ -9,7 +9,7 @@ from flet.types import AnimationValue, OffsetValue, RotateValue, ScaleValue
 
 try:
     from typing import Literal
-except:
+except ImportError:
     from typing_extensions import Literal
 
 

--- a/sdk/python/flet/row.py
+++ b/sdk/python/flet/row.py
@@ -167,9 +167,9 @@ class Row(ConstrainedControl):
     @beartype
     def scroll(self, value: ScrollMode):
         self.__scroll = value
-        if value == True:
+        if value is True:
             value = "auto"
-        elif value == False:
+        elif value is False:
             value = "none"
         self._set_attr("scroll", value)
 

--- a/sdk/python/flet/semantics.py
+++ b/sdk/python/flet/semantics.py
@@ -1,10 +1,9 @@
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 from beartype import beartype
 
 from flet.control import Control, OptionalNumber
 from flet.ref import Ref
-from flet.types import AnimationValue, MarginValue, OffsetValue, RotateValue, ScaleValue
 
 
 class Semantics(Control):

--- a/sdk/python/flet/snack_bar.py
+++ b/sdk/python/flet/snack_bar.py
@@ -2,7 +2,7 @@ from typing import Any, Optional
 
 from beartype import beartype
 
-from flet.control import Control, OptionalNumber
+from flet.control import Control
 from flet.ref import Ref
 
 

--- a/sdk/python/flet/stack.py
+++ b/sdk/python/flet/stack.py
@@ -9,7 +9,7 @@ from flet.types import AnimationValue, OffsetValue, RotateValue, ScaleValue
 
 try:
     from typing import Literal
-except:
+except ImportError:
     from typing_extensions import Literal
 
 ClipBehavior = Literal[None, "none", "antiAlias", "antiAliasWithSaveLayer", "hardEdge"]

--- a/sdk/python/flet/switch.py
+++ b/sdk/python/flet/switch.py
@@ -9,7 +9,7 @@ from flet.types import AnimationValue, OffsetValue, RotateValue, ScaleValue
 
 try:
     from typing import Literal
-except:
+except ImportError:
     from typing_extensions import Literal
 
 

--- a/sdk/python/flet/tabs.py
+++ b/sdk/python/flet/tabs.py
@@ -21,9 +21,9 @@ class Tab(Control):
         Control.__init__(self, ref=ref)
         self.text = text
         self.icon = icon
-        self.__content: Control = None
+        self.__content: Optional[Control] = None
         self.content = content
-        self.__tab_content: Control = None
+        self.__tab_content: Optional[Control] = None
         self.tab_content = tab_content
 
     def _get_control_name(self):

--- a/sdk/python/flet/text.py
+++ b/sdk/python/flet/text.py
@@ -9,7 +9,7 @@ from flet.types import AnimationValue, OffsetValue, RotateValue, ScaleValue
 
 try:
     from typing import Literal
-except:
+except ImportError:
     from typing_extensions import Literal
 
 FontWeight = Literal[

--- a/sdk/python/flet/textfield.py
+++ b/sdk/python/flet/textfield.py
@@ -10,7 +10,7 @@ from flet.types import BorderRadiusValue, PaddingValue
 
 try:
     from typing import Literal
-except:
+except ImportError:
     from typing_extensions import Literal
 
 TextInputType = Literal[

--- a/sdk/python/flet/theme.py
+++ b/sdk/python/flet/theme.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 try:
     from typing import Literal
-except:
+except ImportError:
     from typing_extensions import Literal
 
 VisualDensity = Literal[

--- a/sdk/python/flet/view.py
+++ b/sdk/python/flet/view.py
@@ -1,7 +1,7 @@
 from beartype import beartype
-from beartype.typing import Dict, List, Optional
+from beartype.typing import List, Optional
 
-from flet import Control, padding
+from flet import Control
 from flet.app_bar import AppBar
 from flet.control import (
     CrossAxisAlignment,

--- a/sdk/python/flet/window_drag_area.py
+++ b/sdk/python/flet/window_drag_area.py
@@ -1,7 +1,5 @@
 from typing import Any, Optional, Union
 
-from beartype import beartype
-
 from flet.constrained_control import ConstrainedControl
 from flet.control import Control, OptionalNumber
 from flet.ref import Ref


### PR DESCRIPTION
Python sdk has some syntax warnings. Currently, some warnings that do not affect compatibility have been fixed