### PR TITLE
Add console as a build argument

### DIFF
--- a/sdk/python/packages/flet/src/flet/cli/commands/pack.py
+++ b/sdk/python/packages/flet/src/flet/cli/commands/pack.py
@@ -104,7 +104,7 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "--debug-console",
-            dest="debug-console",
+            dest="debug_console",
             help="Show python console (Ensure correct DEBUG level)",
         )
 
@@ -123,7 +123,6 @@ class Command(BaseCommand):
             import PyInstaller.__main__
             from flet.__pyinstaller.utils import copy_flet_bin
 
-            pyi_args = [options.script, "--noconfirm"]
             pyi_args = [options.script, "--noconfirm"]
             if not options.debug_console:
                 pyi_args.extend(["--noconsole"])

--- a/sdk/python/packages/flet/src/flet/cli/commands/pack.py
+++ b/sdk/python/packages/flet/src/flet/cli/commands/pack.py
@@ -102,6 +102,11 @@ class Command(BaseCommand):
             dest="bundle_id",
             help="bundle identifier (macOS)",
         )
+        parser.add_argument(
+            "--debug-console",
+            dest="debug-console",
+            help="Show python console (Ensure correct DEBUG level)",
+        )
 
     def handle(self, options: argparse.Namespace) -> None:
         # delete "build" directory
@@ -118,7 +123,10 @@ class Command(BaseCommand):
             import PyInstaller.__main__
             from flet.__pyinstaller.utils import copy_flet_bin
 
-            pyi_args = [options.script, "--noconsole", "--noconfirm"]
+            pyi_args = [options.script, "--noconfirm"]
+            pyi_args = [options.script, "--noconfirm"]
+            if not options.debug_console:
+                pyi_args.extend(["--noconsole"])
             if options.icon:
                 pyi_args.extend(["--icon", options.icon])
             if options.name:


### PR DESCRIPTION
PR to resolve: Allow --console to be an argument when packaging #2021 

Adds --debug-console as a build argument to allow the console to be displayed for a packaged flet app

Default is console disabled