### PR TITLE
Added support for AES-256 bit GCM encryption

### DIFF
--- a/sdk/python/packages/flet/src/flet/security.py
+++ b/sdk/python/packages/flet/src/flet/security.py
@@ -41,16 +41,16 @@ def encrypt_aes_gcm_256(plain_text:str,secret_key:str) -> str:
     nonce = os.urandom(32)
     salt = os.urandom(16)
     key = __generate_fernet_key_kdf(secret_key,salt)
-    ag = AESGCM(key)
-    return base64.urlsafe_b64encode(
-        salt + ag.encrypt(nonce,plain_text.encode("utf-8"),None)
-    ).decode()
+    key = hashlib.sha256(key).hexdigest()
+    ag = AESGCM(key[:32].encode())
+    return base64.urlsafe_b64encode(salt + nonce + ag.encrypt(nonce,plain_text.encode("utf-8"),None)).decode("utf-8")
 
 def decrypt_aes_gcm_256(encrypted_data:str,secret_key:str) -> str:
     ciphertext_data_in_bytes = base64.urlsafe_b64decode(encrypted_data)
     salt = ciphertext_data_in_bytes[:16]
     key = __generate_fernet_key_kdf(secret_key,salt)
-    ag = AESGCM(key)
+    key = hashlib.sha256(key).hexdigest()
+    ag = AESGCM(key[:32].encode())
     return ag.decrypt(ciphertext_data_in_bytes[16:48],ciphertext_data_in_bytes[48:],None).decode("utf-8")
 
 

--- a/sdk/python/packages/flet/src/flet/security.py
+++ b/sdk/python/packages/flet/src/flet/security.py
@@ -6,6 +6,7 @@ try:
     from cryptography.fernet import Fernet
     from cryptography.hazmat.primitives import hashes
     from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+    from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 except ImportError:
     raise Exception('Install "cryptography" Python package to use Flet security utils.')
 
@@ -35,3 +36,21 @@ def decrypt(encrypted_data: str, secret_key: str) -> str:
     key = __generate_fernet_key_kdf(secret_key, salt)
     f = Fernet(key)
     return f.decrypt(encrypted_data_bytes[16:]).decode("utf-8")
+
+def encrypt_aes_gcm_256(plain_text:str,secret_key:str) -> str:
+    nonce = os.urandom(32)
+    salt = os.urandom(16)
+    key = __generate_fernet_key_kdf(secret_key,salt)
+    ag = AESGCM(key)
+    return base64.urlsafe_b64encode(
+        salt + ag.encrypt(nonce,plain_text.encode("utf-8"),None)
+    ).decode()
+
+def decrypt_aes_gcm_256(encrypted_data:str,secret_key:str) -> str:
+    ciphertext_data_in_bytes = base64.urlsafe_b64decode(encrypted_data)
+    salt = ciphertext_data_in_bytes[:16]
+    key = __generate_fernet_key_kdf(secret_key,salt)
+    ag = AESGCM(key)
+    return ag.decrypt(ciphertext_data_in_bytes[16:48],ciphertext_data_in_bytes[48:],None).decode("utf-8")
+
+


### PR DESCRIPTION
Despite the fact that AES-128 provides a solid amount of security I believe that going the extra step and adding support for the AES-256-GCM encryption and authentication scheme can be extremely useful to users who want more security in their flet project while not having to actually mess with outside cryptographic libraries. It uses the same libraries as the already existing cryptographic implementation (hashlib + cryptography) so it will not mess with dependencies.  