### PR TITLE
Capturing web client info: IP and user agent

### DIFF
--- a/sdk/python/packages/flet-core/src/flet_core/page.py
+++ b/sdk/python/packages/flet-core/src/flet_core/page.py
@@ -229,6 +229,8 @@ class Page(Control):
             Command(0, "get", ["page", "windowHeight"]),
             Command(0, "get", ["page", "windowTop"]),
             Command(0, "get", ["page", "windowLeft"]),
+            Command(0, "get", ["page", "clientIP"]),
+            Command(0, "get", ["page", "clientUserAgent"]),
         ]
 
     def __set_page_details(self, values):
@@ -242,6 +244,8 @@ class Page(Control):
         self._set_attr("windowHeight", values[7], False)
         self._set_attr("windowTop", values[8], False)
         self._set_attr("windowLeft", values[9], False)
+        self._set_attr("clientIP", values[10], False)
+        self._set_attr("clientUserAgent", values[11], False)
 
     def update(self, *controls):
         with self.__lock:
@@ -1009,6 +1013,16 @@ class Page(Control):
     @property
     def platform(self):
         return self._get_attr("platform")
+
+    # client_ip
+    @property
+    def client_ip(self):
+        return self._get_attr("clientIP")
+
+    # client_user_agent
+    @property
+    def client_user_agent(self):
+        return self._get_attr("clientUserAgent")
 
     # design
     @property

--- a/server/page/client.go
+++ b/server/page/client.go
@@ -38,6 +38,7 @@ type Client struct {
 	role                 ClientRole
 	conn                 connection.Conn
 	clientIP             string
+	clientUserAgent      string
 	subscription         chan []byte
 	sessions             map[string]*model.Session
 	pages                map[string]*model.Page
@@ -49,7 +50,7 @@ func autoID() string {
 	return uuid.New().String()
 }
 
-func NewClient(conn connection.Conn, clientIP string) *Client {
+func NewClient(conn connection.Conn, clientIP string, clientUserAgent string) *Client {
 
 	ip := clientIP
 	if ip == "::1" {
@@ -60,6 +61,7 @@ func NewClient(conn connection.Conn, clientIP string) *Client {
 		id:                   autoID(),
 		conn:                 conn,
 		clientIP:             ip,
+		clientUserAgent:      clientUserAgent,
 		sessions:             make(map[string]*model.Session),
 		pages:                make(map[string]*model.Page),
 		pageNames:            make(map[string]bool),
@@ -269,7 +271,7 @@ func (c *Client) registerWebClientCore(request *RegisterWebClientRequestPayload)
 				return
 			}
 
-			session = newSession(page, uuid.New().String(), c.clientIP,
+			session = newSession(page, uuid.New().String(), c.clientIP, c.clientUserAgent,
 				request.PageRoute, request.PageWidth, request.PageHeight,
 				request.WindowWidth, request.WindowHeight, request.WindowTop, request.WindowLeft,
 				request.IsPWA, request.IsWeb, request.Platform)
@@ -425,7 +427,7 @@ func (c *Client) registerHostClient(message *Message) {
 		// retrieve zero session
 		session := store.GetSession(page, ZeroSession)
 		if session == nil {
-			session = newSession(page, ZeroSession, c.clientIP, "", "", "", "", "", "", "", "", "", "")
+			session = newSession(page, ZeroSession, c.clientIP, c.clientUserAgent, "", "", "", "", "", "", "", "", "", "")
 		} else if !request.Update {
 			err = cleanPage(session)
 			if err != nil {

--- a/server/page/session_handler.go
+++ b/server/page/session_handler.go
@@ -47,7 +47,7 @@ type addCommandBatchItem struct {
 }
 
 // NewSession creates a new instance of Session.
-func newSession(page *model.Page, id string, clientIP string,
+func newSession(page *model.Page, id string, clientIP string, clientUserAgent string,
 	pageRoute string, pageWidth string, pageHeight string,
 	windowWidth string, windowHeight string,
 	windowTop string, windowLeft string, isPwa string, isWeb string, platform string) *model.Session {
@@ -70,6 +70,8 @@ func newSession(page *model.Page, id string, clientIP string,
 	p.SetAttr("pwa", isPwa)
 	p.SetAttr("web", isWeb)
 	p.SetAttr("platform", platform)
+	p.SetAttr("clientIP", clientIP)
+	p.SetAttr("clientUserAgent", clientUserAgent)
 	h.addControl(p)
 
 	return s

--- a/server/server/server.go
+++ b/server/server/server.go
@@ -206,5 +206,5 @@ func websocketHandler(c *gin.Context) {
 	}
 
 	wsc := page_connection.NewWebSocket(conn)
-	page.NewClient(wsc, c.ClientIP())
+	page.NewClient(wsc, c.ClientIP(), c.Request.UserAgent())
 }


### PR DESCRIPTION
New `page` properties: `client_ip` and `client_user_agent`. Close #1053

Usage example:

```python
import flet as ft

def main(page: ft.Page):

    page.add(
        ft.Text(f"Client IP: {page.client_ip}"),
        ft.Text(f"Client user agent: {page.client_user_agent}"),
    )

ft.app(target=main, port=8550, view=ft.WEB_BROWSER)
```