### PR TITLE
improve create command output

### DIFF
--- a/sdk/python/packages/flet/src/flet/cli/commands/create.py
+++ b/sdk/python/packages/flet/src/flet/cli/commands/create.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from flet.cli.commands.base import BaseCommand
 from flet_core.utils import slugify
+from colorama import Fore, Style
 
 
 class Command(BaseCommand):
@@ -64,3 +65,9 @@ class Command(BaseCommand):
             defaults=True,
         ) as worker:
             worker.run_copy()
+            print(Fore.LIGHTGREEN_EX + "\nDone. Now run:\n")
+            print(Style.RESET_ALL)
+            print(Fore.CYAN + "cd", end=" ")
+            print(Fore.WHITE + project_name, end="\n")
+            print(Fore.CYAN + "flet run")
+            print(Style.RESET_ALL)


### PR DESCRIPTION
Now after running create command it will display more info about what to do next.
## Before
![Before applying my edits](https://github.com/flet-dev/flet/assets/114005178/1a448815-2d28-407d-8dc0-757addeec3b4)

## After
![After applying my edits](https://github.com/flet-dev/flet/assets/114005178/cc666233-0790-4e1e-9e3b-359f37db49a7)

## Why this edit ?

Because when I first time create a project I thought it created all of those file in my current folder instead of creating a new folder. So I run `flet run` and I got an error.
