### PR TITLE
Output strings correctly in `__repr__` 

### DIFF
--- a/sdk/python/packages/flet-core/src/flet_core/control.py
+++ b/sdk/python/packages/flet-core/src/flet_core/control.py
@@ -157,7 +157,14 @@ class Control:
         return f"{self._get_control_name()} {attrs}"
 
     def __repr__(self):
-        return f"{self.__class__.__name__}(" + ", ".join(f"{k}={v[0]}" for k, v in self.__attrs.items()) + ")"
+        return (
+            f"{self.__class__.__name__}("
+            + ", ".join(
+                f"{k}={v[0]}" if not isinstance(v[0], str) else f"{k}='{v[0]}'"
+                for k, v in self.__attrs.items()
+            )
+            + ")"
+        )
 
     # event_handlers
     @property


### PR DESCRIPTION
Before :
```python
>>> repr(x)
"Text(value=text)"
```

After:
```python
>>> repr(x)
"Text(value='text')"
```
