### PR TITLE
fix: ensure correct version is fetched in dev mode

### DIFF
--- a/sdk/python/flet/version.py
+++ b/sdk/python/flet/version.py
@@ -1,24 +1,28 @@
 # this file will be replaced by CI
 
 import subprocess as sp
+from pkg_resources import parse_version
+
+from flet.utils import which
 
 
 def update_version():
-    in_repo = sp.run(
+    in_repo = which("git") and sp.run(
         ["git", "status"],
         capture_output=True,
-        text=True
+        text=True,
     ).stdout.startswith("On branch ")
 
     if in_repo:
         # NOTE: this may break if there is a tag name starting with
         #         "v" that isn't a version number
-        version = sp.run(
-            ["git tag |grep '^v' |sort -V |tail -n 1 |sed 's/v//g'"],
+        tags = sp.run(
+            ["git", "tag"],
             capture_output=True,
-            shell=True,
-            text=True
-        ).stdout.strip()
+            text=True,
+        ).stdout.splitlines()
+        versions = filter(lambda t: t.startswith("v"), tags)
+        version = sorted(versions, key=parse_version)[-1][1:]
 
     else:
         version = "0.1.60"  # default to old version

--- a/sdk/python/flet/version.py
+++ b/sdk/python/flet/version.py
@@ -3,19 +3,27 @@
 import subprocess as sp
 
 
-version = "0.1.60"  # default to old version
-in_repo = sp.run(
-    ["git", "status"],
-    capture_output=True,
-    text=True
-).stdout.startswith("On branch ")
-
-if in_repo:
-    # NOTE: this may break if there is a tag name starting with
-    #         "v" that isn't a version number
-    version = sp.run(
-        ["git tag |grep '^v' |sort -V |tail -n 1 |sed 's/v//g'"],
+def update_version():
+    in_repo = sp.run(
+        ["git", "status"],
         capture_output=True,
-        shell=True,
         text=True
-    ).stdout.strip()
+    ).stdout.startswith("On branch ")
+
+    if in_repo:
+        # NOTE: this may break if there is a tag name starting with
+        #         "v" that isn't a version number
+        version = sp.run(
+            ["git tag |grep '^v' |sort -V |tail -n 1 |sed 's/v//g'"],
+            capture_output=True,
+            shell=True,
+            text=True
+        ).stdout.strip()
+
+    else:
+        version = "0.1.60"  # default to old version
+    return version
+
+
+if not globals().get("version", None):
+    version = update_version()

--- a/sdk/python/flet/version.py
+++ b/sdk/python/flet/version.py
@@ -1,2 +1,21 @@
 # this file will be replaced by CI
-version = "0.1.57"
+
+import subprocess as sp
+
+
+version = "0.1.60"  # default to old version
+in_repo = sp.run(
+    ["git", "status"],
+    capture_output=True,
+    text=True
+).stdout.startswith("On branch ")
+
+if in_repo:
+    # NOTE: this may break if there is a tag name starting with
+    #         "v" that isn't a version number
+    version = sp.run(
+        ["git tag |grep '^v' |sort -V |tail -n 1 |sed 's/v//g'"],
+        capture_output=True,
+        shell=True,
+        text=True
+    ).stdout.strip()


### PR DESCRIPTION
Because the version file isn't replaced when the repo is cloned, the version info may go out of date, which can cause issues for local dev.