### PR TITLE
Add checks to allow certain build commands according to "build_on" platform.

### DIFF
--- a/sdk/python/packages/flet/src/flet/cli/commands/build.py
+++ b/sdk/python/packages/flet/src/flet/cli/commands/build.py
@@ -279,7 +279,7 @@ class Command(BaseCommand):
         if current_platform not in self.platforms[target_platform]["can_be_run_on"]:
             # make the platform name more user friendly
             if current_platform == "Darwin":
-                current_patform = "macOS"
+                current_platform = "macOS"
 
             print(f"Can't build {target_platform} on {current_platform}")
             sys.exit(1)

--- a/sdk/python/packages/flet/src/flet/cli/commands/build.py
+++ b/sdk/python/packages/flet/src/flet/cli/commands/build.py
@@ -285,6 +285,10 @@ class Command(BaseCommand):
         target_platform = options.target_platform.lower()
         if not self._can_build_target_platform(target_platform):
             current_platform = platform.system()
+            
+            # make the platform name more user friendly
+            if current_platform == 'Darwin':
+                current_patform = 'MacOS'
             print(f'Can\'t build {target_platform} on {current_platform}')
             sys.exit(1)
 

--- a/sdk/python/packages/flet/src/flet/cli/commands/build.py
+++ b/sdk/python/packages/flet/src/flet/cli/commands/build.py
@@ -276,12 +276,12 @@ class Command(BaseCommand):
         target_platform = options.target_platform.lower()
         # platform check
         current_platform = platform.system()
-        if current_platform not in self.platforms[target_platform]['can_be_run_on']:
+        if current_platform not in self.platforms[target_platform]["can_be_run_on"]:
             # make the platform name more user friendly
-            if current_platform == 'Darwin':
-                current_patform = 'MacOS'
-            
-            print(f'Can\'t build {target_platform} on {current_platform}')
+            if current_platform == "Darwin":
+                current_patform = "MacOS"
+
+            print(f"Can't build {target_platform} on {current_platform}")
             sys.exit(1)
 
         self.verbose = options.verbose

--- a/sdk/python/packages/flet/src/flet/cli/commands/build.py
+++ b/sdk/python/packages/flet/src/flet/cli/commands/build.py
@@ -251,6 +251,22 @@ class Command(BaseCommand):
             help="the branch, tag or commit ID to checkout after cloning the repository with Flutter bootstrap template",
         )
 
+    # according to build matrix given at: 
+    # https://flet.dev/docs/guides/python/packaging-app-for-distribution/#build-platform-matrix
+    @staticmethod
+    def _can_build_target_platform(target_platform: str) -> bool:
+        current_platform = platform.system()
+
+        allowed_builds = {
+            'Darwin': ['ipa', 'apk', 'aab', 'macos', 'web'],  # macos
+            'Windows': ['apk', 'aab', 'linux', 'windows', 'web'],
+            'Linux': ['apk', 'aab', 'linux', 'web']
+        }
+        
+        if not target_platform in allowed_builds[current_platform]:
+            return False
+        return True
+
     def handle(self, options: argparse.Namespace) -> None:
         from cookiecutter.main import cookiecutter
 
@@ -267,6 +283,11 @@ class Command(BaseCommand):
             sys.exit(1)
 
         target_platform = options.target_platform.lower()
+        if not self._can_build_target_platform(target_platform):
+            current_platform = platform.system()
+            print(f'Can\'t build {target_platform} on {current_platform}')
+            sys.exit(1)
+
         self.verbose = options.verbose
 
         python_app_path = Path(options.python_app_path).resolve()

--- a/sdk/python/packages/flet/src/flet/cli/commands/build.py
+++ b/sdk/python/packages/flet/src/flet/cli/commands/build.py
@@ -50,7 +50,7 @@ class Command(BaseCommand):
                 "status_text": "app for Linux",
                 "output": "build/linux/{arch}/release/bundle/*",
                 "dist": "linux",
-                "can_be_run_on": ["Windows", "Linux"],
+                "can_be_run_on": ["Linux"],
             },
             "web": {
                 "build_command": "web",
@@ -279,7 +279,7 @@ class Command(BaseCommand):
         if current_platform not in self.platforms[target_platform]["can_be_run_on"]:
             # make the platform name more user friendly
             if current_platform == "Darwin":
-                current_patform = "MacOS"
+                current_patform = "macOS"
 
             print(f"Can't build {target_platform} on {current_platform}")
             sys.exit(1)

--- a/sdk/python/packages/flet/src/flet/cli/commands/build.py
+++ b/sdk/python/packages/flet/src/flet/cli/commands/build.py
@@ -36,42 +36,49 @@ class Command(BaseCommand):
                 "status_text": "Windows app",
                 "output": "build/windows/x64/runner/Release/*",
                 "dist": "windows",
+                "can_be_run_on": ["Windows"],
             },
             "macos": {
                 "build_command": "macos",
                 "status_text": "macOS bundle",
                 "output": "build/macos/Build/Products/Release/{project_name}.app",
                 "dist": "macos",
+                "can_be_run_on": ["Darwin"],
             },
             "linux": {
                 "build_command": "linux",
                 "status_text": "app for Linux",
                 "output": "build/linux/{arch}/release/bundle/*",
                 "dist": "linux",
+                "can_be_run_on": ["Windows", "Linux"],
             },
             "web": {
                 "build_command": "web",
                 "status_text": "web app",
                 "output": "build/web/*",
                 "dist": "web",
+                "can_be_run_on": ["Darwin", "Windows", "Linux"],
             },
             "apk": {
                 "build_command": "apk",
                 "status_text": ".apk for Android",
                 "output": "build/app/outputs/flutter-apk/*",
                 "dist": "apk",
+                "can_be_run_on": ["Darwin", "Windows", "Linux"],
             },
             "aab": {
                 "build_command": "appbundle",
                 "status_text": ".aab bundle for Android",
                 "output": "build/app/outputs/bundle/release/*",
                 "dist": "aab",
+                "can_be_run_on": ["Darwin", "Windows", "Linux"],
             },
             "ipa": {
                 "build_command": "ipa",
                 "status_text": ".ipa bundle for iOS",
                 "output": "build/ios/archive/*",
                 "dist": "ipa",
+                "can_be_run_on": ["Darwin"],
             },
         }
 
@@ -251,22 +258,6 @@ class Command(BaseCommand):
             help="the branch, tag or commit ID to checkout after cloning the repository with Flutter bootstrap template",
         )
 
-    # according to build matrix given at: 
-    # https://flet.dev/docs/guides/python/packaging-app-for-distribution/#build-platform-matrix
-    @staticmethod
-    def _can_build_target_platform(target_platform: str) -> bool:
-        current_platform = platform.system()
-
-        allowed_builds = {
-            'Darwin': ['ipa', 'apk', 'aab', 'macos', 'web'],  # macos
-            'Windows': ['apk', 'aab', 'linux', 'windows', 'web'],
-            'Linux': ['apk', 'aab', 'linux', 'web']
-        }
-        
-        if not target_platform in allowed_builds[current_platform]:
-            return False
-        return True
-
     def handle(self, options: argparse.Namespace) -> None:
         from cookiecutter.main import cookiecutter
 
@@ -283,12 +274,13 @@ class Command(BaseCommand):
             sys.exit(1)
 
         target_platform = options.target_platform.lower()
-        if not self._can_build_target_platform(target_platform):
-            current_platform = platform.system()
-            
+        # platform check
+        current_platform = platform.system()
+        if current_platform not in self.platforms[target_platform]['can_be_run_on']:
             # make the platform name more user friendly
             if current_platform == 'Darwin':
                 current_patform = 'MacOS'
+            
             print(f'Can\'t build {target_platform} on {current_platform}')
             sys.exit(1)
 


### PR DESCRIPTION
Add checks to allow certain build commands according to build on platform according to matrix given at https://flet.dev/docs/guides/python/packaging-app-for-distribution/#build-platform-matrix .

Addresses issue: #2342  .

Edit: Issue number.