### PR TITLE
runtime: check for DISPLAY instead of XDG_CURRENT_DESKTOP to check if linux machine is GUIless or not

### DIFF
--- a/sdk/python/packages/flet-runtime/src/flet_runtime/utils.py
+++ b/sdk/python/packages/flet-runtime/src/flet_runtime/utils.py
@@ -47,7 +47,7 @@ def is_linux_server():
             with open(p, "r") as file:
                 if "microsoft" in file.read():
                     return False  # it's WSL, not a server
-        return os.environ.get("XDG_CURRENT_DESKTOP") is None
+        return os.environ.get("DISPLAY") is None
     return False
 
 


### PR DESCRIPTION
DISPLAY instruct processes which Xorg server to communicate basically, or at least are a obvious sign that there is some kind of X server available.

In environments, such as TMUX sessions, DISPLAY is propagated inside but the same doesn't happen with XDG_CURRENT_DESKTOP so it happens that one launches a session but no windows shows up, even though if one start the frontend process pointing to the socket in the logs and it works just fine.

BTW I am packaging the flutter module to nixpkgs [1] and I was stuck for a few hours on this until I found out about this check. Basically the approach is to use a hardcoded packaged flutter core instead of flet having to download and failing to run because Nix don't use the concept of global libraries like other distros do.

[1] https://github.com/NixOS/nixpkgs/pull/279936/files