### PR TITLE
Allow the `color` and `bgcolor` of `FilledButton` and `FilledTonalButton` to be set through the `style`

### DIFF
--- a/sdk/python/packages/flet-core/src/flet_core/elevated_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/elevated_button.py
@@ -149,9 +149,21 @@ class ElevatedButton(ConstrainedControl):
             if self.__style is None:
                 self.__style = ButtonStyle()
             if self.__style.color != self.__color or self.disabled:
-                self.__style.color = self.__color if not self.disabled else None
+                # if the color is set through the style, use it
+                if not (
+                    self.__class__.__name__ in ["FilledButton", "FilledTonalButton"]
+                    and self.__style.color
+                    and not self.disabled
+                ):
+                    self.__style.color = self.__color if not self.disabled else None
             if self.__style.bgcolor != self.__bgcolor or self.disabled:
-                self.__style.bgcolor = self.__bgcolor if not self.disabled else None
+                # if the bgcolor is set through the style, use it
+                if not (
+                    self.__class__.__name__ in ["FilledButton", "FilledTonalButton"]
+                    and self.__style.bgcolor
+                    and not self.disabled
+                ):
+                    self.__style.bgcolor = self.__bgcolor if not self.disabled else None
             if self.__style.elevation != self.__elevation:
                 self.__style.elevation = self.__elevation
         if self.__style is not None:


### PR DESCRIPTION
Closes https://github.com/flet-dev/flet/issues/2268

Test code:
```py
import flet as ft


def main(page: ft.Page):
    page.window_always_on_top = True
    page.theme_mode = ft.ThemeMode.LIGHT

    page.add(
        ft.FilledButton(
            "Material",
            icon=ft.icons.ACCESSIBILITY,
            style=ft.ButtonStyle(bgcolor=ft.colors.GREEN, color=ft.colors.BLUE_ACCENT),
        ),
        ft.FilledTonalButton(
            "Material",
            icon=ft.icons.ACCESSIBILITY,
            style=ft.ButtonStyle(bgcolor=ft.colors.RED, color=ft.colors.YELLOW),
        ),
    )


ft.app(target=main)
```
