### PR TITLE
Fix 'flet run' on save subprocess cleanup (view, fletd)

### DIFF
--- a/sdk/python/.pre-commit-config.yaml
+++ b/sdk/python/.pre-commit-config.yaml
@@ -1,9 +1,9 @@
 repos:
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
   - repo: https://github.com/ambv/black
-    rev: 22.12.0
+    rev: 23.9.1
     hooks:
       - id: black


### PR DESCRIPTION
Hello flet devs,

can somebody explain to me why forked repo is not the same?

~/MSE/MSEprojects/PYTHON $ git clone https://github.com/flet-dev/flet flet_contrib_ORIG
~/MSE/MSEprojects/PYTHON $ git clone https://github.com/mse11/flet.git flet_contrib_MSE
 
On flet_contrib_ORIG can play e.g. 'flet run myapp/', but can't push (logical not my repo ) 
On flet_contrib_MSE I can't  e.g. 'flet run myapp/' , but can push (logical my repo ) see ERROR:
  

> File "/home/msestrie/MSE/MSEprojects/PYTHON/flet_contrib_MSE/sdk/python/packages/flet/src/flet/version.py", line 41, in update_version
>     raise RepositoryError(msg)
> 

Should I run some cmd to fix ERROR? 