### PR TITLE
Added `Image.error_content` property

### DIFF
--- a/package/lib/src/controls/create_control.dart
+++ b/package/lib/src/controls/create_control.dart
@@ -172,7 +172,11 @@ Widget createWidget(Key? key, ControlViewModel controlView, Control? parent,
           key: key, parent: parent, control: controlView.control);
     case "image":
       return ImageControl(
-          key: key, parent: parent, control: controlView.control);
+          key: key,
+          parent: parent,
+          children: controlView.children,
+          control: controlView.control,
+          parentDisabled: parentDisabled);
     case "audio":
       return AudioControl(
           parent: parent,

--- a/package/lib/src/controls/image.dart
+++ b/package/lib/src/controls/image.dart
@@ -19,11 +19,18 @@ import 'error.dart';
 
 class ImageControl extends StatelessWidget {
   final Control? parent;
+  final List<Control> children;
   final Control control;
+  final bool parentDisabled;
 
   static const String svgTag = "<svg";
 
-  const ImageControl({Key? key, required this.parent, required this.control})
+  const ImageControl(
+      {Key? key,
+      required this.parent,
+      required this.children,
+      required this.control,
+      required this.parentDisabled})
       : super(key: key);
 
   @override
@@ -47,6 +54,9 @@ class ImageControl extends StatelessWidget {
         Theme.of(context), control.attrString("color", "")!);
     String? semanticsLabel = control.attrString("semanticsLabel");
     var gaplessPlayback = control.attrBool("gaplessPlayback");
+    bool disabled = control.isDisabled || parentDisabled;
+    var errorContentCtrls =
+        children.where((c) => c.name == "error_content" && c.isVisible);
 
     return StoreConnector<AppState, PageArgsModel>(
         distinct: true,
@@ -105,15 +115,23 @@ class ImageControl extends StatelessWidget {
                     blendMode: colorBlendMode ?? BlendMode.srcIn,
                     semanticsLabel: semanticsLabel);
               } else {
-                image = Image.file(io.File(assetSrc.path),
-                    width: width,
-                    height: height,
-                    repeat: repeat,
-                    fit: fit,
-                    color: color,
-                    gaplessPlayback: gaplessPlayback ?? false,
-                    colorBlendMode: colorBlendMode,
-                    semanticLabel: semanticsLabel);
+                image = Image.file(
+                  io.File(assetSrc.path),
+                  width: width,
+                  height: height,
+                  repeat: repeat,
+                  fit: fit,
+                  color: color,
+                  gaplessPlayback: gaplessPlayback ?? false,
+                  colorBlendMode: colorBlendMode,
+                  semanticLabel: semanticsLabel,
+                  errorBuilder: errorContentCtrls.isNotEmpty
+                      ? (context, error, stackTrace) {
+                          return createControl(
+                              control, errorContentCtrls.first.id, disabled);
+                        }
+                      : null,
+                );
               }
             } else {
               // URL
@@ -134,7 +152,13 @@ class ImageControl extends StatelessWidget {
                     color: color,
                     gaplessPlayback: gaplessPlayback ?? false,
                     colorBlendMode: colorBlendMode,
-                    semanticLabel: semanticsLabel);
+                    semanticLabel: semanticsLabel,
+                    errorBuilder: errorContentCtrls.isNotEmpty
+                        ? (context, error, stackTrace) {
+                            return createControl(
+                                control, errorContentCtrls.first.id, disabled);
+                          }
+                        : null);
               }
             }
           }

--- a/sdk/python/packages/flet-core/src/flet_core/__init__.py
+++ b/sdk/python/packages/flet-core/src/flet_core/__init__.py
@@ -12,7 +12,6 @@ from flet_core import (
     padding,
     painting,
     transform,
-    utils,
 )
 from flet_core.alert_dialog import AlertDialog
 from flet_core.alignment import Alignment

--- a/sdk/python/packages/flet-core/src/flet_core/image.py
+++ b/sdk/python/packages/flet-core/src/flet_core/image.py
@@ -1,7 +1,7 @@
 from typing import Any, Optional, Union
 
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import OptionalNumber
+from flet_core.control import Control, OptionalNumber
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
@@ -85,6 +85,7 @@ class Image(ConstrainedControl):
         # Specific
         #
         src_base64: Optional[str] = None,
+        error_content: Optional[Control] = None,
         repeat: Optional[ImageRepeat] = None,
         fit: Optional[ImageFit] = None,
         border_radius: BorderRadiusValue = None,
@@ -125,6 +126,7 @@ class Image(ConstrainedControl):
 
         self.src = src
         self.src_base64 = src_base64
+        self.error_content = error_content
         self.fit = fit
         self.repeat = repeat
         self.border_radius = border_radius
@@ -135,6 +137,13 @@ class Image(ConstrainedControl):
 
     def _get_control_name(self):
         return "image"
+
+    def _get_children(self):
+        children = []
+        if self.__error_content is not None:
+            self.__error_content._set_attr_internal("n", "error_content")
+            children.append(self.__error_content)
+        return children
 
     def _before_build_command(self):
         super()._before_build_command()
@@ -241,3 +250,12 @@ class Image(ConstrainedControl):
     @semantics_label.setter
     def semantics_label(self, value):
         self._set_attr("semanticsLabel", value)
+
+    # error_content
+    @property
+    def error_content(self) -> Optional[Control]:
+        return self.__error_content
+
+    @error_content.setter
+    def error_content(self, value: Optional[Control]):
+        self.__error_content = value

--- a/sdk/python/packages/flet-core/src/flet_core/utils.py
+++ b/sdk/python/packages/flet-core/src/flet_core/utils.py
@@ -1,8 +1,10 @@
 import asyncio
 import inspect
+import math
 import random
 import string
 import sys
+import unicodedata
 
 
 def random_string(length):
@@ -18,3 +20,153 @@ def is_asyncio():
 
 def is_coroutine(method):
     return inspect.iscoroutinefunction(method)
+
+
+def slugify(original: str) -> str:
+    """
+    Make a string url friendly. Useful for creating routes for navigation.
+
+    >>> slugify("What's    up?")
+    'whats-up'
+
+    >>> slugify("  Mitä kuuluu?  ")
+    'mitä-kuuluu'
+    """
+    slugified = original.strip()
+    slugified = " ".join(slugified.split())  # Remove extra spaces between words
+    slugified = slugified.lower()
+    # Remove unicode punctuation
+    slugified = "".join(
+        character
+        for character in slugified
+        if not unicodedata.category(character).startswith("P")
+    )
+    slugified = slugified.replace(" ", "-")
+
+    return slugified
+
+
+class Vector(complex):
+    """
+    Simple immutable 2D vector class based on the Python complex number type
+
+    Create and access - coordinates
+
+    >>> v = Vector(1, 2)
+    >>> v.x, v.y
+    (1.0, 2.0)
+
+    Create and access - angle and magnitude (length)
+
+    >>> v = Vector.polar(math.pi, 2)
+    >>> v
+    Vector(-2.0, 0.0)
+    >>> v.magnitude  # Length of the vector, alias for abs(v)
+    2.0
+    >>> v.radians
+    3.141592653589793
+    >>> v.degrees
+    180.0
+
+    Arithmetic operations
+
+    >>> Vector(1, 1) + 2
+    Vector(3.0, 1.0)
+    >>> Vector(0.1, 0.1) + Vector(0.2, 0.2)  == Vector(0.3, 0.3)  # Float tolerance 10 decimals
+    True
+    >>> Vector(2, 3) - Vector(1, 1)
+    Vector(1.0, 2.0)
+    >>> Vector(1, 1) * 2
+    Vector(2.0, 2.0)
+    >>> round(Vector.polar(math.pi / 4, 1), 1)
+    Vector(0.7, 0.7)
+
+    Get a new vector by adjusting one of the coordinates
+    >>> v = Vector()
+    >>> v.with_x(1)
+    Vector(1.0, 0.0)
+    >>> v.with_y(2)
+    Vector(0.0, 2.0)
+
+    Get a new vector by adjusting angle or magnitude
+
+    >>> v = Vector(1, 2)
+    >>> v = v.with_magnitude(4.47213595499958)  # Twice as long
+    >>> v.x, v.y
+    (2.0, 4.0)
+
+    >>> v = Vector.polar(math.pi, 2)
+    >>> v
+    Vector(-2.0, 0.0)
+    >>> v.with_radians(0)
+    Vector(2.0, 0.0)
+    >>> v.with_degrees(90)
+    Vector(0.0, 2.0)
+    """
+
+    abs_tol = 1e-10
+
+    x = complex.real
+    y = complex.imag
+    __add__ = lambda self, other: type(self)(complex.__add__(self, other))
+    __sub__ = lambda self, other: type(self)(complex.__sub__(self, other))
+    __mul__ = lambda self, other: type(self)(complex.__mul__(self, other))
+    __truediv__ = lambda self, other: type(self)(complex.__truediv__(self, other))
+    __len__ = lambda self: 2
+    __round__ = lambda self, ndigits=None: type(self)(
+        round(self.x, ndigits), round(self.y, ndigits)
+    )
+
+    def __eq__(self, other):
+        return math.isclose(self.x, other.x, abs_tol=self.abs_tol) and math.isclose(
+            self.y, other.y, abs_tol=self.abs_tol
+        )
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __iter__(self):
+        return iter([self.x, self.y])
+
+    def __str__(self):
+        return str(tuple(self))
+
+    def __repr__(self):
+        return f"{type(self).__name__}{str(self)}"
+
+    @classmethod
+    def polar(cls, radians, magnitude):
+        return cls(
+            round(math.cos(radians) * magnitude, 10),
+            round(math.sin(radians) * magnitude, 10),
+        )
+
+    @property
+    def magnitude(self):
+        return abs(self)
+
+    @property
+    def degrees(self):
+        return math.degrees(self.radians)
+
+    @property
+    def radians(self):
+        return math.atan2(self.y, self.x)
+
+    def with_x(self, value):
+        return type(self)(value, self.y)
+
+    def with_y(self, value):
+        return type(self)(self.x, value)
+
+    def with_magnitude(self, value):
+        return self * value / abs(self)
+
+    def with_radians(self, value):
+        magnitude = abs(self)
+        return type(self).polar(value, magnitude)
+
+    def with_degrees(self, value):
+        radians = math.radians(value)
+        magnitude = abs(self)
+        return type(self).polar(radians, magnitude)

--- a/sdk/python/packages/flet-embed/src/flet/utils/__init__.py
+++ b/sdk/python/packages/flet-embed/src/flet/utils/__init__.py
@@ -1,1 +1,1 @@
-from flet_runtime.utils import Vector, slugify
+from flet_core.utils import Vector, slugify

--- a/sdk/python/packages/flet-runtime/src/flet_runtime/utils.py
+++ b/sdk/python/packages/flet-runtime/src/flet_runtime/utils.py
@@ -121,8 +121,12 @@ def is_localhost_url(url):
     )
 
 
-def get_package_root_dir():
-    return str(Path(__file__).parent)
+try:
+    from flet.utils import get_package_root_dir
+except ImportError:
+
+    def get_package_root_dir():
+        return str(Path(__file__).parent)
 
 
 def get_package_bin_dir():
@@ -143,153 +147,3 @@ def get_free_tcp_port():
 def get_current_script_dir():
     pathname = os.path.dirname(sys.argv[0])
     return os.path.abspath(pathname)
-
-
-def slugify(original: str) -> str:
-    """
-    Make a string url friendly. Useful for creating routes for navigation.
-
-    >>> slugify("What's    up?")
-    'whats-up'
-
-    >>> slugify("  Mitä kuuluu?  ")
-    'mitä-kuuluu'
-    """
-    slugified = original.strip()
-    slugified = " ".join(slugified.split())  # Remove extra spaces between words
-    slugified = slugified.lower()
-    # Remove unicode punctuation
-    slugified = "".join(
-        character
-        for character in slugified
-        if not unicodedata.category(character).startswith("P")
-    )
-    slugified = slugified.replace(" ", "-")
-
-    return slugified
-
-
-class Vector(complex):
-    """
-    Simple immutable 2D vector class based on the Python complex number type
-
-    Create and access - coordinates
-
-    >>> v = Vector(1, 2)
-    >>> v.x, v.y
-    (1.0, 2.0)
-
-    Create and access - angle and magnitude (length)
-
-    >>> v = Vector.polar(math.pi, 2)
-    >>> v
-    Vector(-2.0, 0.0)
-    >>> v.magnitude  # Length of the vector, alias for abs(v)
-    2.0
-    >>> v.radians
-    3.141592653589793
-    >>> v.degrees
-    180.0
-
-    Arithmetic operations
-
-    >>> Vector(1, 1) + 2
-    Vector(3.0, 1.0)
-    >>> Vector(0.1, 0.1) + Vector(0.2, 0.2)  == Vector(0.3, 0.3)  # Float tolerance 10 decimals
-    True
-    >>> Vector(2, 3) - Vector(1, 1)
-    Vector(1.0, 2.0)
-    >>> Vector(1, 1) * 2
-    Vector(2.0, 2.0)
-    >>> round(Vector.polar(math.pi / 4, 1), 1)
-    Vector(0.7, 0.7)
-
-    Get a new vector by adjusting one of the coordinates
-    >>> v = Vector()
-    >>> v.with_x(1)
-    Vector(1.0, 0.0)
-    >>> v.with_y(2)
-    Vector(0.0, 2.0)
-
-    Get a new vector by adjusting angle or magnitude
-
-    >>> v = Vector(1, 2)
-    >>> v = v.with_magnitude(4.47213595499958)  # Twice as long
-    >>> v.x, v.y
-    (2.0, 4.0)
-
-    >>> v = Vector.polar(math.pi, 2)
-    >>> v
-    Vector(-2.0, 0.0)
-    >>> v.with_radians(0)
-    Vector(2.0, 0.0)
-    >>> v.with_degrees(90)
-    Vector(0.0, 2.0)
-    """
-
-    abs_tol = 1e-10
-
-    x = complex.real
-    y = complex.imag
-    __add__ = lambda self, other: type(self)(complex.__add__(self, other))
-    __sub__ = lambda self, other: type(self)(complex.__sub__(self, other))
-    __mul__ = lambda self, other: type(self)(complex.__mul__(self, other))
-    __truediv__ = lambda self, other: type(self)(complex.__truediv__(self, other))
-    __len__ = lambda self: 2
-    __round__ = lambda self, ndigits=None: type(self)(
-        round(self.x, ndigits), round(self.y, ndigits)
-    )
-
-    def __eq__(self, other):
-        return math.isclose(self.x, other.x, abs_tol=self.abs_tol) and math.isclose(
-            self.y, other.y, abs_tol=self.abs_tol
-        )
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
-    def __iter__(self):
-        return iter([self.x, self.y])
-
-    def __str__(self):
-        return str(tuple(self))
-
-    def __repr__(self):
-        return f"{type(self).__name__}{str(self)}"
-
-    @classmethod
-    def polar(cls, radians, magnitude):
-        return cls(
-            round(math.cos(radians) * magnitude, 10),
-            round(math.sin(radians) * magnitude, 10),
-        )
-
-    @property
-    def magnitude(self):
-        return abs(self)
-
-    @property
-    def degrees(self):
-        return math.degrees(self.radians)
-
-    @property
-    def radians(self):
-        return math.atan2(self.y, self.x)
-
-    def with_x(self, value):
-        return type(self)(value, self.y)
-
-    def with_y(self, value):
-        return type(self)(self.x, value)
-
-    def with_magnitude(self, value):
-        return self * value / abs(self)
-
-    def with_radians(self, value):
-        magnitude = abs(self)
-        return type(self).polar(value, magnitude)
-
-    def with_degrees(self, value):
-        radians = math.radians(value)
-        magnitude = abs(self)
-        return type(self).polar(radians, magnitude)

--- a/sdk/python/packages/flet/src/flet/utils/__init__.py
+++ b/sdk/python/packages/flet/src/flet/utils/__init__.py
@@ -1,1 +1,7 @@
-from flet_runtime.utils import Vector, slugify
+from pathlib import Path
+
+from flet_core.utils import Vector, slugify
+
+
+def get_package_root_dir():
+    return str(Path(__file__).parent.parent)


### PR DESCRIPTION
Added `Image.error_content` property to display fallback content on image load error.

Usage example:

```python
import flet as ft

def main(page: ft.Page):
    page.add(
        ft.Image(
            src="<some inexisting image>.png",
            error_content=ft.Image(
                src="https://github.com/flet-dev/flet/raw/214a90bd10283629f88d6386b0e3af5029fd85d9/media/icons/macos/flet-png/app_icon_64!!.png",
                error_content=ft.Text("Error loading image!"),
            ),
        )
    )

ft.app(target=main)
```