### PR TITLE
Create initial value for __theme_mode attribute in Page class.

### DIFF
--- a/sdk/python/packages/flet-core/src/flet_core/page.py
+++ b/sdk/python/packages/flet-core/src/flet_core/page.py
@@ -111,6 +111,7 @@ class Page(Control):
         self.__offstage = Offstage()
         self.__theme = None
         self.__dark_theme = None
+        self.__theme_mode = ThemeMode.SYSTEM  # Default Theme Mode
         self.__pubsub = PubSub(conn.pubsubhub, session_id)
         self.__client_storage = ClientStorage(self)
         self.__session_storage = SessionStorage(self)


### PR DESCRIPTION
This change resolves #1153 by initializing `self.__theme_mode` in the `__init__` method of the Page class to avoid the `AttributeError` raised by the `theme_mode` property method on line `1205`. 

I've set this attribute to `ThemeMode.SYSTEM` as noted in the documentation for the default value of `page.theme_mode`