### PR TITLE
padding attribute is not zero by default from the view component

### DIFF
--- a/sdk/python/packages/flet-core/src/flet_core/view.py
+++ b/sdk/python/packages/flet-core/src/flet_core/view.py
@@ -37,7 +37,7 @@ class View(Control):
         vertical_alignment: MainAxisAlignment = MainAxisAlignment.NONE,
         horizontal_alignment: CrossAxisAlignment = CrossAxisAlignment.NONE,
         spacing: OptionalNumber = None,
-        padding: PaddingValue = None,
+        padding: PaddingValue = 0,
         bgcolor: Optional[str] = None,
         scroll: Optional[ScrollMode] = None,
         auto_scroll: Optional[bool] = None,


### PR DESCRIPTION
I noticed a small error in view component,the default padding attribute of view is None but when I launch my application I have the impression that padding is not none so I played with the padding attribute and I understood that padding takes a value of 10, I don't know where the value comes from so I decided to correct this little error by passing a default value to padding to zero.
Here is some screenshoot with not passing padding a value .
![screen](https://user-images.githubusercontent.com/37194177/231626351-0323b4cc-265f-423a-907a-f1adccedd2e0.png)
![view](https://user-images.githubusercontent.com/37194177/231626422-c141d85c-af4f-4528-97cb-c4ded570c8a2.png)
![view_package](https://user-images.githubusercontent.com/37194177/231626459-2dc98771-bdfe-4102-b21f-b21224304267.png)

After passing padding to zero as default value here is the screenshot of it 


![final](https://user-images.githubusercontent.com/37194177/231626969-0734c59f-f705-4074-ba65-ad253b14d934.png)
