### PR TITLE
making Control a cooperative class

### DIFF
--- a/sdk/python/flet/control.py
+++ b/sdk/python/flet/control.py
@@ -100,6 +100,7 @@ class Control:
         disabled: Optional[bool] = None,
         data: Any = None,
     ):
+        super().__init__()
         self.__page: Optional[Page] = None
         self.__attrs = {}
         self.__previous_children = []


### PR DESCRIPTION
I used the observer pattern to propagate changes in a usercontrol object. For that purpose my widget derives from UserControl and another class, called Subject.  Calling super().__init__() in my class did not work because I had the wrong order in the class calls, i.e., class MyWidget(UserControl, Subject), rather than class MyWidget(Subject, UserControl). By including super().__init__() in the Control class such points of confusion are easy to prevent. Here is a further discussion:

https://rhettinger.wordpress.com/2011/05/26/super-considered-super/