### PR TITLE
Add ´__repr__´ to ´Control´

### DIFF
--- a/sdk/python/packages/flet-core/src/flet_core/control.py
+++ b/sdk/python/packages/flet-core/src/flet_core/control.py
@@ -156,6 +156,9 @@ class Control:
             attrs[k] = v[0]
         return f"{self._get_control_name()} {attrs}"
 
+    def __repr__(self):
+        return f"{self.__class__.__name__}(" + ", ".join(f"{k}={v[0]}" for k, v in self.__attrs.items()) + ")"
+
     # event_handlers
     @property
     def event_handlers(self):


### PR DESCRIPTION
More on `__repr__` [here](https://realpython.com/python-repr-vs-str/).

**Example:**
```python
>>> import flet as ft
>>> print(repr(ft.BottomSheet(show_drag_handle=True, visible=False, enable_drag=True)))
BottomSheet(visible=False, open=False, enabledrag=True, showdraghandle=True)
```

**Notes:**

- without the explicit use of `repr(),` the `__str__ ` is instead used:
  ```python
  >>> import flet as ft
  >>> print(ft.BottomSheet(show_drag_handle=True, visible=False, enable_drag=True))
  bottomsheet {'visible': False, 'open': False, 'enabledrag': True, 'showdraghandle': True}
  ```

- `showdraghandle`, for example, is printed instead of `show_drag_handle` because the camelCase `"showDragHandle"` passed in the setter is being lowered in `Control._set_attr_internal` before being added to `Control.__attrs` - this makes it quite impossible for me when grabing it, to make it snake_case

- the attributes `content` or `controls`, are not printed out - obviously because in contrast to the other bool or string attributes, they are not added to the `Control.__attrs` ; any thoughts?
