### PR TITLE
In flet login flow, authorization should allow to override

### DIFF
--- a/sdk/python/flet/page.py
+++ b/sdk/python/flet/page.py
@@ -364,8 +364,9 @@ class Page(Control):
         on_open_authorization_url=None,
         complete_page_html: Optional[str] = None,
         redirect_to_page=False,
+        authorization=Authorization
     ):
-        self.__authorization = Authorization(
+        self.__authorization = authorization(
             provider,
             fetch_user=fetch_user,
             fetch_groups=fetch_groups,


### PR DESCRIPTION
Authorization should allow to override, such as request_token() methods, there are some customizing authorization flows don't support to get access_token thought local client, even if using environment variables are not allowed. More reference: https://open.feishu.cn/document/common-capabilities/sso/api/get-access_token?lang=en-US

In this case, developers should write the code for subsequent authentication and obtaining user information by themselves. According to the above LARK authentication process, developers need to obtain user information from their own servers.