### PR TITLE
Add ´skip_route_change_event´ to ´Page.go_async´

### DIFF
--- a/sdk/python/packages/flet-core/src/flet_core/page.py
+++ b/sdk/python/packages/flet-core/src/flet_core/page.py
@@ -536,18 +536,19 @@ class Page(Control):
         self.update()
         self.query()  # Update query url (required when using go)
 
-    async def go_async(self, route, **kwargs):
+    async def go_async(self, route, skip_route_change_event=False, **kwargs):
         self.route = route if not kwargs else route + self.query.post(kwargs)
 
-        await self.__on_route_change.get_handler()(
-            ControlEvent(
-                target="page",
-                name="route_change",
-                data=self.route,
-                page=self,
-                control=self,
+        if not skip_route_change_event:
+            await self.__on_route_change.get_handler()(
+                ControlEvent(
+                    target="page",
+                    name="route_change",
+                    data=self.route,
+                    page=self,
+                    control=self,
+                )
             )
-        )
         await self.update_async()
         self.query()
 


### PR DESCRIPTION
Seems like this was forgotten by https://github.com/flet-dev/flet/pull/2039.