### PR TITLE
fix changelog for the new import module for OAuth providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,10 @@ ft.app(main, view=ft.AppView.WEB_BROWSER, web_renderer=ft.WebRenderer.HTML)
 ```
 
 * Flet packages `version` is centralized in `flet_core.version`.
-* 💥 **Breaking change:** OAuth providers must be imported from `flet.auth.providers` module, for example:
+* 💥 **Breaking change:** OAuth providers must now be imported from `flet_runtime.auth.oauth_provider` module, for example:
 
 ```python
-from flet.auth.providers import GitHubOAuthProvider
+from flet_runtime.auth.oauth_provider import GitHubOAuthProvider
 ```
 
 * Added `Image.error_content` property - fallback content if image cannot be loaded.


### PR DESCRIPTION
current changelog incorrect points to the new import for OAuth providers as being in `flet.auth.providers`, but it should be in `flet_runtime.auth.oauth_provider`

also, I feel that further emphasis for the "breaking change" could/should be made in the changelog for `flet_runtime` replacing `flet` in general for a number of modules, beyond just the OAuth providers