### PR TITLE
Feature: `TextField` Input validation

### DIFF
--- a/package/lib/src/controls/textfield.dart
+++ b/package/lib/src/controls/textfield.dart
@@ -10,6 +10,7 @@ import '../protocol/update_control_props_payload.dart';
 import '../utils/borders.dart';
 import '../utils/colors.dart';
 import '../utils/text.dart';
+import '../utils/textfield.dart';
 import 'create_control.dart';
 import 'form_field.dart';
 
@@ -162,6 +163,19 @@ class _TextFieldControlState extends State<TextFieldControl> {
                           .toLowerCase(),
                   orElse: () => TextCapitalization.none);
 
+          FilteringTextInputFormatter? inputFilter =
+              parseInputFilter(widget.control, "inputFilter");
+
+          List<TextInputFormatter>? inputFormatters = [];
+          // add non-null input formatters
+          if (inputFilter != null) {
+            inputFormatters.add(inputFilter);
+          }
+          if (textCapitalization != TextCapitalization.none) {
+            inputFormatters
+                .add(TextCapitalizationFormatter(textCapitalization));
+          }
+
           Widget? revealPasswordIcon;
           if (password && canRevealPassword) {
             revealPasswordIcon = GestureDetector(
@@ -241,11 +255,8 @@ class _TextFieldControlState extends State<TextFieldControl> {
               maxLines: maxLines,
               maxLength: maxLength,
               readOnly: readOnly,
-              inputFormatters: textCapitalization != TextCapitalization.none
-                  ? [
-                      TextCapitalizationFormatter(textCapitalization),
-                    ]
-                  : null,
+              inputFormatters:
+                  inputFormatters.isNotEmpty ? inputFormatters : null,
               obscureText: password && !_revealPassword,
               controller: _controller,
               focusNode: focusNode,

--- a/package/lib/src/utils/textfield.dart
+++ b/package/lib/src/utils/textfield.dart
@@ -1,0 +1,36 @@
+import 'dart:convert';
+
+import 'package:flet/src/utils/numbers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../models/control.dart';
+
+FilteringTextInputFormatter? parseInputFilter(
+    Control control, String propName) {
+  var v = control.attrString(propName, null);
+  if (v == null) {
+    return null;
+  }
+
+  final j1 = json.decode(v);
+  return inputFilterFromJSON(j1);
+}
+
+FilteringTextInputFormatter inputFilterFromJSON(dynamic json) {
+  bool allow = true;
+  String? regexString = "";
+  String? replacementString = "";
+
+  if (json != null) {
+    allow = parseBool(json["allow"], true);
+    regexString = json["regex_string"]?.toString();
+    replacementString = json["replacement_string"]?.toString();
+  }
+
+  debugPrint(
+      "Textfield inputFilter - allow: $allow | regexString: $regexString | replacementString: $replacementString");
+
+  return FilteringTextInputFormatter(RegExp(regexString ?? ""),
+      allow: allow, replacementString: replacementString ?? "");
+}

--- a/sdk/python/packages/flet-core/src/flet_core/__init__.py
+++ b/sdk/python/packages/flet-core/src/flet_core/__init__.py
@@ -169,7 +169,14 @@ from flet_core.text import Text, TextOverflow, TextThemeStyle
 from flet_core.text_button import TextButton
 from flet_core.text_span import TextSpan
 from flet_core.text_style import TextDecoration, TextDecorationStyle, TextStyle
-from flet_core.textfield import KeyboardType, InputFilter, TextCapitalization, TextField
+from flet_core.textfield import (
+    KeyboardType,
+    InputFilter,
+    NumbersOnlyInputFilter,
+    TextCapitalization,
+    TextField,
+    TextOnlyInputFilter,
+)
 from flet_core.theme import (
     ColorScheme,
     PageTransitionsTheme,

--- a/sdk/python/packages/flet-core/src/flet_core/__init__.py
+++ b/sdk/python/packages/flet-core/src/flet_core/__init__.py
@@ -169,7 +169,7 @@ from flet_core.text import Text, TextOverflow, TextThemeStyle
 from flet_core.text_button import TextButton
 from flet_core.text_span import TextSpan
 from flet_core.text_style import TextDecoration, TextDecorationStyle, TextStyle
-from flet_core.textfield import KeyboardType, TextCapitalization, TextField
+from flet_core.textfield import KeyboardType, InputFilter, TextCapitalization, TextField
 from flet_core.theme import (
     ColorScheme,
     PageTransitionsTheme,

--- a/sdk/python/packages/flet-core/src/flet_core/textfield.py
+++ b/sdk/python/packages/flet-core/src/flet_core/textfield.py
@@ -71,6 +71,14 @@ class InputFilter:
     allow: bool = field(default=True)
     replacement_string: str = field(default="")
 
+class NumbersOnlyInputFilter(InputFilter):
+    def __init__(self):
+        super().__init__(r"[0-9]")
+
+class TextOnlyInputFilter(InputFilter):
+    def __init__(self):
+        super().__init__(r"[a-zA-Z]")
+
 
 class TextField(FormFieldControl):
     """

--- a/sdk/python/packages/flet-core/src/flet_core/textfield.py
+++ b/sdk/python/packages/flet-core/src/flet_core/textfield.py
@@ -1,3 +1,5 @@
+import dataclasses
+from dataclasses import field
 import time
 from enum import Enum
 from typing import Any, Optional, Union
@@ -61,6 +63,13 @@ class TextCapitalization(Enum):
     CHARACTERS = "characters"
     WORDS = "words"
     SENTENCES = "sentences"
+
+
+@dataclasses.dataclass
+class InputFilter:
+    allow: bool = field(default=True)
+    regex_string: str = field(default="[0-9]")
+    replacement_string: str = field(default="")
 
 
 class TextField(FormFieldControl):
@@ -179,6 +188,7 @@ class TextField(FormFieldControl):
         cursor_height: OptionalNumber = None,
         cursor_radius: OptionalNumber = None,
         selection_color: Optional[str] = None,
+        input_filter: Optional[InputFilter] = None,
         on_change=None,
         on_submit=None,
         on_focus=None,
@@ -269,6 +279,7 @@ class TextField(FormFieldControl):
         self.cursor_width = cursor_width
         self.cursor_radius = cursor_radius
         self.selection_color = selection_color
+        self.input_filter = input_filter
         self.on_change = on_change
         self.on_submit = on_submit
         self.on_focus = on_focus
@@ -279,6 +290,7 @@ class TextField(FormFieldControl):
 
     def _before_build_command(self):
         super()._before_build_command()
+        self._set_attr_json("inputFilter", self.__input_filter)
         if self.bgcolor is not None and self.filled is None:
             self.filled = True  # Flutter requires filled = True to display a bgcolor
 
@@ -508,6 +520,15 @@ class TextField(FormFieldControl):
     @selection_color.setter
     def selection_color(self, value):
         self._set_attr("selectionColor", value)
+
+    # input_filter
+    @property
+    def input_filter(self) -> InputFilter:
+        return self.__input_filter
+
+    @input_filter.setter
+    def input_filter(self, value: Optional[InputFilter]):
+        self.__input_filter = value
 
     # on_change
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/textfield.py
+++ b/sdk/python/packages/flet-core/src/flet_core/textfield.py
@@ -523,7 +523,7 @@ class TextField(FormFieldControl):
 
     # input_filter
     @property
-    def input_filter(self) -> InputFilter:
+    def input_filter(self) -> Optional[InputFilter]:
         return self.__input_filter
 
     @input_filter.setter

--- a/sdk/python/packages/flet-core/src/flet_core/textfield.py
+++ b/sdk/python/packages/flet-core/src/flet_core/textfield.py
@@ -67,8 +67,8 @@ class TextCapitalization(Enum):
 
 @dataclasses.dataclass
 class InputFilter:
+    regex_string: str
     allow: bool = field(default=True)
-    regex_string: str = field(default="[0-9]")
     replacement_string: str = field(default="")
 
 


### PR DESCRIPTION
Close https://github.com/flet-dev/flet/issues/631

**Props:**
```python
@dataclasses.dataclass
class InputFilter:
    regex_string: str
    allow: bool = field(default=True)
    replacement_string: str = field(default="")
```

**Example code:**
```python
import flet as ft


def main(page: ft.Page):
    page.title = "Input Filtering"
    page.add(
        ft.TextField(
            label="Only numbers are allowed :)",
            input_filter=ft.InputFilter(allow=True, regex_string=r"[0-9]"), # only allow numbers
        )
    )

ft.app(target=main)

```

**Capture:**
(when trying to add text characters they are rejected)
![example](https://github.com/flet-dev/flet/assets/98978078/580ca23c-8326-4143-bf17-79a97184f71e)

**Notes:**
- `regex_string` can't be passed to dart as a raw string(using the 'r') 
  ```dart
  RegExp(regexString ?? "")
  ```
  As seen above, this is because the value of `regex_string` is stored in a variable (`regexString`).. hence using string interpolation(`RegExp(r"$regexString")`) for example, will cant work because the variable's name will not be interpolated (we are in raw mode). 
From [`RegExp`](https://api.flutter.dev/flutter/dart-core/RegExp-class.html) docs:
> Use a raw string to treat each character, including \ and $, in a string as a literal character. Each character then gets passed to the [RegExp](https://api.flutter.dev/flutter/dart-core/RegExp-class.html) parser. You should use a raw string as the argument to the [RegExp](https://api.flutter.dev/flutter/dart-core/RegExp-class.html) constructor.



This is my first dart contribution, hence will strongly appreciate opinions. 😄 