### PR TITLE
`CupertinoTextfield` control

### DIFF
--- a/package/lib/src/controls/create_control.dart
+++ b/package/lib/src/controls/create_control.dart
@@ -36,6 +36,7 @@ import 'cupertino_navigation_bar.dart';
 import 'cupertino_radio.dart';
 import 'cupertino_slider.dart';
 import 'cupertino_switch.dart';
+import 'cupertino_textfield.dart';
 import 'datatable.dart';
 import 'date_picker.dart';
 import 'dismissible.dart';
@@ -514,6 +515,13 @@ Widget createWidget(Key? key, ControlViewModel controlView, Control? parent,
       );
     case "textfield":
       return TextFieldControl(
+          key: key,
+          parent: parent,
+          control: controlView.control,
+          children: controlView.children,
+          parentDisabled: parentDisabled);
+    case "cupertinotextfield":
+      return CupertinoTextFieldControl(
           key: key,
           parent: parent,
           control: controlView.control,

--- a/package/lib/src/controls/cupertino_textfield.dart
+++ b/package/lib/src/controls/cupertino_textfield.dart
@@ -1,0 +1,316 @@
+import 'package:flet/src/controls/textfield.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_redux/flutter_redux.dart';
+
+import '../actions.dart';
+import '../flet_app_services.dart';
+import '../models/app_state.dart';
+import '../models/control.dart';
+import '../protocol/update_control_props_payload.dart';
+import '../utils/borders.dart';
+import '../utils/colors.dart';
+import '../utils/text.dart';
+import '../utils/textfield.dart';
+import 'create_control.dart';
+import 'form_field.dart';
+
+class CupertinoTextFieldControl extends StatefulWidget {
+  final Control? parent;
+  final Control control;
+  final List<Control> children;
+  final bool parentDisabled;
+
+  const CupertinoTextFieldControl(
+      {super.key,
+      this.parent,
+      required this.control,
+      required this.children,
+      required this.parentDisabled});
+
+  @override
+  State<CupertinoTextFieldControl> createState() => _CupertinoTextFieldControlState();
+}
+
+class _CupertinoTextFieldControlState extends State<CupertinoTextFieldControl> {
+  String _value = "";
+  bool _revealPassword = false;
+  bool _focused = false;
+  late TextEditingController _controller;
+  late final FocusNode _focusNode;
+  late final FocusNode _shiftEnterfocusNode;
+  String? _lastFocusValue;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController();
+    _shiftEnterfocusNode = FocusNode(
+      onKey: (FocusNode node, RawKeyEvent evt) {
+        if (!evt.isShiftPressed && evt.logicalKey.keyLabel == 'Enter') {
+          if (evt is RawKeyDownEvent) {
+            FletAppServices.of(context).server.sendPageEvent(
+                eventTarget: widget.control.id,
+                eventName: "submit",
+                eventData: "");
+          }
+          return KeyEventResult.handled;
+        } else {
+          return KeyEventResult.ignored;
+        }
+      },
+    );
+    _shiftEnterfocusNode.addListener(_onShiftEnterFocusChange);
+    _focusNode = FocusNode();
+    _focusNode.addListener(_onFocusChange);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _shiftEnterfocusNode.removeListener(_onShiftEnterFocusChange);
+    _shiftEnterfocusNode.dispose();
+    _focusNode.removeListener(_onFocusChange);
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  void _onShiftEnterFocusChange() {
+    setState(() {
+      _focused = _shiftEnterfocusNode.hasFocus;
+    });
+    FletAppServices.of(context).server.sendPageEvent(
+        eventTarget: widget.control.id,
+        eventName: _shiftEnterfocusNode.hasFocus ? "focus" : "blur",
+        eventData: "");
+  }
+
+  void _onFocusChange() {
+    setState(() {
+      _focused = _focusNode.hasFocus;
+    });
+    FletAppServices.of(context).server.sendPageEvent(
+        eventTarget: widget.control.id,
+        eventName: _focusNode.hasFocus ? "focus" : "blur",
+        eventData: "");
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    debugPrint("CupertinoTextField build: ${widget.control.id}");
+
+    bool autofocus = widget.control.attrBool("autofocus", false)!;
+    bool disabled = widget.control.isDisabled || widget.parentDisabled;
+
+    return StoreConnector<AppState, Function>(
+        distinct: true,
+        converter: (store) => store.dispatch,
+        builder: (context, dispatch) {
+          debugPrint("CupertinoTextField StoreConnector build: ${widget.control.id}");
+
+          String value = widget.control.attrs["value"] ?? "";
+          if (_value != value) {
+            _value = value;
+            _controller.text = value;
+          }
+
+          var prefixControls =
+              widget.children.where((c) => c.name == "prefix" && c.isVisible);
+          var suffixControls =
+              widget.children.where((c) => c.name == "suffix" && c.isVisible);
+
+          bool shiftEnter = widget.control.attrBool("shiftEnter", false)!;
+          bool multiline =
+              widget.control.attrBool("multiline", false)! || shiftEnter;
+          int minLines = widget.control.attrInt("minLines", 1)!;
+          int? maxLines =
+              widget.control.attrInt("maxLines", multiline ? null : 1);
+
+          bool readOnly = widget.control.attrBool("readOnly", false)!;
+          bool password = widget.control.attrBool("password", false)!;
+          bool canRevealPassword =
+              widget.control.attrBool("canRevealPassword", false)!;
+          bool onChange = widget.control.attrBool("onChange", false)!;
+
+          var cursorColor = HexColor.fromString(
+              Theme.of(context), widget.control.attrString("cursorColor", "")!);
+          var selectionColor = HexColor.fromString(Theme.of(context),
+              widget.control.attrString("selectionColor", "")!);
+
+          int? maxLength = widget.control.attrInt("maxLength");
+
+          var textSize = widget.control.attrDouble("textSize");
+
+          var color = HexColor.fromString(
+              Theme.of(context), widget.control.attrString("color", "")!);
+          var focusedColor = HexColor.fromString(Theme.of(context),
+              widget.control.attrString("focusedColor", "")!);
+
+          TextStyle? textStyle =
+              parseTextStyle(Theme.of(context), widget.control, "textStyle");
+          if (textSize != null || color != null || focusedColor != null) {
+            textStyle = (textStyle ?? const TextStyle()).copyWith(
+                fontSize: textSize,
+                color: _focused ? focusedColor ?? color : color);
+          }
+
+          TextCapitalization? textCapitalization = TextCapitalization.values
+              .firstWhere(
+                  (a) =>
+                      a.name.toLowerCase() ==
+                      widget.control
+                          .attrString("capitalization", "")!
+                          .toLowerCase(),
+                  orElse: () => TextCapitalization.none);
+
+          FilteringTextInputFormatter? inputFilter =
+              parseInputFilter(widget.control, "inputFilter");
+
+          List<TextInputFormatter>? inputFormatters = [];
+          // add non-null input formatters
+          if (inputFilter != null) {
+            inputFormatters.add(inputFilter);
+          }
+          if (textCapitalization != TextCapitalization.none) {
+            inputFormatters
+                .add(TextCapitalizationFormatter(textCapitalization));
+          }
+
+          Widget? revealPasswordIcon;
+          if (password && canRevealPassword) {
+            revealPasswordIcon = GestureDetector(
+                child: Icon(
+                  _revealPassword ? Icons.visibility_off : Icons.visibility,
+                ),
+                onTap: () {
+                  setState(() {
+                    _revealPassword = !_revealPassword;
+                  });
+                });
+          }
+
+          TextInputType keyboardType = parseTextInputType(
+              widget.control.attrString("keyboardType", "")!);
+
+          if (multiline) {
+            keyboardType = TextInputType.multiline;
+          }
+
+          TextAlign textAlign = TextAlign.values.firstWhere(
+            ((b) =>
+                b.name ==
+                widget.control.attrString("textAlign", "")!.toLowerCase()),
+            orElse: () => TextAlign.start,
+          );
+
+          bool autocorrect = widget.control.attrBool("autocorrect", true)!;
+          bool enableSuggestions =
+              widget.control.attrBool("enableSuggestions", true)!;
+          bool smartDashesType =
+              widget.control.attrBool("smartDashesType", true)!;
+          bool smartQuotesType =
+              widget.control.attrBool("smartQuotesType", true)!;
+
+          FocusNode focusNode = shiftEnter ? _shiftEnterfocusNode : _focusNode;
+
+          var focusValue = widget.control.attrString("focus");
+          if (focusValue != null && focusValue != _lastFocusValue) {
+            _lastFocusValue = focusValue;
+            focusNode.requestFocus();
+          }
+
+          Widget textField = CupertinoTextField(
+              style: textStyle,
+              placeholder: widget.control.attrString("placeholderText"),
+              placeholderStyle: parseTextStyle(Theme.of(context), widget.control, "placeholderStyle"),
+              autofocus: autofocus,
+              enabled: !disabled,
+              onSubmitted: !multiline
+                  ? (_) {
+                      FletAppServices.of(context).server.sendPageEvent(
+                          eventTarget: widget.control.id,
+                          eventName: "submit",
+                          eventData: "");
+                    }
+                  : null,
+              // decoration: buildInputDecoration(
+              //     context,
+              //     widget.control,
+              //     prefixControls.isNotEmpty ? prefixControls.first : null,
+              //     suffixControls.isNotEmpty ? suffixControls.first : null,
+              //     revealPasswordIcon,
+              //     _focused),
+              cursorHeight: widget.control.attrDouble("cursorHeight"),
+              cursorWidth: widget.control.attrDouble("cursorWidth") ?? 2.0,
+              cursorRadius: parseRadius(widget.control, "cursorRadius") ?? const Radius.circular(2.0),
+              keyboardType: keyboardType,
+              autocorrect: autocorrect,
+              enableSuggestions: enableSuggestions,
+              smartDashesType: smartDashesType
+                  ? SmartDashesType.enabled
+                  : SmartDashesType.disabled,
+              smartQuotesType: smartQuotesType
+                  ? SmartQuotesType.enabled
+                  : SmartQuotesType.disabled,
+              textAlign: textAlign,
+              minLines: minLines,
+              maxLines: maxLines,
+              maxLength: maxLength,
+              readOnly: readOnly,
+              inputFormatters:
+                  inputFormatters.isNotEmpty ? inputFormatters : null,
+              obscureText: password && !_revealPassword,
+              controller: _controller,
+              focusNode: focusNode,
+              onChanged: (String value) {
+                //debugPrint(value);
+                setState(() {
+                  _value = value;
+                });
+                List<Map<String, String>> props = [
+                  {"i": widget.control.id, "value": value}
+                ];
+                dispatch(UpdateControlPropsAction(
+                    UpdateControlPropsPayload(props: props)));
+                FletAppServices.of(context)
+                    .server
+                    .updateControlProps(props: props);
+                if (onChange) {
+                  FletAppServices.of(context).server.sendPageEvent(
+                      eventTarget: widget.control.id,
+                      eventName: "change",
+                      eventData: value);
+                }
+              });
+
+          if (cursorColor != null || selectionColor != null) {
+            textField = TextSelectionTheme(
+                data: TextSelectionTheme.of(context).copyWith(
+                    cursorColor: cursorColor, selectionColor: selectionColor),
+                child: textField);
+          }
+
+          if (widget.control.attrInt("expand", 0)! > 0) {
+            return constrainedControl(
+                context, textField, widget.parent, widget.control);
+          } else {
+            return LayoutBuilder(
+              builder: (BuildContext context, BoxConstraints constraints) {
+                if (constraints.maxWidth == double.infinity &&
+                    widget.control.attrDouble("width") == null) {
+                  textField = ConstrainedBox(
+                    constraints: const BoxConstraints.tightFor(width: 300),
+                    child: textField,
+                  );
+                }
+
+                return constrainedControl(
+                    context, textField, widget.parent, widget.control);
+              },
+            );
+          }
+        });
+  }
+}
+

--- a/package/lib/src/controls/cupertino_textfield.dart
+++ b/package/lib/src/controls/cupertino_textfield.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:collection/collection.dart';
 import 'package:flet/src/controls/textfield.dart';
 import 'package:flutter/cupertino.dart';
@@ -15,12 +13,10 @@ import '../protocol/update_control_props_payload.dart';
 import '../utils/borders.dart';
 import '../utils/colors.dart';
 import '../utils/gradient.dart';
-import '../utils/images.dart';
 import '../utils/shadows.dart';
 import '../utils/text.dart';
 import '../utils/textfield.dart';
 import 'create_control.dart';
-import 'error.dart';
 import 'form_field.dart';
 
 class CupertinoTextFieldControl extends StatefulWidget {
@@ -226,37 +222,6 @@ class _CupertinoTextFieldControlState extends State<CupertinoTextFieldControl> {
           var bgColor = HexColor.fromString(
               Theme.of(context), widget.control.attrString("bgColor", "")!);
 
-          DecorationImage? image;
-          var imageSrc = widget.control.attrString("imageSrc", "")!;
-          var imageSrcBase64 = widget.control.attrString("imageSrcBase64", "")!;
-          var imageRepeat = parseImageRepeat(widget.control, "imageRepeat");
-          var imageFit = parseBoxFit(widget.control, "imageFit");
-          var imageOpacity = widget.control.attrDouble("imageOpacity", 1)!;
-
-          if (imageSrcBase64 != "") {
-            try {
-              Uint8List bytes = base64Decode(imageSrcBase64);
-              image = DecorationImage(
-                  image: MemoryImage(bytes),
-                  repeat: imageRepeat,
-                  fit: imageFit,
-                  opacity: imageOpacity);
-            } catch (ex) {
-              return ErrorControl("Error decoding base64: ${ex.toString()}");
-            }
-          } else if (imageSrc != "") {
-            // var assetSrc =
-            //     getAssetSrc(imageSrc, pageArgs.pageUri!, pageArgs.assetsDir);
-            //
-            // image = DecorationImage(
-            //     image: assetSrc.isFile
-            //         ? getFileImageProvider(assetSrc.path)
-            //         : NetworkImage(assetSrc.path),
-            //     repeat: imageRepeat,
-            //     fit: imageFit,
-            //     opacity: imageOpacity);
-          }
-
           Widget textField = CupertinoTextField(
               style: textStyle,
               placeholder: widget.control.attrString("placeholderText"),
@@ -275,7 +240,6 @@ class _CupertinoTextFieldControlState extends State<CupertinoTextFieldControl> {
               decoration: defaultDecoration?.copyWith(
                   color: bgColor,
                   gradient: gradient,
-                  image: image,
                   backgroundBlendMode:
                       bgColor != null || gradient != null ? blendMode : null,
                   border:
@@ -297,6 +261,10 @@ class _CupertinoTextFieldControlState extends State<CupertinoTextFieldControl> {
               smartQuotesType: smartQuotesType
                   ? SmartQuotesType.enabled
                   : SmartQuotesType.disabled,
+              suffixMode: parseVisibilityMode(
+                  widget.control.attrString("suffixVisibilityMode", "")!),
+              prefixMode: parseVisibilityMode(
+                  widget.control.attrString("prefixVisibilityMode", "")!),
               textAlign: textAlign,
               minLines: minLines,
               maxLines: maxLines,

--- a/package/lib/src/controls/form_field.dart
+++ b/package/lib/src/controls/form_field.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 import '../models/control.dart';
@@ -136,4 +137,18 @@ InputDecoration buildInputDecoration(BuildContext context, Control control,
       suffixIcon: suffixIcon != null ? Icon(suffixIcon) : customSuffix,
       suffixText: suffixText,
       suffixStyle: parseTextStyle(Theme.of(context), control, "suffixStyle"));
+}
+
+OverlayVisibilityMode parseVisibilityMode(String type) {
+  switch (type.toLowerCase()) {
+    case "never":
+      return OverlayVisibilityMode.never;
+    case "notediting":
+      return OverlayVisibilityMode.notEditing;
+    case "editing":
+      return OverlayVisibilityMode.editing;
+    case "always":
+      return OverlayVisibilityMode.always;
+  }
+  return OverlayVisibilityMode.always;
 }

--- a/package/lib/src/controls/textfield.dart
+++ b/package/lib/src/controls/textfield.dart
@@ -250,6 +250,7 @@ class _TextFieldControlState extends State<TextFieldControl> {
                   suffixControls.isNotEmpty ? suffixControls.first : null,
                   revealPasswordIcon,
                   _focused),
+              showCursor: widget.control.attrBool("showCursor"),
               cursorHeight: widget.control.attrDouble("cursorHeight"),
               cursorWidth: widget.control.attrDouble("cursorWidth") ?? 2.0,
               cursorRadius: parseRadius(widget.control, "cursorRadius"),

--- a/package/lib/src/controls/textfield.dart
+++ b/package/lib/src/controls/textfield.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_redux/flutter_redux.dart';
@@ -12,6 +13,7 @@ import '../utils/colors.dart';
 import '../utils/text.dart';
 import '../utils/textfield.dart';
 import 'create_control.dart';
+import 'cupertino_textfield.dart';
 import 'form_field.dart';
 
 class TextFieldControl extends StatefulWidget {
@@ -100,6 +102,17 @@ class _TextFieldControlState extends State<TextFieldControl> {
 
     bool autofocus = widget.control.attrBool("autofocus", false)!;
     bool disabled = widget.control.isDisabled || widget.parentDisabled;
+
+    bool adaptive = widget.control.attrBool("adaptive", false)!;
+    if (adaptive &&
+        (defaultTargetPlatform == TargetPlatform.iOS ||
+            defaultTargetPlatform == TargetPlatform.macOS)) {
+      return CupertinoTextFieldControl(
+          control: widget.control,
+          children: widget.children,
+          parent: widget.parent,
+          parentDisabled: widget.parentDisabled);
+    }
 
     return StoreConnector<AppState, Function>(
         distinct: true,

--- a/sdk/python/packages/flet-core/src/flet_core/__init__.py
+++ b/sdk/python/packages/flet-core/src/flet_core/__init__.py
@@ -62,12 +62,15 @@ from flet_core.column import Column
 from flet_core.container import Container, ContainerTapEvent
 from flet_core.control import Control, OptionalNumber
 from flet_core.control_event import ControlEvent
+from flet_core.cupertino_alert_dialog import CupertinoAlertDialog
 from flet_core.cupertino_app_bar import CupertinoAppBar
 from flet_core.cupertino_checkbox import CupertinoCheckbox
+from flet_core.cupertino_dialog_action import CupertinoDialogAction
 from flet_core.cupertino_navigation_bar import CupertinoNavigationBar
 from flet_core.cupertino_radio import CupertinoRadio
 from flet_core.cupertino_slider import CupertinoSlider
 from flet_core.cupertino_switch import CupertinoSwitch
+from flet_core.cupertino_textfield import CupertinoTextField
 from flet_core.datatable import (
     DataCell,
     DataColumn,
@@ -234,6 +237,4 @@ from flet_core.user_control import UserControl
 from flet_core.vertical_divider import VerticalDivider
 from flet_core.view import View
 from flet_core.webview import WebView
-from flet_core.cupertino_alert_dialog import CupertinoAlertDialog
-from flet_core.cupertino_dialog_action import CupertinoDialogAction
 from flet_core.window_drag_area import WindowDragArea

--- a/sdk/python/packages/flet-core/src/flet_core/__init__.py
+++ b/sdk/python/packages/flet-core/src/flet_core/__init__.py
@@ -70,7 +70,7 @@ from flet_core.cupertino_navigation_bar import CupertinoNavigationBar
 from flet_core.cupertino_radio import CupertinoRadio
 from flet_core.cupertino_slider import CupertinoSlider
 from flet_core.cupertino_switch import CupertinoSwitch
-from flet_core.cupertino_textfield import CupertinoTextField
+from flet_core.cupertino_textfield import CupertinoTextField, VisibilityMode
 from flet_core.datatable import (
     DataCell,
     DataColumn,

--- a/sdk/python/packages/flet-core/src/flet_core/container.py
+++ b/sdk/python/packages/flet-core/src/flet_core/container.py
@@ -273,10 +273,9 @@ class Container(ConstrainedControl):
     @blend_mode.setter
     def blend_mode(self, value: BlendMode):
         self.__blend_mode = value
-        if isinstance(value, BlendMode):
-            self._set_attr("blendMode", value.value)
-        else:
-            self.__set_blend_mode(value)
+        self._set_attr(
+            "blendMode", value.value if isinstance(value, BlendMode) else value
+        )
 
     def __set_blend_mode(self, value: BlendModeString):
         self._set_attr("blendMode", value)

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_textfield.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_textfield.py
@@ -1,12 +1,15 @@
-import time
 from typing import Any, Optional, Union
 
 from flet_core.control import Control, OptionalNumber
-from flet_core.form_field_control import FormFieldControl, InputBorder
+from flet_core.form_field_control import InputBorder
 from flet_core.ref import Ref
 from flet_core.text_style import TextStyle
-from flet_core.textfield import KeyboardTypeString, TextCapitalizationString, InputFilter, KeyboardType, \
-    TextCapitalization
+from flet_core.textfield import (
+    InputFilter,
+    KeyboardType,
+    TextField,
+    TextCapitalization,
+)
 from flet_core.types import (
     AnimationValue,
     BorderRadiusValue,
@@ -16,7 +19,6 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     TextAlign,
-    TextAlignString,
 )
 
 try:
@@ -25,8 +27,9 @@ except ImportError:
     from typing_extensions import Literal
 
 
-class CupertinoTextField(FormFieldControl):
+class CupertinoTextField(TextField):
     """
+    An iOS-style text field.
 
     -----
 
@@ -35,67 +38,11 @@ class CupertinoTextField(FormFieldControl):
 
     def __init__(
         self,
-        ref: Optional[Ref] = None,
-        key: Optional[str] = None,
-        width: OptionalNumber = None,
-        height: OptionalNumber = None,
-        expand: Union[None, bool, int] = None,
-        col: Optional[ResponsiveNumber] = None,
-        opacity: OptionalNumber = None,
-        rotate: RotateValue = None,
-        scale: ScaleValue = None,
-        offset: OffsetValue = None,
-        aspect_ratio: OptionalNumber = None,
-        animate_opacity: AnimationValue = None,
-        animate_size: AnimationValue = None,
-        animate_position: AnimationValue = None,
-        animate_rotation: AnimationValue = None,
-        animate_scale: AnimationValue = None,
-        animate_offset: AnimationValue = None,
-        on_animation_end=None,
-        tooltip: Optional[str] = None,
-        visible: Optional[bool] = None,
-        disabled: Optional[bool] = None,
-        data: Any = None,
         #
-        # FormField specific
+        # CupertinoTextField specific
         #
-        text_size: OptionalNumber = None,
-        text_style: Optional[TextStyle] = None,
-        label: Optional[str] = None,
-        label_style: Optional[TextStyle] = None,
-        icon: Optional[str] = None,
-        border: Optional[InputBorder] = None,
-        color: Optional[str] = None,
-        bgcolor: Optional[str] = None,
-        border_radius: BorderRadiusValue = None,
-        border_width: OptionalNumber = None,
-        border_color: Optional[str] = None,
-        focused_color: Optional[str] = None,
-        focused_bgcolor: Optional[str] = None,
-        focused_border_width: OptionalNumber = None,
-        focused_border_color: Optional[str] = None,
-        content_padding: PaddingValue = None,
-        dense: Optional[bool] = None,
-        filled: Optional[bool] = None,
         placeholder_text: Optional[str] = None,
         placeholder_style: Optional[TextStyle] = None,
-        hint_text: Optional[str] = None,
-        hint_style: Optional[TextStyle] = None,
-        helper_text: Optional[str] = None,
-        helper_style: Optional[TextStyle] = None,
-        counter_text: Optional[str] = None,
-        counter_style: Optional[TextStyle] = None,
-        error_text: Optional[str] = None,
-        error_style: Optional[TextStyle] = None,
-        prefix: Optional[Control] = None,
-        prefix_icon: Optional[str] = None,
-        prefix_text: Optional[str] = None,
-        prefix_style: Optional[TextStyle] = None,
-        suffix: Optional[Control] = None,
-        suffix_icon: Optional[str] = None,
-        suffix_text: Optional[str] = None,
-        suffix_style: Optional[TextStyle] = None,
         #
         # TextField Specific
         #
@@ -126,8 +73,70 @@ class CupertinoTextField(FormFieldControl):
         on_submit=None,
         on_focus=None,
         on_blur=None,
+        #
+        # FormField specific
+        #
+        text_size: OptionalNumber = None,
+        text_style: Optional[TextStyle] = None,
+        label: Optional[str] = None,
+        label_style: Optional[TextStyle] = None,
+        icon: Optional[str] = None,
+        border: Optional[InputBorder] = None,
+        color: Optional[str] = None,
+        bgcolor: Optional[str] = None,
+        border_radius: BorderRadiusValue = None,
+        border_width: OptionalNumber = None,
+        border_color: Optional[str] = None,
+        focused_color: Optional[str] = None,
+        focused_bgcolor: Optional[str] = None,
+        focused_border_width: OptionalNumber = None,
+        focused_border_color: Optional[str] = None,
+        content_padding: PaddingValue = None,
+        dense: Optional[bool] = None,
+        filled: Optional[bool] = None,
+        hint_text: Optional[str] = None,
+        hint_style: Optional[TextStyle] = None,
+        helper_text: Optional[str] = None,
+        helper_style: Optional[TextStyle] = None,
+        counter_text: Optional[str] = None,
+        counter_style: Optional[TextStyle] = None,
+        error_text: Optional[str] = None,
+        error_style: Optional[TextStyle] = None,
+        prefix: Optional[Control] = None,
+        prefix_icon: Optional[str] = None,
+        prefix_text: Optional[str] = None,
+        prefix_style: Optional[TextStyle] = None,
+        suffix: Optional[Control] = None,
+        suffix_icon: Optional[str] = None,
+        suffix_text: Optional[str] = None,
+        suffix_style: Optional[TextStyle] = None,
+        #
+        # Control specific
+        #
+        ref: Optional[Ref] = None,
+        key: Optional[str] = None,
+        width: OptionalNumber = None,
+        height: OptionalNumber = None,
+        expand: Union[None, bool, int] = None,
+        col: Optional[ResponsiveNumber] = None,
+        opacity: OptionalNumber = None,
+        rotate: RotateValue = None,
+        scale: ScaleValue = None,
+        offset: OffsetValue = None,
+        aspect_ratio: OptionalNumber = None,
+        animate_opacity: AnimationValue = None,
+        animate_size: AnimationValue = None,
+        animate_position: AnimationValue = None,
+        animate_rotation: AnimationValue = None,
+        animate_scale: AnimationValue = None,
+        animate_offset: AnimationValue = None,
+        on_animation_end=None,
+        tooltip: Optional[str] = None,
+        visible: Optional[bool] = None,
+        disabled: Optional[bool] = None,
+        data: Any = None,
     ):
-        FormFieldControl.__init__(
+        TextField.__init__(
             self,
             ref=ref,
             key=key,
@@ -188,105 +197,47 @@ class CupertinoTextField(FormFieldControl):
             suffix_icon=suffix_icon,
             suffix_text=suffix_text,
             suffix_style=suffix_style,
+            #
+            # TextField
+            #
+            value=value,
+            keyboard_type=keyboard_type,
+            multiline=multiline,
+            min_lines=min_lines,
+            max_lines=max_lines,
+            max_length=max_length,
+            password=password,
+            can_reveal_password=can_reveal_password,
+            read_only=read_only,
+            shift_enter=shift_enter,
+            text_align=text_align,
+            autofocus=autofocus,
+            capitalization=capitalization,
+            autocorrect=autocorrect,
+            enable_suggestions=enable_suggestions,
+            smart_dashes_type=smart_dashes_type,
+            smart_quotes_type=smart_quotes_type,
+            cursor_color=cursor_color,
+            cursor_width=cursor_width,
+            cursor_height=cursor_height,
+            cursor_radius=cursor_radius,
+            selection_color=selection_color,
+            input_filter=input_filter,
+            on_change=on_change,
+            on_submit=on_submit,
+            on_focus=on_focus,
+            on_blur=on_blur,
         )
-        self.value = value
-        self.text_style = text_style
-        self.keyboard_type = keyboard_type
-        self.text_align = text_align
-        self.multiline = multiline
-        self.min_lines = min_lines
-        self.max_lines = max_lines
-        self.max_length = max_length
-        self.read_only = read_only
-        self.shift_enter = shift_enter
+
         self.placeholder_text = placeholder_text
         self.placeholder_style = placeholder_style
-        self.password = password
-        self.can_reveal_password = can_reveal_password
-        self.autofocus = autofocus
-        self.capitalization = capitalization
-        self.autocorrect = autocorrect
-        self.enable_suggestions = enable_suggestions
-        self.smart_dashes_type = smart_dashes_type
-        self.smart_quotes_type = smart_quotes_type
-        self.cursor_color = cursor_color
-        self.cursor_height = cursor_height
-        self.cursor_width = cursor_width
-        self.cursor_radius = cursor_radius
-        self.selection_color = selection_color
-        self.input_filter = input_filter
-        self.on_change = on_change
-        self.on_submit = on_submit
-        self.on_focus = on_focus
-        self.on_blur = on_blur
 
     def _get_control_name(self):
         return "cupertinotextfield"
 
     def _before_build_command(self):
         super()._before_build_command()
-        self._set_attr_json("inputFilter", self.__input_filter)
         self._set_attr_json("placeholderStyle", self.__placeholder_style)
-        if self.bgcolor is not None and self.filled is None:
-            self.filled = True  # Flutter requires filled = True to display a bgcolor
-
-    def focus(self):
-        self._set_attr_json("focus", str(time.time()))
-        self.update()
-
-    async def focus_async(self):
-        self._set_attr_json("focus", str(time.time()))
-        await self.update_async()
-
-    # value
-    @property
-    def value(self) -> Optional[str]:
-        return self._get_attr("value", def_value="")
-
-    @value.setter
-    def value(self, value: Optional[str]):
-        self._set_attr("value", value)
-
-    # keyboard_type
-    @property
-    def keyboard_type(self) -> Optional[KeyboardType]:
-        return self.__keyboard_type
-
-    @keyboard_type.setter
-    def keyboard_type(self, value: Optional[KeyboardType]):
-        self.__keyboard_type = value
-        if isinstance(value, KeyboardType):
-            self._set_attr("keyboardType", value.value)
-        else:
-            self.__set_keyboard_type(value)
-
-    def __set_keyboard_type(self, value: KeyboardTypeString):
-        self._set_attr("keyboardType", value)
-
-    # text_align
-    @property
-    def text_align(self) -> TextAlign:
-        return self.__text_align
-
-    @text_align.setter
-    def text_align(self, value: TextAlign):
-        self.__text_align = value
-        if isinstance(value, TextAlign):
-            self._set_attr("textAlign", value.value)
-        else:
-            self.__set_text_align(value)
-
-    def __set_text_align(self, value: TextAlignString):
-        self._set_attr("textAlign", value)
-
-    # multiline
-    @property
-    def multiline(self) -> Optional[bool]:
-        return self._get_attr("multiline", data_type="bool", def_value=False)
-
-    @multiline.setter
-    def multiline(self, value: Optional[bool]):
-        self._set_attr("multiline", value)
 
     # placeholder_text
     @property
@@ -305,221 +256,3 @@ class CupertinoTextField(FormFieldControl):
     @placeholder_style.setter
     def placeholder_style(self, value: Optional[TextStyle]):
         self.__placeholder_style = value
-
-    # min_lines
-    @property
-    def min_lines(self) -> Optional[int]:
-        return self._get_attr("minLines")
-
-    @min_lines.setter
-    def min_lines(self, value: Optional[int]):
-        self._set_attr("minLines", value)
-
-    # max_lines
-    @property
-    def max_lines(self) -> Optional[int]:
-        return self._get_attr("maxLines")
-
-    @max_lines.setter
-    def max_lines(self, value: Optional[int]):
-        self._set_attr("maxLines", value)
-
-    # max_length
-    @property
-    def max_length(self) -> Optional[int]:
-        return self._get_attr("maxLength")
-
-    @max_length.setter
-    def max_length(self, value: Optional[int]):
-        self._set_attr("maxLength", value)
-
-    # read_only
-    @property
-    def read_only(self) -> Optional[bool]:
-        return self._get_attr("readOnly", data_type="bool", def_value=False)
-
-    @read_only.setter
-    def read_only(self, value: Optional[bool]):
-        self._set_attr("readOnly", value)
-
-    # shift_enter
-    @property
-    def shift_enter(self) -> Optional[bool]:
-        return self._get_attr("shiftEnter", data_type="bool", def_value=False)
-
-    @shift_enter.setter
-    def shift_enter(self, value: Optional[bool]):
-        self._set_attr("shiftEnter", value)
-
-    # password
-    @property
-    def password(self) -> Optional[bool]:
-        return self._get_attr("password", data_type="bool", def_value=False)
-
-    @password.setter
-    def password(self, value: Optional[bool]):
-        self._set_attr("password", value)
-
-    # can_reveal_password
-    @property
-    def can_reveal_password(self) -> Optional[bool]:
-        return self._get_attr("canRevealPassword", data_type="bool", def_value=False)
-
-    @can_reveal_password.setter
-    def can_reveal_password(self, value: Optional[bool]):
-        self._set_attr("canRevealPassword", value)
-
-    # autofocus
-    @property
-    def autofocus(self) -> Optional[bool]:
-        return self._get_attr("autofocus", data_type="bool", def_value=False)
-
-    @autofocus.setter
-    def autofocus(self, value: Optional[bool]):
-        self._set_attr("autofocus", value)
-
-    # capitalization
-    @property
-    def capitalization(self) -> TextCapitalization:
-        return self.__capitalization
-
-    @capitalization.setter
-    def capitalization(self, value: TextCapitalization):
-        self.__capitalization = value
-        if isinstance(value, TextCapitalization):
-            self._set_attr("capitalization", value.value)
-        else:
-            self.__set_capitalization(value)
-
-    def __set_capitalization(self, value: TextCapitalizationString):
-        self._set_attr("capitalization", value)
-
-    # autocorrect
-    @property
-    def autocorrect(self) -> Optional[bool]:
-        return self._get_attr("autocorrect", data_type="bool", def_value=True)
-
-    @autocorrect.setter
-    def autocorrect(self, value: Optional[bool]):
-        self._set_attr("autocorrect", value)
-
-    # enable_suggestions
-    @property
-    def enable_suggestions(self) -> Optional[bool]:
-        return self._get_attr("enableSuggestions", data_type="bool", def_value=True)
-
-    @enable_suggestions.setter
-    def enable_suggestions(self, value: Optional[bool]):
-        self._set_attr("enableSuggestions", value)
-
-    # smart_dashes_type
-    @property
-    def smart_dashes_type(self) -> Optional[bool]:
-        return self._get_attr("smartDashesType", data_type="bool", def_value=True)
-
-    @smart_dashes_type.setter
-    def smart_dashes_type(self, value: Optional[bool]):
-        self._set_attr("smartDashesType", value)
-
-    # smart_quotes_type
-    @property
-    def smart_quotes_type(self) -> Optional[bool]:
-        return self._get_attr("smartQuotesType", data_type="bool", def_value=True)
-
-    @smart_quotes_type.setter
-    def smart_quotes_type(self, value: Optional[bool]):
-        self._set_attr("smartQuotesType", value)
-
-    # cursor_color
-    @property
-    def cursor_color(self):
-        return self._get_attr("cursorColor")
-
-    @cursor_color.setter
-    def cursor_color(self, value):
-        self._set_attr("cursorColor", value)
-
-    # cursor_height
-    @property
-    def cursor_height(self) -> OptionalNumber:
-        return self._get_attr("cursorHeight")
-
-    @cursor_height.setter
-    def cursor_height(self, value: OptionalNumber):
-        self._set_attr("cursorHeight", value)
-
-    # cursor_width
-    @property
-    def cursor_width(self) -> OptionalNumber:
-        return self._get_attr("cursorWidth")
-
-    @cursor_width.setter
-    def cursor_width(self, value: OptionalNumber):
-        self._set_attr("cursorWidth", value)
-
-    # cursor_radius
-    @property
-    def cursor_radius(self) -> OptionalNumber:
-        return self._get_attr("cursorRadius")
-
-    @cursor_radius.setter
-    def cursor_radius(self, value: OptionalNumber):
-        self._set_attr("cursorRadius", value)
-
-    # selection_color
-    @property
-    def selection_color(self):
-        return self._get_attr("selectionColor")
-
-    @selection_color.setter
-    def selection_color(self, value):
-        self._set_attr("selectionColor", value)
-
-    # input_filter
-    @property
-    def input_filter(self) -> Optional[InputFilter]:
-        return self.__input_filter
-
-    @input_filter.setter
-    def input_filter(self, value: Optional[InputFilter]):
-        self.__input_filter = value
-
-    # on_change
-    @property
-    def on_change(self):
-        return self._get_event_handler("change")
-
-    @on_change.setter
-    def on_change(self, handler):
-        self._add_event_handler("change", handler)
-        if handler is not None:
-            self._set_attr("onchange", True)
-        else:
-            self._set_attr("onchange", None)
-
-    # on_submit
-    @property
-    def on_submit(self):
-        return self._get_event_handler("submit")
-
-    @on_submit.setter
-    def on_submit(self, handler):
-        self._add_event_handler("submit", handler)
-
-    # on_focus
-    @property
-    def on_focus(self):
-        return self._get_event_handler("focus")
-
-    @on_focus.setter
-    def on_focus(self, handler):
-        self._add_event_handler("focus", handler)
-
-    # on_blur
-    @property
-    def on_blur(self):
-        return self._get_event_handler("blur")
-
-    @on_blur.setter
-    def on_blur(self, handler):
-        self._add_event_handler("blur", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_textfield.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_textfield.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Any, Optional, Union, List
 
 from flet_core.control import Control, OptionalNumber
@@ -30,6 +31,13 @@ except ImportError:
     from typing_extensions import Literal
 
 
+class VisibilityMode(Enum):
+    NONE = "never"
+    EDITING = "editing"
+    NOT_EDITING = "notEditing"
+    ALWAYS = "always"
+
+
 class CupertinoTextField(TextField):
     """
     An iOS-style text field.
@@ -49,6 +57,8 @@ class CupertinoTextField(TextField):
         gradient: Optional[Gradient] = None,
         blend_mode: BlendMode = BlendMode.NONE,
         shadow: Union[None, BoxShadow, List[BoxShadow]] = None,
+        prefix_visibility_mode: Optional[VisibilityMode] = None,
+        suffix_visibility_mode: Optional[VisibilityMode] = None,
         #
         # TextField Specific
         #
@@ -234,6 +244,8 @@ class CupertinoTextField(TextField):
         self.gradient = gradient
         self.blend_mode = blend_mode
         self.shadow = shadow
+        self.suffix_visibility_mode = suffix_visibility_mode
+        self.prefix_visibility_mode = prefix_visibility_mode
 
     def _get_control_name(self):
         return "cupertinotextfield"
@@ -291,3 +303,29 @@ class CupertinoTextField(TextField):
     @shadow.setter
     def shadow(self, value: Union[None, BoxShadow, List[BoxShadow]]):
         self.__shadow = value if value is not None else []
+
+    # suffix_visibility_mode
+    @property
+    def suffix_visibility_mode(self) -> Optional[VisibilityMode]:
+        return self.__suffix_visibility_mode
+
+    @suffix_visibility_mode.setter
+    def suffix_visibility_mode(self, value: Optional[VisibilityMode]):
+        self.__suffix_visibility_mode = value
+        self._set_attr(
+            "suffixVisibilityMode",
+            value.value if isinstance(value, VisibilityMode) else value,
+        )
+
+    # prefix_visibility_mode
+    @property
+    def prefix_visibility_mode(self) -> Optional[VisibilityMode]:
+        return self.__prefix_visibility_mode
+
+    @prefix_visibility_mode.setter
+    def prefix_visibility_mode(self, value: Optional[VisibilityMode]):
+        self.__prefix_visibility_mode = value
+        self._set_attr(
+            "prefixVisibilityMode",
+            value.value if isinstance(value, VisibilityMode) else value,
+        )

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_textfield.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_textfield.py
@@ -32,7 +32,7 @@ except ImportError:
 
 
 class VisibilityMode(Enum):
-    NONE = "never"
+    NEVER = "never"
     EDITING = "editing"
     NOT_EDITING = "notEditing"
     ALWAYS = "always"

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_textfield.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_textfield.py
@@ -1,8 +1,10 @@
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, List
 
 from flet_core.control import Control, OptionalNumber
 from flet_core.form_field_control import InputBorder
+from flet_core.gradients import Gradient
 from flet_core.ref import Ref
+from flet_core.shadow import BoxShadow
 from flet_core.text_style import TextStyle
 from flet_core.textfield import (
     InputFilter,
@@ -19,6 +21,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     TextAlign,
+    BlendMode,
 )
 
 try:
@@ -43,6 +46,9 @@ class CupertinoTextField(TextField):
         #
         placeholder_text: Optional[str] = None,
         placeholder_style: Optional[TextStyle] = None,
+        gradient: Optional[Gradient] = None,
+        blend_mode: BlendMode = BlendMode.NONE,
+        shadow: Union[None, BoxShadow, List[BoxShadow]] = None,
         #
         # TextField Specific
         #
@@ -67,6 +73,7 @@ class CupertinoTextField(TextField):
         cursor_width: OptionalNumber = None,
         cursor_height: OptionalNumber = None,
         cursor_radius: OptionalNumber = None,
+        show_cursor: Optional[bool] = None,
         selection_color: Optional[str] = None,
         input_filter: Optional[InputFilter] = None,
         on_change=None,
@@ -103,12 +110,8 @@ class CupertinoTextField(TextField):
         error_text: Optional[str] = None,
         error_style: Optional[TextStyle] = None,
         prefix: Optional[Control] = None,
-        prefix_icon: Optional[str] = None,
-        prefix_text: Optional[str] = None,
         prefix_style: Optional[TextStyle] = None,
         suffix: Optional[Control] = None,
-        suffix_icon: Optional[str] = None,
-        suffix_text: Optional[str] = None,
         suffix_style: Optional[TextStyle] = None,
         #
         # Control specific
@@ -190,12 +193,8 @@ class CupertinoTextField(TextField):
             error_text=error_text,
             error_style=error_style,
             prefix=prefix,
-            prefix_icon=prefix_icon,
-            prefix_text=prefix_text,
             prefix_style=prefix_style,
             suffix=suffix,
-            suffix_icon=suffix_icon,
-            suffix_text=suffix_text,
             suffix_style=suffix_style,
             #
             # TextField
@@ -221,6 +220,7 @@ class CupertinoTextField(TextField):
             cursor_width=cursor_width,
             cursor_height=cursor_height,
             cursor_radius=cursor_radius,
+            show_cursor=show_cursor,
             selection_color=selection_color,
             input_filter=input_filter,
             on_change=on_change,
@@ -231,12 +231,17 @@ class CupertinoTextField(TextField):
 
         self.placeholder_text = placeholder_text
         self.placeholder_style = placeholder_style
+        self.gradient = gradient
+        self.blend_mode = blend_mode
+        self.shadow = shadow
 
     def _get_control_name(self):
         return "cupertinotextfield"
 
     def _before_build_command(self):
         super()._before_build_command()
+        self._set_attr_json("gradient", self.__gradient)
+        self._set_attr_json("shadow", self.__shadow if self.__shadow else None)
         self._set_attr_json("placeholderStyle", self.__placeholder_style)
 
     # placeholder_text
@@ -256,3 +261,33 @@ class CupertinoTextField(TextField):
     @placeholder_style.setter
     def placeholder_style(self, value: Optional[TextStyle]):
         self.__placeholder_style = value
+
+    # gradient
+    @property
+    def gradient(self) -> Optional[Gradient]:
+        return self.__gradient
+
+    @gradient.setter
+    def gradient(self, value: Optional[Gradient]):
+        self.__gradient = value
+
+    # blend_mode
+    @property
+    def blend_mode(self) -> BlendMode:
+        return self.__blend_mode
+
+    @blend_mode.setter
+    def blend_mode(self, value: BlendMode):
+        self.__blend_mode = value
+        self._set_attr(
+            "blendMode", value.value if isinstance(value, BlendMode) else value
+        )
+
+    # shadow
+    @property
+    def shadow(self):
+        return self.__shadow
+
+    @shadow.setter
+    def shadow(self, value: Union[None, BoxShadow, List[BoxShadow]]):
+        self.__shadow = value if value is not None else []

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_textfield.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_textfield.py
@@ -1,0 +1,525 @@
+import time
+from typing import Any, Optional, Union
+
+from flet_core.control import Control, OptionalNumber
+from flet_core.form_field_control import FormFieldControl, InputBorder
+from flet_core.ref import Ref
+from flet_core.text_style import TextStyle
+from flet_core.textfield import KeyboardTypeString, TextCapitalizationString, InputFilter, KeyboardType, \
+    TextCapitalization
+from flet_core.types import (
+    AnimationValue,
+    BorderRadiusValue,
+    OffsetValue,
+    PaddingValue,
+    ResponsiveNumber,
+    RotateValue,
+    ScaleValue,
+    TextAlign,
+    TextAlignString,
+)
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
+
+
+class CupertinoTextField(FormFieldControl):
+    """
+
+    -----
+
+    Online docs: https://flet.dev/docs/controls/cupertinotextfield
+    """
+
+    def __init__(
+        self,
+        ref: Optional[Ref] = None,
+        key: Optional[str] = None,
+        width: OptionalNumber = None,
+        height: OptionalNumber = None,
+        expand: Union[None, bool, int] = None,
+        col: Optional[ResponsiveNumber] = None,
+        opacity: OptionalNumber = None,
+        rotate: RotateValue = None,
+        scale: ScaleValue = None,
+        offset: OffsetValue = None,
+        aspect_ratio: OptionalNumber = None,
+        animate_opacity: AnimationValue = None,
+        animate_size: AnimationValue = None,
+        animate_position: AnimationValue = None,
+        animate_rotation: AnimationValue = None,
+        animate_scale: AnimationValue = None,
+        animate_offset: AnimationValue = None,
+        on_animation_end=None,
+        tooltip: Optional[str] = None,
+        visible: Optional[bool] = None,
+        disabled: Optional[bool] = None,
+        data: Any = None,
+        #
+        # FormField specific
+        #
+        text_size: OptionalNumber = None,
+        text_style: Optional[TextStyle] = None,
+        label: Optional[str] = None,
+        label_style: Optional[TextStyle] = None,
+        icon: Optional[str] = None,
+        border: Optional[InputBorder] = None,
+        color: Optional[str] = None,
+        bgcolor: Optional[str] = None,
+        border_radius: BorderRadiusValue = None,
+        border_width: OptionalNumber = None,
+        border_color: Optional[str] = None,
+        focused_color: Optional[str] = None,
+        focused_bgcolor: Optional[str] = None,
+        focused_border_width: OptionalNumber = None,
+        focused_border_color: Optional[str] = None,
+        content_padding: PaddingValue = None,
+        dense: Optional[bool] = None,
+        filled: Optional[bool] = None,
+        placeholder_text: Optional[str] = None,
+        placeholder_style: Optional[TextStyle] = None,
+        hint_text: Optional[str] = None,
+        hint_style: Optional[TextStyle] = None,
+        helper_text: Optional[str] = None,
+        helper_style: Optional[TextStyle] = None,
+        counter_text: Optional[str] = None,
+        counter_style: Optional[TextStyle] = None,
+        error_text: Optional[str] = None,
+        error_style: Optional[TextStyle] = None,
+        prefix: Optional[Control] = None,
+        prefix_icon: Optional[str] = None,
+        prefix_text: Optional[str] = None,
+        prefix_style: Optional[TextStyle] = None,
+        suffix: Optional[Control] = None,
+        suffix_icon: Optional[str] = None,
+        suffix_text: Optional[str] = None,
+        suffix_style: Optional[TextStyle] = None,
+        #
+        # TextField Specific
+        #
+        value: Optional[str] = None,
+        keyboard_type: Optional[KeyboardType] = None,
+        multiline: Optional[bool] = None,
+        min_lines: Optional[int] = None,
+        max_lines: Optional[int] = None,
+        max_length: Optional[int] = None,
+        password: Optional[bool] = None,
+        can_reveal_password: Optional[bool] = None,
+        read_only: Optional[bool] = None,
+        shift_enter: Optional[bool] = None,
+        text_align: TextAlign = TextAlign.NONE,
+        autofocus: Optional[bool] = None,
+        capitalization: TextCapitalization = TextCapitalization.NONE,
+        autocorrect: Optional[bool] = None,
+        enable_suggestions: Optional[bool] = None,
+        smart_dashes_type: Optional[bool] = None,
+        smart_quotes_type: Optional[bool] = None,
+        cursor_color: Optional[str] = None,
+        cursor_width: OptionalNumber = None,
+        cursor_height: OptionalNumber = None,
+        cursor_radius: OptionalNumber = None,
+        selection_color: Optional[str] = None,
+        input_filter: Optional[InputFilter] = None,
+        on_change=None,
+        on_submit=None,
+        on_focus=None,
+        on_blur=None,
+    ):
+        FormFieldControl.__init__(
+            self,
+            ref=ref,
+            key=key,
+            width=width,
+            height=height,
+            expand=expand,
+            col=col,
+            opacity=opacity,
+            rotate=rotate,
+            scale=scale,
+            offset=offset,
+            aspect_ratio=aspect_ratio,
+            animate_opacity=animate_opacity,
+            animate_size=animate_size,
+            animate_position=animate_position,
+            animate_rotation=animate_rotation,
+            animate_scale=animate_scale,
+            animate_offset=animate_offset,
+            on_animation_end=on_animation_end,
+            tooltip=tooltip,
+            visible=visible,
+            disabled=disabled,
+            data=data,
+            #
+            # FormField
+            #
+            text_size=text_size,
+            text_style=text_style,
+            label=label,
+            label_style=label_style,
+            icon=icon,
+            border=border,
+            color=color,
+            bgcolor=bgcolor,
+            border_radius=border_radius,
+            border_width=border_width,
+            border_color=border_color,
+            focused_color=focused_color,
+            focused_bgcolor=focused_bgcolor,
+            focused_border_width=focused_border_width,
+            focused_border_color=focused_border_color,
+            content_padding=content_padding,
+            dense=dense,
+            filled=filled,
+            hint_text=hint_text,
+            hint_style=hint_style,
+            helper_text=helper_text,
+            helper_style=helper_style,
+            counter_text=counter_text,
+            counter_style=counter_style,
+            error_text=error_text,
+            error_style=error_style,
+            prefix=prefix,
+            prefix_icon=prefix_icon,
+            prefix_text=prefix_text,
+            prefix_style=prefix_style,
+            suffix=suffix,
+            suffix_icon=suffix_icon,
+            suffix_text=suffix_text,
+            suffix_style=suffix_style,
+        )
+        self.value = value
+        self.text_style = text_style
+        self.keyboard_type = keyboard_type
+        self.text_align = text_align
+        self.multiline = multiline
+        self.min_lines = min_lines
+        self.max_lines = max_lines
+        self.max_length = max_length
+        self.read_only = read_only
+        self.shift_enter = shift_enter
+        self.placeholder_text = placeholder_text
+        self.placeholder_style = placeholder_style
+        self.password = password
+        self.can_reveal_password = can_reveal_password
+        self.autofocus = autofocus
+        self.capitalization = capitalization
+        self.autocorrect = autocorrect
+        self.enable_suggestions = enable_suggestions
+        self.smart_dashes_type = smart_dashes_type
+        self.smart_quotes_type = smart_quotes_type
+        self.cursor_color = cursor_color
+        self.cursor_height = cursor_height
+        self.cursor_width = cursor_width
+        self.cursor_radius = cursor_radius
+        self.selection_color = selection_color
+        self.input_filter = input_filter
+        self.on_change = on_change
+        self.on_submit = on_submit
+        self.on_focus = on_focus
+        self.on_blur = on_blur
+
+    def _get_control_name(self):
+        return "cupertinotextfield"
+
+    def _before_build_command(self):
+        super()._before_build_command()
+        self._set_attr_json("inputFilter", self.__input_filter)
+        self._set_attr_json("placeholderStyle", self.__placeholder_style)
+        if self.bgcolor is not None and self.filled is None:
+            self.filled = True  # Flutter requires filled = True to display a bgcolor
+
+    def focus(self):
+        self._set_attr_json("focus", str(time.time()))
+        self.update()
+
+    async def focus_async(self):
+        self._set_attr_json("focus", str(time.time()))
+        await self.update_async()
+
+    # value
+    @property
+    def value(self) -> Optional[str]:
+        return self._get_attr("value", def_value="")
+
+    @value.setter
+    def value(self, value: Optional[str]):
+        self._set_attr("value", value)
+
+    # keyboard_type
+    @property
+    def keyboard_type(self) -> Optional[KeyboardType]:
+        return self.__keyboard_type
+
+    @keyboard_type.setter
+    def keyboard_type(self, value: Optional[KeyboardType]):
+        self.__keyboard_type = value
+        if isinstance(value, KeyboardType):
+            self._set_attr("keyboardType", value.value)
+        else:
+            self.__set_keyboard_type(value)
+
+    def __set_keyboard_type(self, value: KeyboardTypeString):
+        self._set_attr("keyboardType", value)
+
+    # text_align
+    @property
+    def text_align(self) -> TextAlign:
+        return self.__text_align
+
+    @text_align.setter
+    def text_align(self, value: TextAlign):
+        self.__text_align = value
+        if isinstance(value, TextAlign):
+            self._set_attr("textAlign", value.value)
+        else:
+            self.__set_text_align(value)
+
+    def __set_text_align(self, value: TextAlignString):
+        self._set_attr("textAlign", value)
+
+    # multiline
+    @property
+    def multiline(self) -> Optional[bool]:
+        return self._get_attr("multiline", data_type="bool", def_value=False)
+
+    @multiline.setter
+    def multiline(self, value: Optional[bool]):
+        self._set_attr("multiline", value)
+
+    # placeholder_text
+    @property
+    def placeholder_text(self):
+        return self._get_attr("placeholderText")
+
+    @placeholder_text.setter
+    def placeholder_text(self, value):
+        self._set_attr("placeholderText", value)
+
+    # placeholder_style
+    @property
+    def placeholder_style(self):
+        return self.__hint_style
+
+    @placeholder_style.setter
+    def placeholder_style(self, value: Optional[TextStyle]):
+        self.__placeholder_style = value
+
+    # min_lines
+    @property
+    def min_lines(self) -> Optional[int]:
+        return self._get_attr("minLines")
+
+    @min_lines.setter
+    def min_lines(self, value: Optional[int]):
+        self._set_attr("minLines", value)
+
+    # max_lines
+    @property
+    def max_lines(self) -> Optional[int]:
+        return self._get_attr("maxLines")
+
+    @max_lines.setter
+    def max_lines(self, value: Optional[int]):
+        self._set_attr("maxLines", value)
+
+    # max_length
+    @property
+    def max_length(self) -> Optional[int]:
+        return self._get_attr("maxLength")
+
+    @max_length.setter
+    def max_length(self, value: Optional[int]):
+        self._set_attr("maxLength", value)
+
+    # read_only
+    @property
+    def read_only(self) -> Optional[bool]:
+        return self._get_attr("readOnly", data_type="bool", def_value=False)
+
+    @read_only.setter
+    def read_only(self, value: Optional[bool]):
+        self._set_attr("readOnly", value)
+
+    # shift_enter
+    @property
+    def shift_enter(self) -> Optional[bool]:
+        return self._get_attr("shiftEnter", data_type="bool", def_value=False)
+
+    @shift_enter.setter
+    def shift_enter(self, value: Optional[bool]):
+        self._set_attr("shiftEnter", value)
+
+    # password
+    @property
+    def password(self) -> Optional[bool]:
+        return self._get_attr("password", data_type="bool", def_value=False)
+
+    @password.setter
+    def password(self, value: Optional[bool]):
+        self._set_attr("password", value)
+
+    # can_reveal_password
+    @property
+    def can_reveal_password(self) -> Optional[bool]:
+        return self._get_attr("canRevealPassword", data_type="bool", def_value=False)
+
+    @can_reveal_password.setter
+    def can_reveal_password(self, value: Optional[bool]):
+        self._set_attr("canRevealPassword", value)
+
+    # autofocus
+    @property
+    def autofocus(self) -> Optional[bool]:
+        return self._get_attr("autofocus", data_type="bool", def_value=False)
+
+    @autofocus.setter
+    def autofocus(self, value: Optional[bool]):
+        self._set_attr("autofocus", value)
+
+    # capitalization
+    @property
+    def capitalization(self) -> TextCapitalization:
+        return self.__capitalization
+
+    @capitalization.setter
+    def capitalization(self, value: TextCapitalization):
+        self.__capitalization = value
+        if isinstance(value, TextCapitalization):
+            self._set_attr("capitalization", value.value)
+        else:
+            self.__set_capitalization(value)
+
+    def __set_capitalization(self, value: TextCapitalizationString):
+        self._set_attr("capitalization", value)
+
+    # autocorrect
+    @property
+    def autocorrect(self) -> Optional[bool]:
+        return self._get_attr("autocorrect", data_type="bool", def_value=True)
+
+    @autocorrect.setter
+    def autocorrect(self, value: Optional[bool]):
+        self._set_attr("autocorrect", value)
+
+    # enable_suggestions
+    @property
+    def enable_suggestions(self) -> Optional[bool]:
+        return self._get_attr("enableSuggestions", data_type="bool", def_value=True)
+
+    @enable_suggestions.setter
+    def enable_suggestions(self, value: Optional[bool]):
+        self._set_attr("enableSuggestions", value)
+
+    # smart_dashes_type
+    @property
+    def smart_dashes_type(self) -> Optional[bool]:
+        return self._get_attr("smartDashesType", data_type="bool", def_value=True)
+
+    @smart_dashes_type.setter
+    def smart_dashes_type(self, value: Optional[bool]):
+        self._set_attr("smartDashesType", value)
+
+    # smart_quotes_type
+    @property
+    def smart_quotes_type(self) -> Optional[bool]:
+        return self._get_attr("smartQuotesType", data_type="bool", def_value=True)
+
+    @smart_quotes_type.setter
+    def smart_quotes_type(self, value: Optional[bool]):
+        self._set_attr("smartQuotesType", value)
+
+    # cursor_color
+    @property
+    def cursor_color(self):
+        return self._get_attr("cursorColor")
+
+    @cursor_color.setter
+    def cursor_color(self, value):
+        self._set_attr("cursorColor", value)
+
+    # cursor_height
+    @property
+    def cursor_height(self) -> OptionalNumber:
+        return self._get_attr("cursorHeight")
+
+    @cursor_height.setter
+    def cursor_height(self, value: OptionalNumber):
+        self._set_attr("cursorHeight", value)
+
+    # cursor_width
+    @property
+    def cursor_width(self) -> OptionalNumber:
+        return self._get_attr("cursorWidth")
+
+    @cursor_width.setter
+    def cursor_width(self, value: OptionalNumber):
+        self._set_attr("cursorWidth", value)
+
+    # cursor_radius
+    @property
+    def cursor_radius(self) -> OptionalNumber:
+        return self._get_attr("cursorRadius")
+
+    @cursor_radius.setter
+    def cursor_radius(self, value: OptionalNumber):
+        self._set_attr("cursorRadius", value)
+
+    # selection_color
+    @property
+    def selection_color(self):
+        return self._get_attr("selectionColor")
+
+    @selection_color.setter
+    def selection_color(self, value):
+        self._set_attr("selectionColor", value)
+
+    # input_filter
+    @property
+    def input_filter(self) -> Optional[InputFilter]:
+        return self.__input_filter
+
+    @input_filter.setter
+    def input_filter(self, value: Optional[InputFilter]):
+        self.__input_filter = value
+
+    # on_change
+    @property
+    def on_change(self):
+        return self._get_event_handler("change")
+
+    @on_change.setter
+    def on_change(self, handler):
+        self._add_event_handler("change", handler)
+        if handler is not None:
+            self._set_attr("onchange", True)
+        else:
+            self._set_attr("onchange", None)
+
+    # on_submit
+    @property
+    def on_submit(self):
+        return self._get_event_handler("submit")
+
+    @on_submit.setter
+    def on_submit(self, handler):
+        self._add_event_handler("submit", handler)
+
+    # on_focus
+    @property
+    def on_focus(self):
+        return self._get_event_handler("focus")
+
+    @on_focus.setter
+    def on_focus(self, handler):
+        self._add_event_handler("focus", handler)
+
+    # on_blur
+    @property
+    def on_blur(self):
+        return self._get_event_handler("blur")
+
+    @on_blur.setter
+    def on_blur(self, handler):
+        self._add_event_handler("blur", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/textfield.py
+++ b/sdk/python/packages/flet-core/src/flet_core/textfield.py
@@ -194,6 +194,7 @@ class TextField(FormFieldControl):
         enable_suggestions: Optional[bool] = None,
         smart_dashes_type: Optional[bool] = None,
         smart_quotes_type: Optional[bool] = None,
+        show_cursor: Optional[bool] = None,
         cursor_color: Optional[str] = None,
         cursor_width: OptionalNumber = None,
         cursor_height: OptionalNumber = None,
@@ -283,6 +284,7 @@ class TextField(FormFieldControl):
         self.adaptive = adaptive
         self.capitalization = capitalization
         self.autocorrect = autocorrect
+        self.show_cursor = show_cursor
         self.enable_suggestions = enable_suggestions
         self.smart_dashes_type = smart_dashes_type
         self.smart_quotes_type = smart_quotes_type
@@ -469,6 +471,15 @@ class TextField(FormFieldControl):
     @autocorrect.setter
     def autocorrect(self, value: Optional[bool]):
         self._set_attr("autocorrect", value)
+
+    # show_cursor
+    @property
+    def show_cursor(self) -> Optional[bool]:
+        return self._get_attr("showCursor", data_type="bool", def_value=True)
+
+    @show_cursor.setter
+    def show_cursor(self, value: Optional[bool]):
+        self._set_attr("showCursor", value)
 
     # enable_suggestions
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/textfield.py
+++ b/sdk/python/packages/flet-core/src/flet_core/textfield.py
@@ -1,6 +1,6 @@
 import dataclasses
-from dataclasses import field
 import time
+from dataclasses import field
 from enum import Enum
 from typing import Any, Optional, Union
 
@@ -71,9 +71,11 @@ class InputFilter:
     allow: bool = field(default=True)
     replacement_string: str = field(default="")
 
+
 class NumbersOnlyInputFilter(InputFilter):
     def __init__(self):
         super().__init__(r"[0-9]")
+
 
 class TextOnlyInputFilter(InputFilter):
     def __init__(self):
@@ -174,6 +176,7 @@ class TextField(FormFieldControl):
         #
         # TextField Specific
         #
+        adaptive: Optional[bool] = None,
         value: Optional[str] = None,
         keyboard_type: Optional[KeyboardType] = None,
         multiline: Optional[bool] = None,
@@ -277,6 +280,7 @@ class TextField(FormFieldControl):
         self.password = password
         self.can_reveal_password = can_reveal_password
         self.autofocus = autofocus
+        self.adaptive = adaptive
         self.capitalization = capitalization
         self.autocorrect = autocorrect
         self.enable_suggestions = enable_suggestions
@@ -431,6 +435,15 @@ class TextField(FormFieldControl):
     @autofocus.setter
     def autofocus(self, value: Optional[bool]):
         self._set_attr("autofocus", value)
+
+    # adaptive
+    @property
+    def adaptive(self) -> Optional[bool]:
+        return self._get_attr("adaptive", data_type="bool", def_value=False)
+
+    @adaptive.setter
+    def adaptive(self, value: Optional[bool]):
+        self._set_attr("adaptive", value)
 
     # capitalization
     @property


### PR DESCRIPTION
Closes #2376 

TestCode:
```py
import flet as ft


def main(page: ft.Page):
    page.window_always_on_top = True
    page.theme_mode = ft.ThemeMode.LIGHT

    page.add(
        ft.CupertinoTextField(
            bgcolor=ft.colors.BLUE_100,
            shadow=ft.BoxShadow(color=ft.colors.RED_400, blur_radius=5, spread_radius=5),
            on_change=lambda e: print("CupertinoTextField change = ", e.control.value),
            placeholder_text="Enter text here",
            suffix=ft.Icon(ft.icons.EDIT),
            suffix_visibility_mode=ft.VisibilityMode.EDITING,
        ),
    )


ft.app(target=main)
```
