### PR TITLE
Add accessor previous_children to Refs

### DIFF
--- a/sdk/python/packages/flet-core/src/flet_core/ref.py
+++ b/sdk/python/packages/flet-core/src/flet_core/ref.py
@@ -1,4 +1,4 @@
-from typing import Generic, TypeVar
+from typing import Generic, TypeVar, Optional, List, Any
 
 T = TypeVar("T")
 
@@ -14,3 +14,8 @@ class Ref(Generic[T]):
     @current.setter
     def current(self, value: T):
         self._current = value
+
+    @property
+    def previous_children(self) -> Optional[List[Any]]:
+        return self._current._Control__previous_children
+


### PR DESCRIPTION
Adds a quick accessor to fetch the previous children of a ref.

calling REF_VALUE.current.previous_children should return list of the previous children controls belonging to the ref. If no children then returns an empty list