### PR TITLE
Page configuration in a separate class.

### DIFF
--- a/sdk/python/flet/__init__.py
+++ b/sdk/python/flet/__init__.py
@@ -151,3 +151,4 @@ from flet.user_control import UserControl
 from flet.vertical_divider import VerticalDivider
 from flet.view import View
 from flet.window_drag_area import WindowDragArea
+from flet.metaconfig import BaseConfig

--- a/sdk/python/flet/metaconfig.py
+++ b/sdk/python/flet/metaconfig.py
@@ -1,0 +1,29 @@
+from typing import List, Any, Dict, Tuple
+
+class Meta(type):
+
+    _exclude_attrs: List[str] = ['__module__', '__qualname__']
+    _include_attrs: Dict[Dict[str, Any], Any] = {}
+    
+    def __new__(cls, name: str, bases: Tuple[type], attrs: Dict[str, Any]) -> type:
+        
+        for i in attrs:
+            if i not in cls._exclude_attrs:
+                cls._include_attrs[name] = {i: attrs[i]}
+
+        return super().__new__(cls, name, bases, attrs)
+    
+    def __init__(self, name: str, bases: Tuple[type], attrs: Dict[str, Any]) -> None:
+        self.name = name
+        self.bases = bases
+        self.attrs = attrs
+        setattr(self, '_set_page_attrs', self._set_page_attrs)
+
+    def _set_page_attrs(self, obj: Any, config: str) -> None:
+        for key, value in self._include_attrs[config].items():
+            if key not in self._exclude_attrs:
+                setattr(obj, key, value)
+
+
+class BaseConfig(metaclass=Meta):
+    pass

--- a/sdk/python/flet/metaconfig.py
+++ b/sdk/python/flet/metaconfig.py
@@ -1,23 +1,23 @@
 from typing import List, Any, Dict, Tuple
 
+
 class Meta(type):
 
-    _exclude_attrs: List[str] = ['__module__', '__qualname__']
+    _exclude_attrs: List[str] = ["__module__", "__qualname__"]
     _include_attrs: Dict[Dict[str, Any], Any] = {}
-    
-    def __new__(cls, name: str, bases: Tuple[type], attrs: Dict[str, Any]) -> type:
-        
-        for i in attrs:
-            if i not in cls._exclude_attrs:
-                cls._include_attrs[name] = {i: attrs[i]}
 
+    def __new__(cls, name: str, bases: Tuple[type], attrs: Dict[str, Any]) -> type:
+        class_attributes = {i: attrs[i] for i in attrs if i not in cls._exclude_attrs}
+        cls._include_attrs[name] = class_attributes
         return super().__new__(cls, name, bases, attrs)
-    
+
     def __init__(self, name: str, bases: Tuple[type], attrs: Dict[str, Any]) -> None:
         self.name = name
         self.bases = bases
         self.attrs = attrs
-        setattr(self, '_set_page_attrs', self._set_page_attrs)
+        setattr(
+            self, "_set_page_attrs", self._set_page_attrs
+        )  # Add _set_page_attrs method to every child class to be called from Page class
 
     def _set_page_attrs(self, obj: Any, config: str) -> None:
         for key, value in self._include_attrs[config].items():

--- a/sdk/python/flet/page.py
+++ b/sdk/python/flet/page.py
@@ -8,8 +8,9 @@ from typing import Any, cast
 from urllib.parse import urlparse
 
 from beartype import beartype
-from beartype.typing import Dict, List, Optional
+from beartype.typing import Dict, List, Optional, Type
 
+from flet.metaconfig import BaseConfig
 from flet import constants
 from flet.app_bar import AppBar
 from flet.auth.authorization import Authorization
@@ -158,6 +159,9 @@ class Page(Control):
 
     def get_control(self, id):
         return self._index.get(id)
+    
+    def from_config(self, config: Type[BaseConfig]):
+        config._set_page_attrs(self, config.__name__)
 
     def _before_build_command(self):
         super()._before_build_command()


### PR DESCRIPTION
I've implemented a meta classes and a new method for handling basic page configuration for different purposes.

Here is a quick example:
```python
import flet as ft
from flet import BaseConfig

class WindowsWindowConfig(BaseConfig):
    theme=ft.Theme(color_scheme_seed='green')
    on_resize='on_resize'
    window_minimizable=False

class AndroidWindowConfig(BaseConfig):
    window_height=600
    window_width=400


def main(page: ft.Page):
    if page.platform == 'windows':
        page.from_config(WindowsWindowConfig)
    elif page.platform == 'android':
        page.from_config(AndroidWindowConfig)
    
    page.add(ft.Text("Hello Word"))
    page.add(ft.Text(page.platform))

ft.app(target=main)
```
# Details
## New file and a method

- There is a new Python file named `metaconfig.py` which consists of a meta class and a class inheriting from the metaclass. Those are `Meta` and `BaseConfig`
- There is a new method in the `Page` class named `from_config(config: Type[BaseConfig])` which takes a `class that inherits from BaseConfig` and has page attributes

## How to use
As shown in the example above, you
- At first, must create a class and inherit from `BaseConfig`
- You can include any properties, method or events from [Page docs](https://flet.dev/docs/controls/page), there are no hardcoded values
- At last, pass your class as an argument to `page.from_config()` method and you're good to go

## Use cases
- You may want to have different page configurations for different platforms
- You may want to use different page configuration for a production and a development server which you can define beforehand
- You may want to have configuration settings in a separate file to maintain a clean code
- While testing, you may need to deal with different configuration modes and you don't need to rewrite everything from scratch

## Note:
You can also have methods inside of those classes as far as they have `@staticmethod` decorator and they don't have to access a `page` object directly.

Methods must be passed as `string` to variables

```python
class WindowsWindowConfig(BaseConfig):
    theme=ft.Theme(color_scheme_seed='green')
    on_resize='on_resize'
    window_minimizable=False
    on_resize="on_resize"
    
    @staticmethod
    def on_resize(e):
        print("Page has been resized")

```



