### PR TITLE
Declare setuptools as a dependency

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -9,6 +9,7 @@ authors = [
 dependencies = [
     "websocket-client>=1.2.1",
     "beartype>=0.9.1",
+    "setuptools>=56",
     'typing_extensions; python_version < "3.8"',
     "repath>=0.9.0",
     "watchdog>=2.1.9",


### PR DESCRIPTION
Flet uses pkg_resources in code, but does not declare the package that provides it as a dependency. While setuptools is populated by default in most virtual environment implementations now, it is continuously being disfavored and is already not present in some tools. This patch properly declares setuptools as a dependency and avoids Flet from crashing in such environments.

Since Flet's usage of pkg_resources is quite minimal, it may be worthwhile to eventually move to packaging instead (which pkg_resources vendors), or implement a more lightweight version sorting logic to replace the dependency.

The lower version bound is chosen pretty much arbitrarily. Version 56.0.0 is the default setuptools vendored by the standard library's ensurepip module.