### PR TITLE
Page transition without animation

### DIFF
--- a/package/lib/src/utils/theme.dart
+++ b/package/lib/src/utils/theme.dart
@@ -65,7 +65,25 @@ PageTransitionsBuilder parseTransitionsBuilder(
       return const CupertinoPageTransitionsBuilder();
     case "zoom":
       return const ZoomPageTransitionsBuilder();
+    case "none":
+      return const NoPageTransitionsBuilder();
     default:
       return defaultBuilder;
+  }
+}
+
+class NoPageTransitionsBuilder extends PageTransitionsBuilder {
+  const NoPageTransitionsBuilder();
+
+  @override
+  Widget buildTransitions<T>(
+    PageRoute<T>? route,
+    BuildContext? context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget? child,
+  ) {
+    // only return the child without warping it with animations
+    return child!;
   }
 }

--- a/sdk/python/flet/theme.py
+++ b/sdk/python/flet/theme.py
@@ -25,6 +25,7 @@ PageTransitionString = Literal["fadeUpwards", "openUpwards", "zoom", "cupertino"
 
 
 class PageTransitionTheme(Enum):
+    NONE = "none"
     FADE_UPWARDS = "fadeUpwards"
     OPEN_UPWARDS = "openUpwards"
     ZOOM = "zoom"


### PR DESCRIPTION
Close #808

Example code:

```python
    theme = ft.Theme()
    theme.page_transitions.macos = ft.PageTransitionTheme.NONE
    page.theme = theme
```