### PR TITLE
Verify `Slider.value` limits

### DIFF
--- a/package/lib/src/controls/slider.dart
+++ b/package/lib/src/controls/slider.dart
@@ -93,7 +93,14 @@ class _SliderControlState extends State<SliderControl> {
 
     double value = widget.control.attrDouble("value", 0)!;
     if (_value != value) {
-      _value = value;
+      // verify limits
+      if (value < min) {
+        _value = min;
+      } else if (value > max) {
+        _value = max;
+      } else {
+        _value = value;
+      }
     }
 
     var slider = Slider(

--- a/sdk/python/packages/flet-core/src/flet_core/slider.py
+++ b/sdk/python/packages/flet-core/src/flet_core/slider.py
@@ -135,7 +135,13 @@ class Slider(ConstrainedControl):
     # value
     @property
     def value(self) -> OptionalNumber:
-        return self._get_attr("value", data_type="float")
+        v = self._get_attr("value", data_type="float")
+        # verify limits
+        if v < self.min:
+            v = self.min
+        elif v > self.max:
+            v = self.max
+        return v
 
     @value.setter
     def value(self, value: OptionalNumber):


### PR DESCRIPTION
Close https://github.com/flet-dev/flet/issues/1052

**Test Code:**
The main issue is resolved: `slider.value `now prints `100` (the `max`)
```py
>>> import flet as ft
>>> slider = ft.Slider(divisions=100, value=150, min=0, max=100)
>>> slider.value
100

# but :

>>> repr(slider)
'Slider(value=150, min=0, max=100, divisions=100)'
```

**Important Note:** 
As seen above the `__repr__` or even `__str__` still has `value=150`. 
This is because the `self.__attrs` (where the props are stored) is not updated. 

This could be solved by adding `self.value = v` (resetting the value / updating the `self.__attrs`) when verifying the limits in the `value @property` as follows: 

```py
@property
def value(self) -> OptionalNumber:
    v = self._get_attr("value", data_type="float")
    # verify limits
    if v < self.min:
        v = self.min
        self.value = v
    elif v > self.max:
        v = self.max
        self.value = v

    return v
```

but because we are in the `@property`, it will **only** be applied when `slider.value` is called. 

```py
>>> import flet as ft
>>> slider = ft.Slider(divisions=100, value=150, min=0, max=100)
>>> repr(slider)
'Slider(value=150, min=0, max=100, divisions=100)'
>>> slider.value
100
>>> repr(slider)
'Slider(value=100, min=0, max=100, divisions=100)'
```

Let me have your thoughts on the importance of this.
  