### PR TITLE
Determine in which direction the `Dismissible` was dismissed 

### DIFF
--- a/package/lib/src/controls/dismissible.dart
+++ b/package/lib/src/controls/dismissible.dart
@@ -59,7 +59,7 @@ class DismissibleControl extends StatelessWidget {
                 : Container(color: Colors.transparent),
             onDismissed: (DismissDirection d) {
               server.sendPageEvent(
-                  eventTarget: control.id, eventName: "dismiss", eventData: "");
+                  eventTarget: control.id, eventName: "dismiss", eventData: d.name);
             },
             onResize: () {
               server.sendPageEvent(

--- a/sdk/python/packages/flet-core/src/flet_core/__init__.py
+++ b/sdk/python/packages/flet-core/src/flet_core/__init__.py
@@ -21,9 +21,6 @@ from flet_core.app_bar import AppBar
 from flet_core.audio import Audio
 from flet_core.badge import Badge
 from flet_core.banner import Banner
-from flet_core.menu_bar import MenuBar, MenuStyle
-from flet_core.submenu_button import SubmenuButton
-from flet_core.menu_item_button import MenuItemButton
 from flet_core.blur import Blur, BlurTileMode
 from flet_core.border import Border, BorderSide
 from flet_core.border_radius import BorderRadius
@@ -79,7 +76,7 @@ from flet_core.datatable import (
     DataTable,
 )
 from flet_core.date_picker import DatePicker, DatePickerEntryMode, DatePickerMode
-from flet_core.dismissible import Dismissible
+from flet_core.dismissible import Dismissible, DismissibleDismissEvent
 from flet_core.divider import Divider
 from flet_core.drag_target import DragTarget, DragTargetAcceptEvent
 from flet_core.draggable import Draggable
@@ -130,6 +127,8 @@ from flet_core.list_tile import ListTile
 from flet_core.list_view import ListView
 from flet_core.margin import Margin
 from flet_core.markdown import Markdown, MarkdownExtensionSet
+from flet_core.menu_bar import MenuBar, MenuStyle
+from flet_core.menu_item_button import MenuItemButton
 from flet_core.navigation_bar import (
     NavigationBar,
     NavigationBarLabelBehavior,
@@ -181,6 +180,7 @@ from flet_core.shake_detector import ShakeDetector
 from flet_core.slider import Slider
 from flet_core.snack_bar import DismissDirection, SnackBar, SnackBarBehavior
 from flet_core.stack import Stack
+from flet_core.submenu_button import SubmenuButton
 from flet_core.switch import Switch
 from flet_core.tabs import Tab, Tabs
 from flet_core.template_route import TemplateRoute

--- a/sdk/python/packages/flet-core/src/flet_core/dismissible.py
+++ b/sdk/python/packages/flet-core/src/flet_core/dismissible.py
@@ -2,6 +2,8 @@ from typing import Any, Optional, Dict, Union
 
 from flet_core.constrained_control import ConstrainedControl
 from flet_core.control import Control, OptionalNumber
+from flet_core.control_event import ControlEvent
+from flet_core.event_handler import EventHandler
 from flet_core.ref import Ref
 from flet_core.snack_bar import DismissDirection
 from flet_core.types import (
@@ -99,6 +101,9 @@ class Dismissible(ConstrainedControl):
             disabled=disabled,
             data=data,
         )
+
+        self.__on_dismiss = EventHandler(lambda e: DismissibleDismissEvent(e.data))
+        self._add_event_handler("dismiss", self.__on_dismiss.get_handler())
 
         self.content = content
         self.background = background
@@ -217,7 +222,8 @@ class Dismissible(ConstrainedControl):
 
     @on_dismiss.setter
     def on_dismiss(self, handler):
-        self._add_event_handler("dismiss", handler)
+        self.__on_dismiss.subscribe(handler)
+        self._set_attr("dismiss", True if handler is not None else None)
 
     # on_update
     @property
@@ -236,3 +242,8 @@ class Dismissible(ConstrainedControl):
     @on_resize.setter
     def on_resize(self, handler):
         self._add_event_handler("resize", handler)
+
+
+class DismissibleDismissEvent(ControlEvent):
+    def __init__(self, d: str) -> None:
+        self.direction: DismissDirection = DismissDirection(d)

--- a/sdk/python/packages/flet-core/src/flet_core/dismissible.py
+++ b/sdk/python/packages/flet-core/src/flet_core/dismissible.py
@@ -1,9 +1,9 @@
 from typing import Any, Optional, Dict, Union
 
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.snack_bar import DismissDirection
 from flet_core.control import Control, OptionalNumber
 from flet_core.ref import Ref
+from flet_core.snack_bar import DismissDirection
 from flet_core.types import (
     ResponsiveNumber,
     ScaleValue,
@@ -213,7 +213,7 @@ class Dismissible(ConstrainedControl):
     # on_dismiss
     @property
     def on_dismiss(self):
-        return self._get_event_handler("action")
+        return self._get_event_handler("dismiss")
 
     @on_dismiss.setter
     def on_dismiss(self, handler):


### PR DESCRIPTION
Closes #2329 

### Code:
```py
import flet as ft

def main(page):
    page.window_height, page.window_width = 370, 400
    page.theme_mode = ft.ThemeMode.LIGHT

    def handle_dismiss(e):
        lv.controls.remove(e.control)
        print(e.data)
        page.show_snack_bar(
            ft.SnackBar(
                content=ft.Text(f"Tile was dismissed in the {'right' if e.data == ft.DismissDirection.START_TO_END.value else 'left'} direction!"),
                behavior=ft.SnackBarBehavior.FLOATING,
            )
        )
        page.update()

    page.add(
        lv := ft.ListView(
            controls=[
                ft.Dismissible(
                    content=ft.ListTile(title=ft.Text(f"Item {i}")),
                    dismiss_direction=ft.DismissDirection.HORIZONTAL,
                    background=ft.Container(bgcolor=ft.colors.GREEN),
                    secondary_background=ft.Container(bgcolor=ft.colors.RED),
                    on_dismiss=handle_dismiss,
                    dismiss_thresholds={
                        ft.DismissDirection.HORIZONTAL: 0.1,
                        ft.DismissDirection.START_TO_END: 0.1
                    }
                )
                for i in range(5)
            ]
        )
    )


ft.app(target=main)
```