### PR TITLE
fix typo: "Countinuos" of `CountinuosRectangleBorder` and similar to "Continuous"

### DIFF
--- a/package/lib/src/utils/borders.dart
+++ b/package/lib/src/utils/borders.dart
@@ -112,7 +112,7 @@ OutlinedBorder? outlinedBorderFromJSON(Map<String, dynamic> json) {
         borderRadius: json["radius"] != null
             ? borderRadiusFromJSON(json["radius"])
             : BorderRadius.zero);
-  } else if (type == "countinuosRectangle") {
+  } else if (type == "continuousRectangle") {
     return ContinuousRectangleBorder(
         borderRadius: json["radius"] != null
             ? borderRadiusFromJSON(json["radius"])

--- a/sdk/python/packages/flet-core/src/flet_core/__init__.py
+++ b/sdk/python/packages/flet-core/src/flet_core/__init__.py
@@ -28,7 +28,7 @@ from flet_core.buttons import (
     BeveledRectangleBorder,
     ButtonStyle,
     CircleBorder,
-    CountinuosRectangleBorder,
+    ContinuousRectangleBorder,
     OutlinedBorder,
     RoundedRectangleBorder,
     StadiumBorder,

--- a/sdk/python/packages/flet-core/src/flet_core/buttons.py
+++ b/sdk/python/packages/flet-core/src/flet_core/buttons.py
@@ -39,8 +39,8 @@ class BeveledRectangleBorder(OutlinedBorder):
 
 
 @dataclasses.dataclass
-class CountinuosRectangleBorder(OutlinedBorder):
-    type: str = field(default="countinuosRectangle")
+class ContinuousRectangleBorder(OutlinedBorder):
+    type: str = field(default="continuousRectangle")
     radius: BorderRadiusValue = field(default=None)
 
 


### PR DESCRIPTION
**Note:** Breaking change!
If merged, docs [here](https://flet.dev/docs/controls/elevatedbutton/#style) on `shape` should be directly updated.