### PR TITLE
make ink=True behavior consistent with ink=False

### DIFF
--- a/package/lib/src/controls/container.dart
+++ b/package/lib/src/controls/container.dart
@@ -113,16 +113,27 @@ class ContainerControl extends StatelessWidget {
             var ink = Ink(
                 decoration: boxDecor,
                 child: InkWell(
-                  onTap: onClick || onHover
-                      ? () {
+                  // Dummy callback to enable widget
+                  // see https://github.com/flutter/flutter/issues/50116#issuecomment-582047374
+                  // and https://github.com/flutter/flutter/blob/eed80afe2c641fb14b82a22279d2d78c19661787/packages/flutter/lib/src/material/ink_well.dart#L1125-L1129
+                  onTap: onHover
+                      ? () {}
+                      : null,
+                  onTapDown: onClick
+                      ? (details) {
                           debugPrint("Container ${control.id} clicked!");
                           ws.pageEventFromWeb(
                               eventTarget: control.id,
                               eventName: "click",
-                              eventData: "");
+                              eventData: json.encode(ContainerTapEvent(
+                                      localX: details.localPosition.dx,
+                                      localY: details.localPosition.dy,
+                                      globalX: details.globalPosition.dx,
+                                      globalY: details.globalPosition.dy)
+                                  .toJson()));
                         }
                       : null,
-                  onLongPress: onLongPress || onHover
+                  onLongPress: onLongPress
                       ? () {
                           debugPrint("Container ${control.id} long pressed!");
                           ws.pageEventFromWeb(

--- a/sdk/python/flet/container.py
+++ b/sdk/python/flet/container.py
@@ -116,8 +116,6 @@ class Container(ConstrainedControl):
         )
 
         def convert_container_tap_event_data(e):
-            if self.ink:
-                return e
             d = json.loads(e.data)
             return ContainerTapEvent(**d)
 


### PR DESCRIPTION
Use onTapDown instead of onTap like ink = False
Also:
passing a dummy callback to onTap when onHover is True to enble the widget instead of
passing a ws.pageEventFromWeb callback to onTap and onLongPress to reduce websocket traffic