### PR TITLE
Add default values in Border dataclass

### DIFF
--- a/sdk/python/flet/border.py
+++ b/sdk/python/flet/border.py
@@ -10,10 +10,10 @@ class BorderSide:
 
 @dataclasses.dataclass
 class Border:
-    top: Optional[BorderSide]
-    right: Optional[BorderSide]
-    bottom: Optional[BorderSide]
-    left: Optional[BorderSide]
+    top: Optional[BorderSide] = dataclasses.field(default=None)
+    right: Optional[BorderSide] = dataclasses.field(default=None)
+    bottom: Optional[BorderSide] = dataclasses.field(default=None)
+    left: Optional[BorderSide] = dataclasses.field(default=None)
 
 
 def all(width: Optional[float] = None, color: Optional[str] = None):


### PR DESCRIPTION
When I customize the sidebar, I want there to be a dividing line on the right, so I use the Container class and add the border parameter. In this process, I found that the Border class must pass in all four parameters, but I want the effect to be 
```python
Border(right=BorderSide(2, colors.PRIMARY))
```
now it must be
```python
Border(None, BorderSide(2, colors.PRIMARY), None, None)
```

The pr add default values in Border dataclass.