### PR TITLE
Added missing imports.

### DIFF
--- a/sdk/python/flet/__init__.py
+++ b/sdk/python/flet/__init__.py
@@ -44,6 +44,8 @@ from flet.gradients import LinearGradient, RadialGradient, SweepGradient
 from flet.grid_view import GridView
 from flet.icon import Icon
 from flet.icon_button import IconButton
+from flet import icons
+from flet import colors
 from flet.image import Image
 from flet.list_tile import ListTile
 from flet.list_view import ListView


### PR DESCRIPTION
Added missing imports for `flet.icons` and `flet.colors`, because these imports were missing the only way to use them was to call them directly or importing them directly from the app we are building, this would cause that when using something like: 
```
from flet import icons, colors

icons.PALETTE
colors.BLACK
```
the code would work but when just importing flet and using those items from flet directly it would cause an error as they would not be found inside flet, so, the following code would cause an error:
```
import flet

flet.icons.PALETTE 
flet.colors.BLACK
```
After adding the import to the `__init__.py` script the second example would then work as normal as well as the first one.