### PR TITLE
Fix controls setter for empty list input

### DIFF
--- a/sdk/python/flet/alert_dialog.py
+++ b/sdk/python/flet/alert_dialog.py
@@ -138,7 +138,7 @@ class AlertDialog(Control):
 
     @actions.setter
     def actions(self, value):
-        self.__actions = value or []
+        self.__actions = value if value is not None else []
 
     # actions_padding
     @property

--- a/sdk/python/flet/app_bar.py
+++ b/sdk/python/flet/app_bar.py
@@ -138,4 +138,4 @@ class AppBar(Control):
 
     @actions.setter
     def actions(self, value):
-        self.__actions = value or []
+        self.__actions = value if value is not None else []

--- a/sdk/python/flet/auth/authorization.py
+++ b/sdk/python/flet/auth/authorization.py
@@ -24,7 +24,7 @@ class Authorization:
     ) -> None:
         self.fetch_user = fetch_user
         self.fetch_groups = fetch_groups
-        self.scope = scope or []
+        self.scope = scope if scope is not None else []
         self.provider = provider
         self.__token: Optional[OAuthToken] = None
         self.user: Optional[User] = None

--- a/sdk/python/flet/auth/oauth_provider.py
+++ b/sdk/python/flet/auth/oauth_provider.py
@@ -23,11 +23,11 @@ class OAuthProvider:
         self.authorization_endpoint = authorization_endpoint
         self.token_endpoint = token_endpoint
         self.redirect_url = redirect_url
-        self.scopes = scopes or []
-        self.user_scopes = user_scopes or []
+        self.scopes = scopes if scopes is not None else []
+        self.user_scopes = user_scopes if user_scopes is not None else []
         self.user_endpoint = user_endpoint
         self.user_id_fn = user_id_fn
-        self.group_scopes = group_scopes or []
+        self.group_scopes = group_scopes if group_scopes is not None else []
 
     def _name(self):
         raise Exception("Not implemented")

--- a/sdk/python/flet/banner.py
+++ b/sdk/python/flet/banner.py
@@ -133,7 +133,7 @@ class Banner(Control):
 
     @actions.setter
     def actions(self, value):
-        self.__actions = value or []
+        self.__actions = value if value is not None else []
 
     # force_actions_below
     @property

--- a/sdk/python/flet/column.py
+++ b/sdk/python/flet/column.py
@@ -192,4 +192,4 @@ class Column(ConstrainedControl):
 
     @controls.setter
     def controls(self, value):
-        self.__controls = value or []
+        self.__controls = value if value is not None else []

--- a/sdk/python/flet/dropdown.py
+++ b/sdk/python/flet/dropdown.py
@@ -154,7 +154,7 @@ class Dropdown(FormFieldControl):
 
     @options.setter
     def options(self, value):
-        self.__options = value or []
+        self.__options = value if value is not None else []
 
     # value
     @property

--- a/sdk/python/flet/grid_view.py
+++ b/sdk/python/flet/grid_view.py
@@ -178,4 +178,4 @@ class GridView(ConstrainedControl):
 
     @controls.setter
     def controls(self, value):
-        self.__controls = value or []
+        self.__controls = value if value is not None else []

--- a/sdk/python/flet/list_view.py
+++ b/sdk/python/flet/list_view.py
@@ -168,7 +168,7 @@ class ListView(ConstrainedControl):
 
     @controls.setter
     def controls(self, value):
-        self.__controls = value or []
+        self.__controls = value if value is not None else []
 
     # auto_scroll
     @property

--- a/sdk/python/flet/navigation_rail.py
+++ b/sdk/python/flet/navigation_rail.py
@@ -238,8 +238,7 @@ class NavigationRail(ConstrainedControl):
     @destinations.setter
     @beartype
     def destinations(self, value: Optional[List[NavigationRailDestination]]):
-        value = value or []
-        self.__destinations = value
+        self.__destinations = value if value is not None else []
 
     # on_change
     @property

--- a/sdk/python/flet/page.py
+++ b/sdk/python/flet/page.py
@@ -401,7 +401,7 @@ class Page(Control):
     ):
         return self.__conn.send_command(
             self._session_id,
-            Command(indent=0, name=name, values=values or [], attrs=attrs or {}),
+            Command(indent=0, name=name, values=values if values is not None else [], attrs=attrs or {}),
         )
 
     @beartype
@@ -617,7 +617,7 @@ class Page(Control):
     @controls.setter
     @beartype
     def controls(self, value: Optional[List[Control]]):
-        self.__default_view.controls = value or []
+        self.__default_view.controls = value if value is not None else []
 
     # appbar
     @property

--- a/sdk/python/flet/popup_menu_button.py
+++ b/sdk/python/flet/popup_menu_button.py
@@ -173,8 +173,7 @@ class PopupMenuButton(ConstrainedControl):
     @items.setter
     @beartype
     def items(self, value: Optional[List[PopupMenuItem]]):
-        value = value or []
-        self.__items = value
+        self.__items = value if value is not None else []
 
     # on_cancelled
     @property

--- a/sdk/python/flet/row.py
+++ b/sdk/python/flet/row.py
@@ -192,4 +192,4 @@ class Row(ConstrainedControl):
 
     @controls.setter
     def controls(self, value):
-        self.__controls = value or []
+        self.__controls = value if value is not None else []

--- a/sdk/python/flet/stack.py
+++ b/sdk/python/flet/stack.py
@@ -87,7 +87,7 @@ class Stack(ConstrainedControl):
 
     @controls.setter
     def controls(self, value):
-        self.__controls = value or []
+        self.__controls = value if value is not None else []
 
     # clip_behavior
     @property

--- a/sdk/python/flet/tabs.py
+++ b/sdk/python/flet/tabs.py
@@ -154,8 +154,7 @@ class Tabs(ConstrainedControl):
     @tabs.setter
     @beartype
     def tabs(self, value: Optional[List[Tab]]):
-        value = value or []
-        self.__tabs = value
+        self.__tabs = value if value is not None else []
 
     # on_change
     @property

--- a/sdk/python/flet/view.py
+++ b/sdk/python/flet/view.py
@@ -30,7 +30,7 @@ class View(Control):
     ):
         Control.__init__(self)
 
-        self.controls = controls or []
+        self.controls = controls if controls is not None else []
         self.route = route
         self.appbar = appbar
         self.floating_action_button = floating_action_button


### PR DESCRIPTION
User might pass an empty list to the setter then modify the list in-place with another name/variable referencing the list and expect the controls' content will change as well.
Current `value or []` will surprisingly break this use-case. Given that in-place modification will work if user pass non-empty list, this behavior is not satisfactory.
Also -- Google python style guide says: Always use `is None` and `is not None` to check for a `None` value. https://google.github.io/styleguide/pyguide.html#2144-decision