### PR TITLE
`SegmentedButton` control

### DIFF
--- a/package/lib/src/controls/create_control.dart
+++ b/package/lib/src/controls/create_control.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 
 import 'package:collection/collection.dart';
+import 'package:flet/src/controls/segmented_button.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 
@@ -233,7 +234,6 @@ Widget createWidget(Key? key, ControlViewModel controlView, Control? parent,
           children: controlView.children,
           parentDisabled: parentDisabled,
           dispatch: controlView.dispatch);
-
     case "progressring":
       return ProgressRingControl(
           key: key, parent: parent, control: controlView.control);
@@ -306,6 +306,14 @@ Widget createWidget(Key? key, ControlViewModel controlView, Control? parent,
           control: controlView.control,
           children: controlView.children,
           parentDisabled: parentDisabled);
+    case "segmentedbutton":
+      return SegmentedButtonControl(
+          key: key,
+          parent: parent,
+          control: controlView.control,
+          children: controlView.children,
+          parentDisabled: parentDisabled,
+          dispatch: controlView.dispatch);
     case "stack":
       return StackControl(
           key: key,

--- a/package/lib/src/controls/segmented_button.dart
+++ b/package/lib/src/controls/segmented_button.dart
@@ -1,0 +1,154 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import '../actions.dart';
+import '../flet_app_services.dart';
+import '../models/control.dart';
+import '../protocol/update_control_props_payload.dart';
+import '../utils/desktop.dart';
+import 'create_control.dart';
+import '../utils/buttons.dart';
+import '../utils/debouncer.dart';
+import 'error.dart';
+
+class SegmentedButtonControl extends StatefulWidget {
+  final Control? parent;
+  final Control control;
+  final List<Control> children;
+  final bool parentDisabled;
+  final dynamic dispatch;
+
+  const SegmentedButtonControl({
+    Key? key,
+    this.parent,
+    required this.control,
+    required this.children,
+    required this.parentDisabled,
+    required this.dispatch,
+  }) : super(key: key);
+
+  @override
+  State<SegmentedButtonControl> createState() => _SegmentedButtonControlState();
+}
+
+class _SegmentedButtonControlState extends State<SegmentedButtonControl> {
+  final _debouncer = Debouncer(milliseconds: isDesktop() ? 10 : 100);
+  Set calendarView = {"1"};
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    _debouncer.dispose();
+    super.dispose();
+  }
+
+  void onChange(var selections) {
+    List s = jsonDecode(selections.toList().toString());
+    debugPrint("onChange values: $s");
+
+    List<Map<String, String>> props = [
+      {
+        "i": widget.control.id,
+        "selected": s.toString(),
+      }
+    ];
+    widget.dispatch(
+        UpdateControlPropsAction(UpdateControlPropsPayload(props: props)));
+
+    _debouncer.run(() {
+      final server = FletAppServices.of(context).server;
+      server.updateControlProps(props: props);
+      server.sendPageEvent(
+          eventTarget: widget.control.id,
+          eventName: "change",
+          eventData: s.toString());
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    debugPrint("SegmentedButtonControl build: ${widget.control.id}");
+    debugPrint("ATTRS: ${widget.control.attrs}");
+
+    debugPrint("CHILDREN: ${widget.children}");
+
+    var theme = Theme.of(context);
+    var style = parseButtonStyle(Theme.of(context), widget.control, "style",
+        defaultForegroundColor: theme.colorScheme.primary,
+        defaultBackgroundColor: theme.colorScheme.surface,
+        defaultOverlayColor: theme.colorScheme.primary.withOpacity(0.08),
+        defaultShadowColor: theme.colorScheme.shadow,
+        defaultSurfaceTintColor: theme.colorScheme.surfaceTint,
+        defaultElevation: 1,
+        defaultPadding: const EdgeInsets.symmetric(horizontal: 8),
+        defaultBorderSide: BorderSide.none,
+        defaultShape: theme.useMaterial3
+            ? const StadiumBorder()
+            : RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)));
+
+    bool allowEmptySelection =
+        widget.control.attrBool("allowEmptySelection", false)!;
+
+    bool allowMultipleSelection =
+        widget.control.attrBool("allowMultipleSelection", false)!;
+
+    Set selected = jsonDecode(widget.control.attrString("selected", "[]")!).toSet();
+    debugPrint("selected: $selected");
+
+    List<Control?> segments =
+        widget.children.where((c) => c.name == "segment").toList();
+    debugPrint("segments: $segments");
+
+    if (selected.isEmpty) {
+      return const ErrorControl(
+          "Selected property must contain at least one value.");
+    }
+
+    if (!allowMultipleSelection && selected.length != 1) {
+      return const ErrorControl("When allow_multiple_selection is False, "
+          "the selected property must contain exactly one value.");
+    }
+
+    if (allowMultipleSelection && selected.length > segments.length) {
+      return const ErrorControl("The length of the selected property must "
+          "be less than or equal to the number of segments.");
+    }
+
+    var selectedIcon = widget.children.where((c) => c.name == "selectedIcon");
+
+    bool showSelectedIcon = widget.control.attrBool("showSelectedIcon", true)!;
+
+    bool disabled = widget.control.isDisabled || widget.parentDisabled;
+    debugPrint(
+        "SegmentedButtonControl StoreConnector build: ${widget.control.id}");
+
+    var sb = SegmentedButton(
+        emptySelectionAllowed: allowEmptySelection,
+        multiSelectionEnabled: allowMultipleSelection,
+        selected: selected.isNotEmpty ? selected: {},
+        showSelectedIcon: showSelectedIcon,
+        style: style,
+        selectedIcon: selectedIcon.isNotEmpty
+            ? createControl(widget.control, selectedIcon.first.id, disabled)
+            : null,
+        onSelectionChanged: !disabled
+            ? (newSelection) {
+                debugPrint("onSelectionChanged: $newSelection");
+                onChange(newSelection.toSet());
+                setState() {
+                  selected = newSelection;
+                }
+              }
+            : null,
+        segments: List.generate(segments.length, (int index) {
+          return ButtonSegment(
+              value: index.toString(), label: Text(index.toString()));
+        }));
+
+    return constrainedControl(context, sb, widget.parent, widget.control);
+  }
+}

--- a/sdk/python/packages/flet-core/src/flet_core/__init__.py
+++ b/sdk/python/packages/flet-core/src/flet_core/__init__.py
@@ -156,6 +156,7 @@ from flet_core.responsive_row import ResponsiveRow
 from flet_core.row import Row
 from flet_core.safe_area import SafeArea
 from flet_core.scrollable_control import OnScrollEvent
+from flet_core.segmented_button import Segment, SegmentedButton
 from flet_core.semantics import Semantics
 from flet_core.shader_mask import ShaderMask
 from flet_core.shadow import BoxShadow, ShadowBlurStyle

--- a/sdk/python/packages/flet-core/src/flet_core/segmented_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/segmented_button.py
@@ -1,0 +1,277 @@
+import time
+from typing import Any, Optional, Union, List, Set
+
+from flet_core.buttons import ButtonStyle
+from flet_core.constrained_control import ConstrainedControl
+from flet_core.control import Control, OptionalNumber
+from flet_core.ref import Ref
+from flet_core.types import (
+    AnimationValue,
+    OffsetValue,
+    ResponsiveNumber,
+    RotateValue,
+    ScaleValue,
+)
+
+
+class Segment(Control):
+    def __init__(
+        self,
+        ref: Optional[Ref] = None,
+        expand: Union[None, bool, int] = None,
+        col: Optional[ResponsiveNumber] = None,
+        opacity: OptionalNumber = None,
+        tooltip: Optional[str] = None,
+        visible: Optional[bool] = None,
+        disabled: Optional[bool] = None,
+        data: Any = None,
+        #
+        # Specific
+        #
+        value: str = None,
+        icon: Optional[Control] = None,
+        label: Optional[Control] = None,
+    ):
+        Control.__init__(
+            self,
+            ref=ref,
+            expand=expand,
+            col=col,
+            opacity=opacity,
+            tooltip=tooltip,
+            visible=visible,
+            disabled=disabled,
+            data=data,
+        )
+
+        self.value = value
+        self.label = label
+        self.icon = icon
+
+    def _get_control_name(self):
+        return "segment"
+
+    def _before_build_command(self):
+        super()._before_build_command()
+
+    def _get_children(self):
+        children = []
+        if self.__label:
+            self.__label._set_attr_internal("n", "label")
+            children.append(self.__label)
+        if self.__icon:
+            self.__icon._set_attr_internal("n", "icon")
+            children.append(self.__icon)
+        return children
+
+    # label
+    @property
+    def label(self) -> Optional[Control]:
+        return self.__label
+
+    @label.setter
+    def label(self, value: Optional[Control]):
+        self.__label = value
+
+    # icon
+    @property
+    def icon(self) -> Optional[Control]:
+        return self.__icon
+
+    @icon.setter
+    def icon(self, value: Optional[Control]):
+        self.__icon = value
+
+    # value
+    @property
+    def value(self) -> str:
+        return self._get_attr("value")
+
+    @value.setter
+    def value(self, value: str):
+        self._set_attr("value", value)
+
+
+class SegmentedButton(ConstrainedControl):
+    """
+
+
+    -----
+
+    Online docs: https://flet.dev/docs/controls/segmentedbutton
+    """
+
+    def __init__(
+        self,
+        segments: List[Segment],
+        ref: Optional[Ref] = None,
+        key: Optional[str] = None,
+        width: OptionalNumber = None,
+        height: OptionalNumber = None,
+        left: OptionalNumber = None,
+        top: OptionalNumber = None,
+        right: OptionalNumber = None,
+        bottom: OptionalNumber = None,
+        expand: Union[None, bool, int] = None,
+        col: Optional[ResponsiveNumber] = None,
+        opacity: OptionalNumber = None,
+        rotate: RotateValue = None,
+        scale: ScaleValue = None,
+        offset: OffsetValue = None,
+        aspect_ratio: OptionalNumber = None,
+        animate_opacity: AnimationValue = None,
+        animate_size: AnimationValue = None,
+        animate_position: AnimationValue = None,
+        animate_rotation: AnimationValue = None,
+        animate_scale: AnimationValue = None,
+        animate_offset: AnimationValue = None,
+        on_animation_end=None,
+        tooltip: Optional[str] = None,
+        visible: Optional[bool] = None,
+        disabled: Optional[bool] = None,
+        data: Any = None,
+        #
+        # Specific
+        #
+        style: Optional[ButtonStyle] = None,
+        allow_empty_selection: Optional[bool] = None,
+        allow_multiple_selection: Optional[bool] = None,
+        selected: Optional[Set] = None,
+        selected_icon: Optional[Control] = None,
+        show_selected_icon: Optional[bool] = None,
+        on_change=None,
+    ):
+        ConstrainedControl.__init__(
+            self,
+            ref=ref,
+            key=key,
+            width=width,
+            height=height,
+            left=left,
+            top=top,
+            right=right,
+            bottom=bottom,
+            expand=expand,
+            col=col,
+            opacity=opacity,
+            rotate=rotate,
+            scale=scale,
+            offset=offset,
+            aspect_ratio=aspect_ratio,
+            animate_opacity=animate_opacity,
+            animate_size=animate_size,
+            animate_position=animate_position,
+            animate_rotation=animate_rotation,
+            animate_scale=animate_scale,
+            animate_offset=animate_offset,
+            on_animation_end=on_animation_end,
+            tooltip=tooltip,
+            visible=visible,
+            disabled=disabled,
+            data=data,
+        )
+
+        self.segments = segments
+        self.show_selected_icon = show_selected_icon
+        self.allow_multiple_selection = allow_multiple_selection
+        self.allow_empty_selection = allow_empty_selection
+        self.selected_icon = selected_icon
+        self.selected = selected
+        self.style = style
+        self.on_change = on_change
+
+    def _get_control_name(self):
+        return "segmentedbutton"
+
+    def _before_build_command(self):
+        super()._before_build_command()
+        if self.__style is None:
+            self.__style = ButtonStyle()
+            self.__style.side = self._wrap_attr_dict(self.__style.side)
+            self.__style.shape = self._wrap_attr_dict(self.__style.shape)
+        self._set_attr_json("style", self.__style)
+        self._set_attr_json("selected", self.__selected)
+
+    def _get_children(self):
+        children = []
+        for segment in self.segments:
+            segment._set_attr_internal("n", "segment")
+            children.append(segment)
+        if self.__selected_icon:
+            self.__selected_icon._set_attr_internal("n", "selectedIcon")
+            children.append(self.__selected_icon)
+        return children
+
+    # style
+    @property
+    def style(self) -> Optional[ButtonStyle]:
+        return self.__style
+
+    @style.setter
+    def style(self, value: Optional[ButtonStyle]):
+        self.__style = value
+
+    # on_change
+    @property
+    def on_change(self):
+        return self._get_event_handler("change")
+
+    @on_change.setter
+    def on_change(self, handler):
+        self._add_event_handler("change", handler)
+
+    # segments
+    @property
+    def segments(self):
+        return self.__segments
+
+    @segments.setter
+    def segments(self, value):
+        self.__segments = value if value is not None else []
+
+    # allow_empty_selection
+    @property
+    def allow_empty_selection(self) -> Optional[bool]:
+        return self._get_attr("allowEmptySelection", data_type="bool", def_value=False)
+
+    @allow_empty_selection.setter
+    def allow_empty_selection(self, value: Optional[bool]):
+        self._set_attr("allowEmptySelection", value)
+
+    # allow_multiple_selection
+    @property
+    def allow_multiple_selection(self) -> Optional[bool]:
+        return self._get_attr(
+            "allowMultipleSelection", data_type="bool", def_value=False
+        )
+
+    @allow_multiple_selection.setter
+    def allow_multiple_selection(self, value: Optional[bool]):
+        self._set_attr("allowMultipleSelection", value)
+
+    # selected
+    @property
+    def selected(self) -> Set:
+        return self._get_attr("selected")
+
+    @selected.setter
+    def selected(self, value: Set):
+        self.__selected = list(value) if isinstance(value, set) else []
+
+    # show_selected_icon
+    @property
+    def show_selected_icon(self) -> Optional[bool]:
+        return self._get_attr("showSelectedIcon", data_type="bool", def_value=True)
+
+    @show_selected_icon.setter
+    def show_selected_icon(self, value: Optional[bool]):
+        self._set_attr("showSelectedIcon", value)
+
+    # selected_icon
+    @property
+    def selected_icon(self) -> Optional[Control]:
+        return self.__selected_icon
+
+    @selected_icon.setter
+    def selected_icon(self, value: Optional[Control]):
+        self.__selected_icon = value


### PR DESCRIPTION
This Implementation is not yet complete! _Two_ important props are lacking a proper/working implementation: `segments` and `on_change`.
- `segments`: Parsing the segments doesnt work as expected;
- `on_change`: It is called as expected but the selected segments are not properly being updated (this is certainly related to the improper implementation of `segments` and `selected`)

**Test code:**
```py
import flet as ft


def main(page: ft.Page):
    def handle_change(e):
        print("on_change data : " + str(e.data))

    page.add(
        ft.SegmentedButton(
            on_change=handle_change,
            selected_icon=ft.Icon(ft.icons.CLOUD, size=20),
            selected={"1", "3"},
            allow_multiple_selection=True,
            segments=[
                ft.Segment(
                    value="0",
                    label=ft.Text("0"),
                    icon=ft.Icon(ft.icons.CALENDAR_TODAY),
                ),
                ft.Segment(
                    value="1",
                    label=ft.Text("1"),
                    icon=ft.Icon(ft.icons.CALENDAR_VIEW_DAY),
                ),
                ft.Segment(
                    value="2",
                    label=ft.Text("2"),
                    icon=ft.Icon(ft.icons.CALENDAR_VIEW_WEEK),
                ),
                ft.Segment(
                    value="3",
                    label=ft.Text("3"),
                    icon=ft.Icon(ft.icons.CALENDAR_VIEW_MONTH),
                )
            ]
        )
    )


ft.app(target=main)
```
