### PR TITLE
add `thumb_icon` to `Switch`

### DIFF
--- a/package/lib/src/controls/switch.dart
+++ b/package/lib/src/controls/switch.dart
@@ -8,6 +8,7 @@ import '../models/control.dart';
 import '../protocol/update_control_props_payload.dart';
 import '../utils/buttons.dart';
 import '../utils/colors.dart';
+import '../utils/icons.dart';
 import 'create_control.dart';
 import 'list_tile.dart';
 
@@ -110,6 +111,8 @@ class _SwitchControlState extends State<SwitchControl> {
                   widget.control.attrString("inactiveTrackColor", "")!),
               thumbColor: parseMaterialStateColor(
                   Theme.of(context), widget.control, "thumbColor"),
+              thumbIcon: parseMaterialStateIcon(
+                  Theme.of(context), widget.control, "thumbIcon"),
               trackColor: parseMaterialStateColor(
                   Theme.of(context), widget.control, "trackColor"),
               value: _value,

--- a/package/lib/src/utils/icons.dart
+++ b/package/lib/src/utils/icons.dart
@@ -1,7 +1,24 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 
+import '../models/control.dart';
 import 'material_icons.dart';
+import 'material_state.dart';
 
 IconData? getMaterialIcon(String iconName) {
   return materialIcons[iconName.toLowerCase()];
+}
+
+MaterialStateProperty<Icon?>? parseMaterialStateIcon(
+    ThemeData theme, Control control, String propName) {
+  var v = control.attrString(propName, null);
+  if (v == null) {
+    return null;
+  }
+
+  final j1 = json.decode(v);
+
+  return getMaterialStateProperty<Icon?>(
+      j1, (jv) => Icon(getMaterialIcon(jv as String)), null);
 }

--- a/sdk/python/packages/flet-core/src/flet_core/switch.py
+++ b/sdk/python/packages/flet-core/src/flet_core/switch.py
@@ -94,6 +94,7 @@ class Switch(ConstrainedControl):
         inactive_thumb_color: Optional[str] = None,
         inactive_track_color: Optional[str] = None,
         thumb_color: Union[None, str, Dict[MaterialState, str]] = None,
+        thumb_icon: Union[None, str, Dict[MaterialState, str]] = None,
         track_color: Union[None, str, Dict[MaterialState, str]] = None,
         on_change=None,
         on_focus=None,
@@ -137,6 +138,7 @@ class Switch(ConstrainedControl):
         self.inactive_thumb_color = inactive_thumb_color
         self.inactive_track_color = inactive_track_color
         self.thumb_color = thumb_color
+        self.thumb_icon = thumb_icon
         self.track_color = track_color
         self.on_change = on_change
         self.on_focus = on_focus
@@ -148,6 +150,7 @@ class Switch(ConstrainedControl):
     def _before_build_command(self):
         super()._before_build_command()
         self._set_attr_json("thumbColor", self.__thumb_color)
+        self._set_attr_json("thumbIcon", self.__thumb_icon)
         self._set_attr_json("trackColor", self.__track_color)
 
     # value
@@ -237,6 +240,15 @@ class Switch(ConstrainedControl):
     @thumb_color.setter
     def thumb_color(self, value: Union[None, str, Dict[MaterialState, str]]):
         self.__thumb_color = value
+
+    # thumb_icon
+    @property
+    def thumb_icon(self) -> Union[None, str, Dict[MaterialState, str]]:
+        return self.__thumb_icon
+
+    @thumb_icon.setter
+    def thumb_icon(self, value: Union[None, str, Dict[MaterialState, str]]):
+        self.__thumb_icon = value
 
     # track_color
     @property


### PR DESCRIPTION
Close #1638 

**Example:**
```python
import flet as ft


def main(page: ft.Page):
    page.window_height, page.window_width = 160, 200

    page.add(
        ft.Switch(
            thumb_color={
                ft.MaterialState.HOVERED: ft.colors.GREEN,
                ft.MaterialState.FOCUSED: ft.colors.RED,
                ft.MaterialState.DEFAULT: ft.colors.BLUE,
            },
            thumb_icon={
                ft.MaterialState.SELECTED: ft.icons.CHECK,
                ft.MaterialState.DEFAULT: ft.icons.CLOSE,
            },
        )
    )


ft.app(target=main)
```

**Capture:** 
![thumbIcon](https://github.com/flet-dev/flet/assets/98978078/82d9da87-c035-4f1e-a46f-e53ee5435394)

