### PR TITLE
Refactor code, add Enum deprecation utils

### DIFF
--- a/sdk/python/packages/flet-core/src/flet_core/bottom_sheet.py
+++ b/sdk/python/packages/flet-core/src/flet_core/bottom_sheet.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 from flet_core.control import Control, OptionalNumber
 from flet_core.ref import Ref

--- a/sdk/python/packages/flet-core/src/flet_core/canvas/shadow.py
+++ b/sdk/python/packages/flet-core/src/flet_core/canvas/shadow.py
@@ -1,4 +1,3 @@
-import dataclasses
 from typing import Any, List, Optional
 
 from flet_core.canvas.path import Path

--- a/sdk/python/packages/flet-core/src/flet_core/canvas/text.py
+++ b/sdk/python/packages/flet-core/src/flet_core/canvas/text.py
@@ -4,7 +4,6 @@ from flet_core.alignment import Alignment
 from flet_core.canvas.shape import Shape
 from flet_core.control import OptionalNumber
 from flet_core.inline_span import InlineSpan
-from flet_core.text_span import TextSpan
 from flet_core.text_style import TextStyle
 from flet_core.types import TextAlign
 

--- a/sdk/python/packages/flet-core/src/flet_core/circle_avatar.py
+++ b/sdk/python/packages/flet-core/src/flet_core/circle_avatar.py
@@ -70,7 +70,6 @@ class CircleAvatar(ConstrainedControl):
 
     def __init__(
         self,
-        icon: Optional[str] = None,
         key: Optional[str] = None,
         ref: Optional[Ref] = None,
         width: OptionalNumber = None,
@@ -174,15 +173,6 @@ class CircleAvatar(ConstrainedControl):
     @background_image_url.setter
     def background_image_url(self, value):
         self._set_attr("backgroundImageUrl", value)
-
-    # icon
-    @property
-    def icon(self):
-        return self._get_attr("icon")
-
-    @icon.setter
-    def icon(self, value):
-        self._set_attr("icon", value)
 
     # radius
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/clipboard.py
+++ b/sdk/python/packages/flet-core/src/flet_core/clipboard.py
@@ -1,5 +1,4 @@
 import dataclasses
-import time
 from typing import Any, Optional
 
 from flet_core.control import Control

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_checkbox.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_checkbox.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 from flet_core.constrained_control import ConstrainedControl
 from flet_core.control import OptionalNumber

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_radio.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_radio.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 from flet_core.constrained_control import ConstrainedControl
 from flet_core.control import OptionalNumber
@@ -7,7 +7,6 @@ from flet_core.types import (
     AnimationValue,
     LabelPosition,
     LabelPositionString,
-    MaterialState,
     OffsetValue,
     ResponsiveNumber,
     RotateValue,

--- a/sdk/python/packages/flet-core/src/flet_core/date_picker.py
+++ b/sdk/python/packages/flet-core/src/flet_core/date_picker.py
@@ -5,7 +5,7 @@ from typing import Any, Optional, Union
 from flet_core.control import Control, OptionalNumber
 from flet_core.ref import Ref
 from flet_core.text_style import TextStyle
-from flet_core.textfield import KeyboardType, KeyboardTypeString
+from flet_core.textfield import KeyboardType
 from flet_core.types import ResponsiveNumber
 
 try:

--- a/sdk/python/packages/flet-core/src/flet_core/haptic_feedback.py
+++ b/sdk/python/packages/flet-core/src/flet_core/haptic_feedback.py
@@ -1,5 +1,3 @@
-import dataclasses
-import time
 from typing import Any, Optional
 
 from flet_core.control import Control

--- a/sdk/python/packages/flet-core/src/flet_core/list_view.py
+++ b/sdk/python/packages/flet-core/src/flet_core/list_view.py
@@ -11,7 +11,6 @@ from flet_core.types import (
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
-    ScrollMode,
 )
 
 

--- a/sdk/python/packages/flet-core/src/flet_core/local_connection.py
+++ b/sdk/python/packages/flet-core/src/flet_core/local_connection.py
@@ -1,5 +1,4 @@
 import logging
-from typing import List
 
 import flet_core
 from flet_core.connection import Connection

--- a/sdk/python/packages/flet-core/src/flet_core/locks.py
+++ b/sdk/python/packages/flet-core/src/flet_core/locks.py
@@ -1,4 +1,4 @@
-class NopeLock():
+class NopeLock:
     def __enter__(self):
         pass
 
@@ -6,7 +6,7 @@ class NopeLock():
         pass
 
 
-class AsyncNopeLock():
+class AsyncNopeLock:
     async def __aenter__(self):
         pass
 

--- a/sdk/python/packages/flet-core/src/flet_core/navigation_drawer.py
+++ b/sdk/python/packages/flet-core/src/flet_core/navigation_drawer.py
@@ -1,14 +1,9 @@
-from enum import Enum
-from typing import Any, List, Optional, Union
-
-from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
-from flet_core.ref import Ref
-from flet_core.types import (
-    PaddingValue,
-)
+from typing import Any, List, Optional
 
 from flet_core.buttons import OutlinedBorder
+from flet_core.control import Control, OptionalNumber
+from flet_core.ref import Ref
+from flet_core.types import PaddingValue
 
 
 class NavigationDrawerDestination(Control):

--- a/sdk/python/packages/flet-core/src/flet_core/row.py
+++ b/sdk/python/packages/flet-core/src/flet_core/row.py
@@ -15,7 +15,6 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     ScrollMode,
-    ScrollModeString,
 )
 
 

--- a/sdk/python/packages/flet-core/src/flet_core/scrollable_control.py
+++ b/sdk/python/packages/flet-core/src/flet_core/scrollable_control.py
@@ -137,5 +137,4 @@ class OnScrollEvent(ControlEvent):
         self.velocity: Optional[float] = v
 
     def __str__(self):
-        attrs = {}
         return f"{self.event_type}: pixels={self.pixels}, min_scroll_extent={self.min_scroll_extent}, max_scroll_extent={self.max_scroll_extent}, viewport_dimension={self.viewport_dimension}, scroll_delta={self.scroll_delta}, direction={self.direction}, overscroll={self.overscroll}, velocity={self.velocity}"

--- a/sdk/python/packages/flet-core/src/flet_core/segmented_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/segmented_button.py
@@ -1,5 +1,4 @@
 import json
-import time
 from typing import Any, List, Optional, Set, Union
 
 from flet_core.buttons import ButtonStyle

--- a/sdk/python/packages/flet-core/src/flet_core/semantics.py
+++ b/sdk/python/packages/flet-core/src/flet_core/semantics.py
@@ -1,6 +1,6 @@
 from typing import Any, Optional
 
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 
 

--- a/sdk/python/packages/flet-core/src/flet_core/tabs.py
+++ b/sdk/python/packages/flet-core/src/flet_core/tabs.py
@@ -1,7 +1,6 @@
 from typing import Any, Dict, List, Optional, Union
 
 from flet_core.border import BorderSide
-from flet_core.border_radius import BorderRadius
 from flet_core.constrained_control import ConstrainedControl
 from flet_core.control import Control, OptionalNumber
 from flet_core.ref import Ref

--- a/sdk/python/packages/flet-core/src/flet_core/theme.py
+++ b/sdk/python/packages/flet-core/src/flet_core/theme.py
@@ -1,13 +1,13 @@
 import dataclasses
 from dataclasses import field
-from enum import Enum
+from enum import Enum, EnumMeta
 from typing import Dict, Optional, Union
+from warnings import warn
 
 from flet_core.border import BorderSide
 from flet_core.border_radius import BorderRadius
 from flet_core.text_style import TextStyle
 from flet_core.types import MaterialState, PaddingValue
-from flet_core.utils import DeprecatedEnumMeta
 
 try:
     from typing import Literal
@@ -19,7 +19,18 @@ VisualDensityString = Literal[
 ]
 
 
-class ThemeVisualDensity(Enum, metaclass=DeprecatedEnumMeta):
+class ThemeVisualDensityDeprecated(EnumMeta):
+    def __getattribute__(self, item):
+        if item == "ADAPTIVEPLATFORMDENSITY":
+            warn(
+                "ADAPTIVEPLATFORMDENSITY is deprecated, use ADAPTIVE_PLATFORM_DENSITY instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        return EnumMeta.__getattribute__(self, item)
+
+
+class ThemeVisualDensity(Enum, metaclass=ThemeVisualDensityDeprecated):
     NONE = None
     STANDARD = "standard"
     COMPACT = "compact"

--- a/sdk/python/packages/flet-core/src/flet_core/theme.py
+++ b/sdk/python/packages/flet-core/src/flet_core/theme.py
@@ -6,7 +6,8 @@ from typing import Dict, Optional, Union
 from flet_core.border import BorderSide
 from flet_core.border_radius import BorderRadius
 from flet_core.text_style import TextStyle
-from flet_core.types import MaterialState, PaddingValue, ThemeMode
+from flet_core.types import MaterialState, PaddingValue
+from flet_core.utils import DeprecatedEnumMeta
 
 try:
     from typing import Literal
@@ -18,12 +19,13 @@ VisualDensityString = Literal[
 ]
 
 
-class ThemeVisualDensity(Enum):
+class ThemeVisualDensity(Enum, metaclass=DeprecatedEnumMeta):
     NONE = None
     STANDARD = "standard"
     COMPACT = "compact"
     COMFORTABLE = "comfortable"
     ADAPTIVEPLATFORMDENSITY = "adaptivePlatformDensity"
+    ADAPTIVE_PLATFORM_DENSITY = "adaptivePlatformDensity"
 
 
 PageTransitionString = Literal["fadeUpwards", "openUpwards", "zoom", "cupertino"]

--- a/sdk/python/packages/flet-core/src/flet_core/time_picker.py
+++ b/sdk/python/packages/flet-core/src/flet_core/time_picker.py
@@ -141,7 +141,7 @@ class TimePicker(Control):
 
     @value.setter
     def value(self, value: Optional[Union[time, str]]):
-        if isinstance(value, (time)):
+        if isinstance(value, time):
             value = value.strftime("%H:%M")
         self._set_attr("value", value)
 

--- a/sdk/python/packages/flet-core/src/flet_core/tooltip.py
+++ b/sdk/python/packages/flet-core/src/flet_core/tooltip.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 from flet_core.border import Border
 from flet_core.control import Control, OptionalNumber

--- a/sdk/python/packages/flet-core/src/flet_core/utils.py
+++ b/sdk/python/packages/flet-core/src/flet_core/utils.py
@@ -6,8 +6,6 @@ import re
 import string
 import sys
 import unicodedata
-from enum import EnumMeta
-from warnings import warn
 
 
 def random_string(length):
@@ -161,15 +159,3 @@ class Vector(complex):
         radians = math.radians(value)
         magnitude = abs(self)
         return type(self).polar(radians, magnitude)
-
-
-class DeprecatedEnumMeta(EnumMeta):
-
-    def __getattribute__(self, item):
-        if item == 'ADAPTIVEPLATFORMDENSITY':
-            warn(
-                'ADAPTIVEPLATFORMDENSITY is deprecated, use ADAPTIVE_PLATFORM_DENSITY instead.',
-                DeprecationWarning,
-                stacklevel=2
-            )
-        return EnumMeta.__getattribute__(self, item)

--- a/sdk/python/packages/flet-core/src/flet_core/utils.py
+++ b/sdk/python/packages/flet-core/src/flet_core/utils.py
@@ -6,10 +6,12 @@ import re
 import string
 import sys
 import unicodedata
+from enum import EnumMeta
+from warnings import warn
 
 
 def random_string(length):
-    return "".join(random.choice(string.ascii_letters) for i in range(length))
+    return "".join(random.choice(string.ascii_letters) for _ in range(length))
 
 
 def is_asyncio():
@@ -159,3 +161,15 @@ class Vector(complex):
         radians = math.radians(value)
         magnitude = abs(self)
         return type(self).polar(radians, magnitude)
+
+
+class DeprecatedEnumMeta(EnumMeta):
+
+    def __getattribute__(self, item):
+        if item == 'ADAPTIVEPLATFORMDENSITY':
+            warn(
+                'ADAPTIVEPLATFORMDENSITY is deprecated, use ADAPTIVE_PLATFORM_DENSITY instead.',
+                DeprecationWarning,
+                stacklevel=2
+            )
+        return EnumMeta.__getattribute__(self, item)

--- a/sdk/python/packages/flet-core/src/flet_core/webview.py
+++ b/sdk/python/packages/flet-core/src/flet_core/webview.py
@@ -1,20 +1,14 @@
-from enum import Enum
-from typing import Any, List, Optional, Union
+from typing import Any, Optional, Union
 
 from flet_core.constrained_control import ConstrainedControl
 from flet_core.control import OptionalNumber
 from flet_core.ref import Ref
-from flet_core.text_span import TextSpan
 from flet_core.types import (
     AnimationValue,
-    FontWeight,
-    FontWeightString,
     OffsetValue,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
-    TextAlign,
-    TextAlignString,
 )
 
 try:

--- a/sdk/python/packages/flet-fastapi/src/flet_fastapi/flet_app.py
+++ b/sdk/python/packages/flet-fastapi/src/flet_fastapi/flet_app.py
@@ -7,8 +7,9 @@ import traceback
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
+from fastapi import WebSocket
+
 import flet_fastapi
-from fastapi import WebSocket, WebSocketDisconnect
 from flet_core.event import Event
 from flet_core.local_connection import LocalConnection
 from flet_core.page import Page

--- a/sdk/python/packages/flet-fastapi/src/flet_fastapi/flet_fastapi.py
+++ b/sdk/python/packages/flet-fastapi/src/flet_fastapi/flet_fastapi.py
@@ -2,8 +2,6 @@ from contextlib import asynccontextmanager
 from typing import Any, Callable, Coroutine, Dict, List, Optional, Sequence, Type, Union
 
 import fastapi
-import flet_fastapi
-from fastapi.applications import AppType
 from fastapi.datastructures import Default
 from fastapi.params import Depends
 from fastapi.utils import generate_unique_id
@@ -11,7 +9,8 @@ from starlette.middleware import Middleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 from starlette.routing import BaseRoute
-from starlette.types import Lifespan
+
+import flet_fastapi
 
 
 class FastAPI(fastapi.FastAPI):

--- a/sdk/python/packages/flet-fastapi/src/flet_fastapi/flet_oauth.py
+++ b/sdk/python/packages/flet-fastapi/src/flet_fastapi/flet_oauth.py
@@ -1,7 +1,7 @@
 from fastapi import HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
+
 from flet_fastapi.flet_app_manager import app_manager
-from flet_fastapi.oauth_state import OAuthState
 
 
 class FletOAuth:

--- a/sdk/python/packages/flet-fastapi/src/flet_fastapi/flet_static_files.py
+++ b/sdk/python/packages/flet-fastapi/src/flet_fastapi/flet_static_files.py
@@ -5,8 +5,10 @@ import tempfile
 from pathlib import Path
 from typing import Optional, Tuple
 
-import flet_fastapi
 from fastapi.staticfiles import StaticFiles
+from starlette.types import Receive, Scope, Send
+
+import flet_fastapi
 from flet_core.types import WebRenderer
 from flet_fastapi.flet_app_manager import app_manager
 from flet_fastapi.once import Once
@@ -15,7 +17,6 @@ from flet_runtime.utils import (
     patch_index_html,
     patch_manifest_json,
 )
-from starlette.types import Receive, Scope, Send
 
 logger = logging.getLogger(flet_fastapi.__name__)
 
@@ -82,7 +83,7 @@ class FletStaticFiles(StaticFiles):
         if stat_result is None:
             return super().lookup_path(self.index)
 
-        return (full_path, stat_result)
+        return full_path, stat_result
 
     async def __config(self, root_path: str):
         if self.__proxy_path:

--- a/sdk/python/packages/flet-runtime/src/flet_runtime/app.py
+++ b/sdk/python/packages/flet-runtime/src/flet_runtime/app.py
@@ -15,14 +15,7 @@ from typing import Optional
 import flet_runtime
 from flet_core.event import Event
 from flet_core.page import Page
-from flet_core.types import (
-    FLET_APP,
-    FLET_APP_HIDDEN,
-    FLET_APP_WEB,
-    WEB_BROWSER,
-    AppView,
-    WebRenderer,
-)
+from flet_core.types import AppView, WebRenderer
 from flet_core.utils import is_coroutine, random_string
 from flet_runtime.async_local_socket_connection import AsyncLocalSocketConnection
 from flet_runtime.sync_local_socket_connection import SyncLocalSocketConnection

--- a/sdk/python/packages/flet-runtime/src/flet_runtime/auth/authorization.py
+++ b/sdk/python/packages/flet-runtime/src/flet_runtime/auth/authorization.py
@@ -6,14 +6,15 @@ import time
 from typing import List, Optional, Tuple
 
 import httpx
+from oauthlib.oauth2 import WebApplicationClient
+from oauthlib.oauth2.rfc6749.tokens import OAuth2Token
+
 from flet.version import version
 from flet_core.locks import AsyncNopeLock, NopeLock
 from flet_core.utils import is_asyncio
 from flet_runtime.auth.oauth_provider import OAuthProvider
 from flet_runtime.auth.oauth_token import OAuthToken
 from flet_runtime.auth.user import User
-from oauthlib.oauth2 import WebApplicationClient
-from oauthlib.oauth2.rfc6749.tokens import OAuth2Token
 
 
 class Authorization:
@@ -77,7 +78,7 @@ class Authorization:
             scope=self.scope,
             state=self.state,
         )
-        return (authorization_url, self.state)
+        return authorization_url, self.state
 
     def request_token(self, code: str):
         req = self.__get_request_token_request(code)

--- a/sdk/python/packages/flet-runtime/src/flet_runtime/uploads.py
+++ b/sdk/python/packages/flet-runtime/src/flet_runtime/uploads.py
@@ -2,7 +2,6 @@ import hashlib
 import hmac
 import logging
 import os
-import sys
 import urllib.parse
 from datetime import datetime, timedelta
 from typing import Optional

--- a/sdk/python/packages/flet-runtime/src/flet_runtime/utils.py
+++ b/sdk/python/packages/flet-runtime/src/flet_runtime/utils.py
@@ -158,7 +158,7 @@ def get_local_ip():
             s.connect(("8.8.8.8", 80))
             local_ip = s.getsockname()[0]
         return local_ip
-    except Exception as e:
+    except Exception:
         hostname = socket.gethostname()
         return socket.gethostbyname(hostname)
 

--- a/sdk/python/packages/flet/build-wheels.py
+++ b/sdk/python/packages/flet/build-wheels.py
@@ -155,7 +155,7 @@ def rehash(path, blocksize=1 << 20):
             h.update(block)
     digest = "sha256=" + urlsafe_b64encode(h.digest()).decode("latin1").rstrip("=")
     # unicode/str python2 issues
-    return (digest, str(length))  # type: ignore
+    return digest, str(length)  # type: ignore
 
 
 def rehash_record_lines(root_dir):

--- a/sdk/python/packages/flet/build-wheels.py
+++ b/sdk/python/packages/flet/build-wheels.py
@@ -7,7 +7,6 @@ import pathlib
 import shutil
 import stat
 import sys
-import tarfile
 import urllib.request
 import zipfile
 from base64 import urlsafe_b64encode

--- a/sdk/python/packages/flet/src/flet/cli/commands/publish.py
+++ b/sdk/python/packages/flet/src/flet/cli/commands/publish.py
@@ -1,5 +1,4 @@
 import argparse
-import json
 import os
 import re
 import shutil

--- a/sdk/python/packages/flet/src/flet/cli/commands/run.py
+++ b/sdk/python/packages/flet/src/flet/cli/commands/run.py
@@ -2,7 +2,6 @@ import argparse
 import os
 import platform
 import signal
-import socket
 import subprocess
 import sys
 import tempfile
@@ -12,6 +11,9 @@ from pathlib import Path
 from urllib.parse import quote, urlparse, urlunparse
 
 import qrcode
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers import Observer
+
 from flet.cli.commands.base import BaseCommand
 from flet_core.utils import random_string
 from flet_runtime.app import close_flet_view, open_flet_view
@@ -21,8 +23,6 @@ from flet_runtime.utils import (
     is_windows,
     open_in_browser,
 )
-from watchdog.events import FileSystemEventHandler
-from watchdog.observers import Observer
 
 
 class Command(BaseCommand):


### PR DESCRIPTION
`ThemeVisualDensity.ADAPTIVEPLATFORMDENSITY` is now deprecated, and `ThemeVisualDensity.ADAPTIVE_PLATFORM_DENSITY` should be used instead.
The deprecation class is in the `theme.py` file.
