### PR TITLE
`FloatingActionButtonLocation` offset

### DIFF
--- a/package/lib/src/controls/floating_action_button.dart
+++ b/package/lib/src/controls/floating_action_button.dart
@@ -6,6 +6,7 @@ import '../utils/borders.dart';
 import '../utils/colors.dart';
 import '../utils/icons.dart';
 import '../utils/launch_url.dart';
+import '../utils/transforms.dart';
 import 'create_control.dart';
 import 'error.dart';
 
@@ -129,9 +130,39 @@ FloatingActionButtonLocation parseFloatingActionButtonLocation(
     FloatingActionButtonLocation.startTop
   ];
 
-  return fabLocations.firstWhere(
-      (l) =>
-          l.toString().split('.').last.toLowerCase() ==
-          control.attrString(propName, "")!.toLowerCase(),
-      orElse: () => defValue);
+  try {
+    // throw Exception("to stop the constant rebuild/blinking uncomment this line");
+    OffsetDetails? fabLocationOffsetDetails = parseOffset(control, propName);
+    if (fabLocationOffsetDetails != null) {
+      return CustomFloatingActionButtonLocation(
+          dx: fabLocationOffsetDetails.x, dy: fabLocationOffsetDetails.y);
+    } else {
+      return defValue;
+    }
+  } catch (e) {
+    return fabLocations.firstWhere(
+        (l) =>
+            l.toString().split('.').last.toLowerCase() ==
+            control.attrString(propName, "")!.toLowerCase(),
+        orElse: () => defValue);
+  }
+}
+
+class CustomFloatingActionButtonLocation extends FloatingActionButtonLocation {
+  final double dx;
+  final double dy;
+
+  CustomFloatingActionButtonLocation({required this.dx, required this.dy});
+
+  @override
+  Offset getOffset(ScaffoldPrelayoutGeometry scaffoldGeometry) {
+    double x = scaffoldGeometry.scaffoldSize.width - dx;
+    double y = scaffoldGeometry.scaffoldSize.height - dy;
+    debugPrint(
+        "CUSTOM_FLOATING_ACTION_BUTTON_LOCATION - x: $x - y: $y - width: ${scaffoldGeometry.scaffoldSize.width} - height: ${scaffoldGeometry.scaffoldSize.height}");
+    return Offset(x, y);
+  }
+
+  @override
+  String toString() => 'CustomFloatingActionButtonLocation';
 }

--- a/package/lib/src/controls/floating_action_button.dart
+++ b/package/lib/src/controls/floating_action_button.dart
@@ -131,7 +131,6 @@ FloatingActionButtonLocation parseFloatingActionButtonLocation(
   ];
 
   try {
-    // throw Exception("to stop the constant rebuild/blinking uncomment this line");
     OffsetDetails? fabLocationOffsetDetails = parseOffset(control, propName);
     if (fabLocationOffsetDetails != null) {
       return CustomFloatingActionButtonLocation(
@@ -156,12 +155,18 @@ class CustomFloatingActionButtonLocation extends FloatingActionButtonLocation {
 
   @override
   Offset getOffset(ScaffoldPrelayoutGeometry scaffoldGeometry) {
-    double x = scaffoldGeometry.scaffoldSize.width - dx;
-    double y = scaffoldGeometry.scaffoldSize.height - dy;
-    debugPrint(
-        "CUSTOM_FLOATING_ACTION_BUTTON_LOCATION - x: $x - y: $y - width: ${scaffoldGeometry.scaffoldSize.width} - height: ${scaffoldGeometry.scaffoldSize.height}");
-    return Offset(x, y);
+    return Offset(scaffoldGeometry.scaffoldSize.width - dx,
+        scaffoldGeometry.scaffoldSize.height - dy);
   }
+
+  @override
+  bool operator ==(Object other) =>
+      other is CustomFloatingActionButtonLocation &&
+      other.dx == dx &&
+      other.dy == dy;
+
+  @override
+  int get hashCode => dx.hashCode + dy.hashCode;
 
   @override
   String toString() => 'CustomFloatingActionButtonLocation';

--- a/sdk/python/packages/flet-core/src/flet_core/page.py
+++ b/sdk/python/packages/flet-core/src/flet_core/page.py
@@ -39,6 +39,7 @@ from flet_core.types import (
     CrossAxisAlignment,
     FloatingActionButtonLocation,
     MainAxisAlignment,
+    OffsetValue,
     PaddingValue,
     PageDesignLanguage,
     PageDesignString,
@@ -1343,12 +1344,14 @@ class Page(Control):
 
     # floating_action_button_location
     @property
-    def floating_action_button_location(self) -> Optional[FloatingActionButtonLocation]:
+    def floating_action_button_location(
+        self,
+    ) -> Union[FloatingActionButtonLocation, OffsetValue]:
         return self.__default_view.floating_action_button_location
 
     @floating_action_button_location.setter
     def floating_action_button_location(
-        self, value: Optional[FloatingActionButtonLocation]
+        self, value: Union[FloatingActionButtonLocation, OffsetValue]
     ):
         self.__default_view.floating_action_button_location = value
 

--- a/sdk/python/packages/flet-core/src/flet_core/view.py
+++ b/sdk/python/packages/flet-core/src/flet_core/view.py
@@ -18,6 +18,7 @@ from flet_core.types import (
     MainAxisAlignmentString,
     PaddingValue,
     ScrollMode,
+    OffsetValue,
 )
 
 
@@ -39,7 +40,9 @@ class View(ScrollableControl):
         appbar: Union[AppBar, CupertinoAppBar, None] = None,
         bottom_appbar: Optional[BottomAppBar] = None,
         floating_action_button: Optional[FloatingActionButton] = None,
-        floating_action_button_location: Optional[FloatingActionButtonLocation] = None,
+        floating_action_button_location: Union[
+            FloatingActionButtonLocation, OffsetValue
+        ] = None,
         navigation_bar: Union[NavigationBar, CupertinoNavigationBar, None] = None,
         drawer: Optional[NavigationDrawer] = None,
         end_drawer: Optional[NavigationDrawer] = None,
@@ -91,6 +94,10 @@ class View(ScrollableControl):
     def _before_build_command(self):
         super()._before_build_command()
         self._set_attr_json("padding", self.__padding)
+        if not isinstance(self.__floating_action_button_location, (FloatingActionButtonLocation, str)):
+            self._set_attr_json(
+                "floatingActionButtonLocation", self.__floating_action_button_location
+            )
 
     def _get_children(self):
         children = []
@@ -158,11 +165,15 @@ class View(ScrollableControl):
 
     # floating_action_button_location
     @property
-    def floating_action_button_location(self) -> FloatingActionButtonLocation:
+    def floating_action_button_location(
+        self,
+    ) -> Union[FloatingActionButtonLocation, OffsetValue]:
         return self.__floating_action_button_location
 
     @floating_action_button_location.setter
-    def floating_action_button_location(self, value: FloatingActionButtonLocation):
+    def floating_action_button_location(
+        self, value: Union[FloatingActionButtonLocation, OffsetValue]
+    ):
         self.__floating_action_button_location = value
         self._set_attr(
             "floatingActionButtonLocation",


### PR DESCRIPTION
Issue: When using the offset as fab_location, the FAB is always rebuilt (kind of blinks).

Test Code: 
```py

import flet as ft

def main(page: ft.Page):
    page.floating_action_button = ft.FloatingActionButton(
        content=ft.Row(
            [ft.Icon(ft.icons.ADD), ft.Text("Add")], alignment="center", spacing=5
        ),
        bgcolor=ft.colors.AMBER_300,
        shape=ft.RoundedRectangleBorder(radius=5),
        width=100,
        mini=True,
    )

    page.floating_action_button_location = (150, 100)

ft.app(target=main)
```
