### PR TITLE
Fix for issue in build_update_commands() when checking for commands attrs id.

### DIFF
--- a/sdk/python/flet/control.py
+++ b/sdk/python/flet/control.py
@@ -309,7 +309,7 @@ class Control:
                     while i < len(commands):
                         cmd = commands[i]
                         if cmd.name == "add" and any(
-                            c for c in cmd.commands if c.attrs["id"] == ctrl.__uid
+                            c for c in cmd.commands if c.attrs.get("id") == ctrl.__uid
                         ):
                             # insert delete command before add
                             commands.insert(i, Command(0, "remove", [ctrl.__uid]))


### PR DESCRIPTION
Fixed issue with `if cmd.name == "add" and any(c for c in cmd.commands if c.attrs["id"] == ctrl.__uid):` 
because some commands may not have the id value so now it's `if cmd.name == "add" and any( c for c in cmd.commands if c.attrs.get("id") == ctrl.__uid ):