### PR TITLE
Remove hard-coded colors in Markdown default code theme

### DIFF
--- a/package/lib/src/controls/highlight_view.dart
+++ b/package/lib/src/controls/highlight_view.dart
@@ -74,8 +74,6 @@ class HighlightView extends StatelessWidget {
   }
 
   static const _rootKey = 'root';
-  static const _defaultFontColor = Color(0xff000000);
-  static const _defaultBackgroundColor = Color(0xffffffff);
 
   // TODO: dart:io is not available at web platform currently
   // See: https://github.com/flutter/flutter/issues/39998
@@ -86,14 +84,16 @@ class HighlightView extends StatelessWidget {
   Widget build(BuildContext context) {
     var style = TextStyle(
       fontFamily: _defaultFontFamily,
-      color: theme[_rootKey]?.color ?? _defaultFontColor,
+      color: theme[_rootKey]?.color ??
+          Theme.of(context).colorScheme.onSurfaceVariant,
     );
     if (textStyle != null) {
       style = style.merge(textStyle);
     }
 
     var d = BoxDecoration(
-        color: theme[_rootKey]?.backgroundColor ?? _defaultBackgroundColor);
+        color: theme[_rootKey]?.backgroundColor ??
+            Theme.of(context).colorScheme.surfaceVariant);
 
     if (decoration != null) {
       d = d.copyWith(borderRadius: (decoration as BoxDecoration).borderRadius);

--- a/package/lib/src/controls/markdown.dart
+++ b/package/lib/src/controls/markdown.dart
@@ -26,7 +26,7 @@ class MarkdownControl extends StatelessWidget {
     final ws = FletAppServices.of(context).ws;
 
     var value = control.attrString("value", "")!;
-    var codeTheme = control.attrString("codeTheme", "github")!;
+    var codeTheme = control.attrString("codeTheme", "")!;
     md.ExtensionSet extensionSet = md.ExtensionSet.none;
     switch (control.attrString("extensionSet", "")!.toLowerCase()) {
       case "commonmark":
@@ -60,7 +60,8 @@ class MarkdownControl extends StatelessWidget {
               imageDirectory: getBaseUri(pageUri!).toString(),
               extensionSet: extensionSet,
               builders: {
-                'code': CodeElementBuilder(codeTheme, mdStyleSheet),
+                'code':
+                    CodeElementBuilder(codeTheme.toLowerCase(), mdStyleSheet),
               },
               styleSheet: mdStyleSheet,
               onTapLink: (String text, String? href, String title) {
@@ -105,7 +106,7 @@ class CodeElementBuilder extends MarkdownElementBuilder {
 
         // Specify highlight theme
         // All available themes are listed in `themes` folder
-        theme: themeMap[codeTheme] ?? themeMap["github"]!,
+        theme: themeMap[codeTheme] ?? {},
 
         // Specify padding
         padding: mdStyleSheet.codeblockPadding,


### PR DESCRIPTION
Fix #728