### PR TITLE
Set filled=True when setting bgcolor in TextField

### DIFF
--- a/sdk/python/flet/textfield.py
+++ b/sdk/python/flet/textfield.py
@@ -181,6 +181,9 @@ class TextField(FormFieldControl):
         on_focus=None,
         on_blur=None,
     ):
+        if bgcolor is not None and filled is None:
+            filled = True  # Flutter requires filled = True to display a bgcolor
+
         FormFieldControl.__init__(
             self,
             ref=ref,

--- a/sdk/python/tests/test_textfield.py
+++ b/sdk/python/tests/test_textfield.py
@@ -106,3 +106,17 @@ def test_border_enum():
 
     with pytest.raises(beartype.roar.BeartypeCallHintParamViolation):
         r = ft.TextField(border=1)
+
+
+def test_bgcolor_sets_filled():
+    r = ft.TextField(bgcolor=ft.colors.BLUE)
+    assert r.filled is not None and r.filled
+    assert r._get_attr("filled") is not None and r._get_attr("filled")
+
+    r = ft.TextField(bgcolor=ft.colors.BLUE, filled=True)
+    assert r.filled is not None and r.filled
+    assert r._get_attr("filled") is not None and r._get_attr("filled")
+
+    r = ft.TextField(bgcolor=ft.colors.BLUE, filled=False)
+    assert r.filled is not None and not r.filled
+    assert r._get_attr("filled") is not None and not r._get_attr("filled")


### PR DESCRIPTION
Resolve flet-dev/flet#757

Based on comments, seems useful to automatically set `filled=True` when creating a TextField