### PR TITLE
Added AlertDialog.inset_padding property

### DIFF
--- a/package/lib/src/controls/alert_dialog.dart
+++ b/package/lib/src/controls/alert_dialog.dart
@@ -65,6 +65,7 @@ class _AlertDialogControlState extends State<AlertDialogControl> {
       actionsPadding: parseEdgeInsets(widget.control, "actionsPadding"),
       actionsAlignment: actionsAlignment,
       shape: parseOutlinedBorder(widget.control, "shape"),
+      insetPadding: parseEdgeInsets(widget.control, "insetPadding"),
     );
   }
 

--- a/package/lib/src/controls/alert_dialog.dart
+++ b/package/lib/src/controls/alert_dialog.dart
@@ -65,7 +65,8 @@ class _AlertDialogControlState extends State<AlertDialogControl> {
       actionsPadding: parseEdgeInsets(widget.control, "actionsPadding"),
       actionsAlignment: actionsAlignment,
       shape: parseOutlinedBorder(widget.control, "shape"),
-      insetPadding: parseEdgeInsets(widget.control, "insetPadding"),
+      insetPadding: parseEdgeInsets(widget.control, "insetPadding") ??
+          const EdgeInsets.symmetric(horizontal: 40.0, vertical: 24.0),
     );
   }
 

--- a/sdk/python/packages/flet-core/src/flet_core/alert_dialog.py
+++ b/sdk/python/packages/flet-core/src/flet_core/alert_dialog.py
@@ -78,6 +78,7 @@ class AlertDialog(Control):
         actions_padding: PaddingValue = None,
         actions_alignment: MainAxisAlignment = MainAxisAlignment.NONE,
         shape: Optional[OutlinedBorder] = None,
+        inset_padding: PaddingValue = None,
         on_dismiss=None,
     ):
 
@@ -103,6 +104,7 @@ class AlertDialog(Control):
         self.actions_padding = actions_padding
         self.actions_alignment = actions_alignment
         self.shape = shape
+        self.inset_padding = inset_padding
         self.on_dismiss = on_dismiss
 
     def _get_control_name(self):
@@ -114,6 +116,7 @@ class AlertDialog(Control):
         self._set_attr_json("contentPadding", self.__content_padding)
         self._set_attr_json("titlePadding", self.__title_padding)
         self._set_attr_json("shape", self.__shape)
+        self._set_attr_json("insetPadding", self.__inset_padding)
 
     def _get_children(self):
         children = []
@@ -224,6 +227,15 @@ class AlertDialog(Control):
     @shape.setter
     def shape(self, value: Optional[OutlinedBorder]):
         self.__shape = value
+
+    # inset_padding
+    @property
+    def inset_padding(self) -> PaddingValue:
+        return self.__inset_padding
+
+    @inset_padding.setter
+    def inset_padding(self, value: PaddingValue):
+        self.__inset_padding = value
 
     # on_dismiss
     @property


### PR DESCRIPTION
Added AlertDialog.inset_paddin property to manage padding of Alert Dialog. On mobile phones with small width of screen, Dialog looks very thin. All pytests passed.

Usage example:
import flet as ft

def main(page: ft.Page):
    page.title = "AlertDialog examples"

    dlg = ft.AlertDialog(
        title=ft.Text("Hello, you!"), on_dismiss=lambda e: print("Dialog dismissed!"), inset_padding=ft.padding.symmetric(vertical=0, horizontal=0)
    )

    def close_dlg(e):
        dlg_modal.open = False
        page.update()

    dlg_modal = ft.AlertDialog(
        modal=True,
        title=ft.Text("Please confirm"),
        content=ft.Text("Do you really want to delete all those files?"),
        actions=[
            ft.TextButton("Yes", on_click=close_dlg),
            ft.TextButton("No", on_click=close_dlg),
        ],
        actions_alignment=ft.MainAxisAlignment.END,
        on_dismiss=lambda e: print("Modal dialog dismissed!"),
    )

    def open_dlg(e):
        page.dialog = dlg
        dlg.open = True
        page.update()

    def open_dlg_modal(e):
        page.dialog = dlg_modal
        dlg_modal.open = True
        page.update()

    page.add(
        ft.ElevatedButton("Open dialog", on_click=open_dlg),
        ft.ElevatedButton("Open modal dialog", on_click=open_dlg_modal),
    )

ft.app(target=main)