### PR TITLE
Fix Contribution guide as PDM is no longer used

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ All isort command line options can be found [here](https://pycqa.github.io/isort
 
 ### pre-commit
 
-[pre-commit](https://pre-commit.com) is a dev dependency of Flet and is automatically installed by `pdm install`.
+[pre-commit](https://pre-commit.com) is a dev dependency of Flet and is automatically installed by `poetry install`.
 To install the pre-commit hooks run: `pre-commit install`.
 Once installed, everytime you commit, pre-commit will run the configured hooks against changed files.
 


### PR DESCRIPTION
Fix the contribution guide by replacing the old command `pdm install` with the new `poetry install` as PDM is no longer used as package manager for this project