### PR TITLE
`CupertinoButton` Control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@
 # VS Code
 .vscode/
 
+# Pycharm Files
+.idea/
+
 # mac specific
 .DS_Store
 *.bkp

--- a/package/lib/src/controls/create_control.dart
+++ b/package/lib/src/controls/create_control.dart
@@ -31,6 +31,7 @@ import 'clipboard.dart';
 import 'column.dart';
 import 'container.dart';
 import 'cupertino_alert_dialog.dart';
+import 'cupertino_button.dart';
 import 'cupertino_checkbox.dart';
 import 'cupertino_dialog_action.dart';
 import 'cupertino_list_tile.dart';
@@ -284,6 +285,13 @@ Widget createWidget(Key? key, ControlViewModel controlView, Control? parent,
           key: key, parent: parent, control: controlView.control);
     case "elevatedbutton":
       return ElevatedButtonControl(
+          key: key,
+          parent: parent,
+          control: controlView.control,
+          children: controlView.children,
+          parentDisabled: parentDisabled);
+    case "cupertinobutton":
+      return CupertinoButtonControl(
           key: key,
           parent: parent,
           control: controlView.control,

--- a/package/lib/src/controls/cupertino_button.dart
+++ b/package/lib/src/controls/cupertino_button.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+import '../models/control.dart';
+import '../utils/alignment.dart';
+import '../utils/borders.dart';
+import '../utils/colors.dart';
+import '../utils/edge_insets.dart';
+import '../utils/launch_url.dart';
+import 'create_control.dart';
+import 'error.dart';
+import 'flet_control_stateful_mixin.dart';
+
+class CupertinoButtonControl extends StatefulWidget {
+  final Control? parent;
+  final Control control;
+  final List<Control> children;
+  final bool parentDisabled;
+
+  const CupertinoButtonControl(
+      {super.key,
+      this.parent,
+      required this.control,
+      required this.children,
+      required this.parentDisabled});
+
+  @override
+  State<CupertinoButtonControl> createState() => _CupertinoButtonControlState();
+}
+
+class _CupertinoButtonControlState extends State<CupertinoButtonControl>
+    with FletControlStatefulMixin {
+  @override
+  Widget build(BuildContext context) {
+    debugPrint("CupertinoButton build: ${widget.control.id}");
+
+    var contentCtrls = widget.children.where((c) => c.name == "content");
+    if (contentCtrls.isEmpty) {
+      return const ErrorControl(
+          "CupertinoButton has no content control. Please specify one.");
+    }
+    String url = widget.control.attrString("url", "")!;
+    Color? disabledColor = HexColor.fromString(
+        Theme.of(context), widget.control.attrString("disabledColor", "")!);
+    Color? bgColor = HexColor.fromString(
+        Theme.of(context), widget.control.attrString("bgColor", "")!);
+    bool disabled = widget.control.isDisabled || widget.parentDisabled;
+
+    Function()? onPressed = !disabled
+        ? () {
+            debugPrint("Button ${widget.control.id} clicked!");
+            if (url != "") {
+              openWebBrowser(url,
+                  webWindowName: widget.control.attrString("urlTarget"));
+            }
+            sendControlEvent(widget.control.id, "click", "");
+          }
+        : null;
+
+    CupertinoButton? button;
+
+    button = CupertinoButton(
+      onPressed: onPressed,
+      disabledColor: disabledColor ?? CupertinoColors.quaternarySystemFill,
+      color: bgColor,
+      padding: parseEdgeInsets(widget.control, "padding"),
+      borderRadius: parseBorderRadius(widget.control, "borderRadius") ?? const BorderRadius.all(Radius.circular(8.0)),
+      pressedOpacity: widget.control.attrDouble("opacityOnClick", 0.4),
+      alignment:
+          parseAlignment(widget.control, "alignment") ?? Alignment.center,
+      minSize: widget.control.attrDouble("minSize", 44.0),
+      child: createControl(widget.control, contentCtrls.first.id, disabled),
+    );
+
+    return constrainedControl(context, button, widget.parent, widget.control);
+  }
+}

--- a/package/lib/src/controls/cupertino_button.dart
+++ b/package/lib/src/controls/cupertino_button.dart
@@ -33,18 +33,29 @@ class _CupertinoButtonControlState extends State<CupertinoButtonControl>
   @override
   Widget build(BuildContext context) {
     debugPrint("CupertinoButton build: ${widget.control.id}");
+    bool disabled = widget.control.isDisabled || widget.parentDisabled;
 
     var contentCtrls = widget.children.where((c) => c.name == "content");
     if (contentCtrls.isEmpty) {
       return const ErrorControl(
           "CupertinoButton has no content control. Please specify one.");
     }
+
+    bool filled = widget.control.attrBool("filled", false)!;
+    double pressedOpacity = widget.control.attrDouble("opacityOnClick", 0.4)!;
+    double minSize = widget.control.attrDouble("minSize", 44.0)!;
     String url = widget.control.attrString("url", "")!;
-    Color? disabledColor = HexColor.fromString(
-        Theme.of(context), widget.control.attrString("disabledColor", "")!);
+    EdgeInsets? padding = parseEdgeInsets(widget.control, "padding");
+    Color disabledColor = HexColor.fromString(Theme.of(context),
+            widget.control.attrString("disabledColor", "")!) ??
+        CupertinoColors.quaternarySystemFill;
     Color? bgColor = HexColor.fromString(
         Theme.of(context), widget.control.attrString("bgColor", "")!);
-    bool disabled = widget.control.isDisabled || widget.parentDisabled;
+    AlignmentGeometry alignment =
+        parseAlignment(widget.control, "alignment") ?? Alignment.center;
+    BorderRadius borderRadius =
+        parseBorderRadius(widget.control, "borderRadius") ??
+            const BorderRadius.all(Radius.circular(8.0));
 
     Function()? onPressed = !disabled
         ? () {
@@ -59,18 +70,30 @@ class _CupertinoButtonControlState extends State<CupertinoButtonControl>
 
     CupertinoButton? button;
 
-    button = CupertinoButton(
-      onPressed: onPressed,
-      disabledColor: disabledColor ?? CupertinoColors.quaternarySystemFill,
-      color: bgColor,
-      padding: parseEdgeInsets(widget.control, "padding"),
-      borderRadius: parseBorderRadius(widget.control, "borderRadius") ?? const BorderRadius.all(Radius.circular(8.0)),
-      pressedOpacity: widget.control.attrDouble("opacityOnClick", 0.4),
-      alignment:
-          parseAlignment(widget.control, "alignment") ?? Alignment.center,
-      minSize: widget.control.attrDouble("minSize", 44.0),
-      child: createControl(widget.control, contentCtrls.first.id, disabled),
-    );
+    button = !filled
+        ? CupertinoButton(
+            onPressed: onPressed,
+            disabledColor: disabledColor,
+            color: bgColor,
+            padding: padding,
+            borderRadius: borderRadius,
+            pressedOpacity: pressedOpacity,
+            alignment: alignment,
+            minSize: minSize,
+            child:
+                createControl(widget.control, contentCtrls.first.id, disabled),
+          )
+        : CupertinoButton.filled(
+            onPressed: onPressed,
+            disabledColor: disabledColor,
+            padding: padding,
+            borderRadius: borderRadius,
+            pressedOpacity: pressedOpacity,
+            alignment: alignment,
+            minSize: minSize,
+            child:
+                createControl(widget.control, contentCtrls.first.id, disabled),
+          );
 
     return constrainedControl(context, button, widget.parent, widget.control);
   }

--- a/package/lib/src/controls/elevated_button.dart
+++ b/package/lib/src/controls/elevated_button.dart
@@ -1,3 +1,4 @@
+import 'package:flet/src/controls/cupertino_button.dart';
 import 'package:flutter/material.dart';
 
 import '../models/control.dart';
@@ -8,6 +9,7 @@ import '../utils/launch_url.dart';
 import 'create_control.dart';
 import 'error.dart';
 import 'flet_control_stateful_mixin.dart';
+import 'flet_store_mixin.dart';
 
 class ElevatedButtonControl extends StatefulWidget {
   final Control? parent;
@@ -27,7 +29,7 @@ class ElevatedButtonControl extends StatefulWidget {
 }
 
 class _ElevatedButtonControlState extends State<ElevatedButtonControl>
-    with FletControlStatefulMixin {
+    with FletControlStatefulMixin, FletStoreMixin {
   late final FocusNode _focusNode;
   String? _lastFocusValue;
 
@@ -54,103 +56,116 @@ class _ElevatedButtonControlState extends State<ElevatedButtonControl>
   Widget build(BuildContext context) {
     debugPrint("Button build: ${widget.control.id}");
 
-    String text = widget.control.attrString("text", "")!;
-    String url = widget.control.attrString("url", "")!;
-    IconData? icon = parseIcon(widget.control.attrString("icon", "")!);
-    Color? iconColor = HexColor.fromString(
-        Theme.of(context), widget.control.attrString("iconColor", "")!);
-    var contentCtrls = widget.children.where((c) => c.name == "content");
-    bool onHover = widget.control.attrBool("onHover", false)!;
-    bool onLongPress = widget.control.attrBool("onLongPress", false)!;
-    bool autofocus = widget.control.attrBool("autofocus", false)!;
-    bool disabled = widget.control.isDisabled || widget.parentDisabled;
-
-    Function()? onPressed = !disabled
-        ? () {
-            debugPrint("Button ${widget.control.id} clicked!");
-            if (url != "") {
-              openWebBrowser(url,
-                  webWindowName: widget.control.attrString("urlTarget"));
-            }
-            sendControlEvent(widget.control.id, "click", "");
-          }
-        : null;
-
-    Function()? onLongPressHandler = onLongPress && !disabled
-        ? () {
-            debugPrint("Button ${widget.control.id} long pressed!");
-            sendControlEvent(widget.control.id, "long_press", "");
-          }
-        : null;
-
-    Function(bool)? onHoverHandler = onHover && !disabled
-        ? (state) {
-            debugPrint("Button ${widget.control.id} hovered!");
-            sendControlEvent(widget.control.id, "hover", state.toString());
-          }
-        : null;
-
-    ElevatedButton? button;
-
-    var theme = Theme.of(context);
-
-    var style = parseButtonStyle(Theme.of(context), widget.control, "style",
-        defaultForegroundColor: theme.colorScheme.primary,
-        defaultBackgroundColor: theme.colorScheme.surface,
-        defaultOverlayColor: theme.colorScheme.primary.withOpacity(0.08),
-        defaultShadowColor: theme.colorScheme.shadow,
-        defaultSurfaceTintColor: theme.colorScheme.surfaceTint,
-        defaultElevation: 1,
-        defaultPadding: const EdgeInsets.symmetric(horizontal: 8),
-        defaultBorderSide: BorderSide.none,
-        defaultShape: theme.useMaterial3
-            ? const StadiumBorder()
-            : RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)));
-
-    if (icon != null) {
-      if (text == "") {
-        return const ErrorControl("Error displaying ElevatedButton",
-            description: "\"icon\" must be specified together with \"text\".");
+    return withPagePlatform((context, platform) {
+      bool adaptive = widget.control.attrBool("adaptive", false)!;
+      if (adaptive &&
+          (platform == TargetPlatform.iOS ||
+              platform == TargetPlatform.macOS)) {
+        return CupertinoButtonControl(
+            control: widget.control,
+            parentDisabled: widget.parentDisabled,
+            children: widget.children);
       }
-      button = ElevatedButton.icon(
-          style: style,
-          autofocus: autofocus,
-          focusNode: _focusNode,
-          onPressed: onPressed,
-          onLongPress: onLongPressHandler,
-          onHover: onHoverHandler,
-          icon: Icon(
-            icon,
-            color: iconColor,
-          ),
-          label: Text(text));
-    } else if (contentCtrls.isNotEmpty) {
-      button = ElevatedButton(
-          style: style,
-          autofocus: autofocus,
-          focusNode: _focusNode,
-          onPressed: onPressed,
-          onLongPress: onLongPressHandler,
-          onHover: onHoverHandler,
-          child:
-              createControl(widget.control, contentCtrls.first.id, disabled));
-    } else {
-      button = ElevatedButton(
-          style: style,
-          autofocus: autofocus,
-          focusNode: _focusNode,
-          onPressed: onPressed,
-          onLongPress: onLongPressHandler,
-          onHover: onHoverHandler,
-          child: Text(text));
-    }
 
-    var focusValue = widget.control.attrString("focus");
-    if (focusValue != null && focusValue != _lastFocusValue) {
-      _lastFocusValue = focusValue;
-      _focusNode.requestFocus();
-    }
+      String text = widget.control.attrString("text", "")!;
+      String url = widget.control.attrString("url", "")!;
+      IconData? icon = parseIcon(widget.control.attrString("icon", "")!);
+      Color? iconColor = HexColor.fromString(
+          Theme.of(context), widget.control.attrString("iconColor", "")!);
+      var contentCtrls = widget.children.where((c) => c.name == "content");
+      bool onHover = widget.control.attrBool("onHover", false)!;
+      bool onLongPress = widget.control.attrBool("onLongPress", false)!;
+      bool autofocus = widget.control.attrBool("autofocus", false)!;
+      bool disabled = widget.control.isDisabled || widget.parentDisabled;
 
-    return constrainedControl(context, button, widget.parent, widget.control);
+      Function()? onPressed = !disabled
+          ? () {
+              debugPrint("Button ${widget.control.id} clicked!");
+              if (url != "") {
+                openWebBrowser(url,
+                    webWindowName: widget.control.attrString("urlTarget"));
+              }
+              sendControlEvent(widget.control.id, "click", "");
+            }
+          : null;
+
+      Function()? onLongPressHandler = onLongPress && !disabled
+          ? () {
+              debugPrint("Button ${widget.control.id} long pressed!");
+              sendControlEvent(widget.control.id, "long_press", "");
+            }
+          : null;
+
+      Function(bool)? onHoverHandler = onHover && !disabled
+          ? (state) {
+              debugPrint("Button ${widget.control.id} hovered!");
+              sendControlEvent(widget.control.id, "hover", state.toString());
+            }
+          : null;
+
+      ElevatedButton? button;
+
+      var theme = Theme.of(context);
+
+      var style = parseButtonStyle(Theme.of(context), widget.control, "style",
+          defaultForegroundColor: theme.colorScheme.primary,
+          defaultBackgroundColor: theme.colorScheme.surface,
+          defaultOverlayColor: theme.colorScheme.primary.withOpacity(0.08),
+          defaultShadowColor: theme.colorScheme.shadow,
+          defaultSurfaceTintColor: theme.colorScheme.surfaceTint,
+          defaultElevation: 1,
+          defaultPadding: const EdgeInsets.symmetric(horizontal: 8),
+          defaultBorderSide: BorderSide.none,
+          defaultShape: theme.useMaterial3
+              ? const StadiumBorder()
+              : RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)));
+
+      if (icon != null) {
+        if (text == "") {
+          return const ErrorControl("Error displaying ElevatedButton",
+              description:
+                  "\"icon\" must be specified together with \"text\".");
+        }
+        button = ElevatedButton.icon(
+            style: style,
+            autofocus: autofocus,
+            focusNode: _focusNode,
+            onPressed: onPressed,
+            onLongPress: onLongPressHandler,
+            onHover: onHoverHandler,
+            icon: Icon(
+              icon,
+              color: iconColor,
+            ),
+            label: Text(text));
+      } else if (contentCtrls.isNotEmpty) {
+        button = ElevatedButton(
+            style: style,
+            autofocus: autofocus,
+            focusNode: _focusNode,
+            onPressed: onPressed,
+            onLongPress: onLongPressHandler,
+            onHover: onHoverHandler,
+            child:
+                createControl(widget.control, contentCtrls.first.id, disabled));
+      } else {
+        button = ElevatedButton(
+            style: style,
+            autofocus: autofocus,
+            focusNode: _focusNode,
+            onPressed: onPressed,
+            onLongPress: onLongPressHandler,
+            onHover: onHoverHandler,
+            child: Text(text));
+      }
+
+      var focusValue = widget.control.attrString("focus");
+      if (focusValue != null && focusValue != _lastFocusValue) {
+        _lastFocusValue = focusValue;
+        _focusNode.requestFocus();
+      }
+
+      return constrainedControl(context, button, widget.parent, widget.control);
+    });
   }
 }

--- a/sdk/python/packages/flet-core/src/flet_core/__init__.py
+++ b/sdk/python/packages/flet-core/src/flet_core/__init__.py
@@ -66,6 +66,7 @@ from flet_core.control import Control, OptionalNumber
 from flet_core.control_event import ControlEvent
 from flet_core.cupertino_alert_dialog import CupertinoAlertDialog
 from flet_core.cupertino_app_bar import CupertinoAppBar
+from flet_core.cupertino_button import CupertinoButton
 from flet_core.cupertino_checkbox import CupertinoCheckbox
 from flet_core.cupertino_dialog_action import CupertinoDialogAction
 from flet_core.cupertino_list_tile import CupertinoListTile

--- a/sdk/python/packages/flet-core/src/flet_core/control.py
+++ b/sdk/python/packages/flet-core/src/flet_core/control.py
@@ -227,6 +227,7 @@ class Control:
 
     @opacity.setter
     def opacity(self, value):
+        value = max(0.0, min(value, 1.0))  # make sure 0.0 <= value <= 1.0
         self._set_attr("opacity", value)
 
     # tooltip

--- a/sdk/python/packages/flet-core/src/flet_core/control.py
+++ b/sdk/python/packages/flet-core/src/flet_core/control.py
@@ -227,7 +227,8 @@ class Control:
 
     @opacity.setter
     def opacity(self, value):
-        value = max(0.0, min(value, 1.0))  # make sure 0.0 <= value <= 1.0
+        if value is not None:
+            value = max(0.0, min(value, 1.0))  # make sure 0.0 <= value <= 1.0
         self._set_attr("opacity", value)
 
     # tooltip

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_button.py
@@ -26,6 +26,19 @@ class CupertinoButton(ConstrainedControl):
 
     def __init__(
         self,
+        content: Optional[Control] = None,
+        bgcolor: Optional[str] = None,
+        disabled_color: Optional[str] = None,
+        opacity_on_click: OptionalNumber = None,
+        padding: PaddingValue = None,
+        alignment: Optional[Alignment] = None,
+        border_radius: BorderRadiusValue = None,
+        url: Optional[str] = None,
+        url_target: Optional[str] = None,
+        on_click=None,
+        #
+        # Common
+        #
         ref: Optional[Ref] = None,
         key: Optional[str] = None,
         width: OptionalNumber = None,
@@ -52,19 +65,6 @@ class CupertinoButton(ConstrainedControl):
         visible: Optional[bool] = None,
         disabled: Optional[bool] = None,
         data: Any = None,
-        #
-        # Specific
-        #
-        content: Optional[Control] = None,
-        bgcolor: Optional[str] = None,
-        disabled_color: Optional[str] = None,
-        opacity_on_click: OptionalNumber = None,
-        padding: PaddingValue = None,
-        alignment: Optional[Alignment] = None,
-        border_radius: BorderRadiusValue = None,
-        url: Optional[str] = None,
-        url_target: Optional[str] = None,
-        on_click=None,
     ):
         ConstrainedControl.__init__(
             self,

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_button.py
@@ -147,7 +147,8 @@ class CupertinoButton(ConstrainedControl):
 
     @opacity_on_click.setter
     def opacity_on_click(self, value: OptionalNumber):
-        value = max(0.0, min(value, 1.0))  # make sure 0.0 <= value <= 1.0
+        if value is not None:
+            value = max(0.0, min(value, 1.0))  # make sure 0.0 <= value <= 1.0
         self._set_attr("opacityOnClick", value)
 
     # border_radius

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_button.py
@@ -29,6 +29,7 @@ class CupertinoButton(ConstrainedControl):
         content: Optional[Control] = None,
         bgcolor: Optional[str] = None,
         disabled_color: Optional[str] = None,
+        filled: Optional[bool] = None,
         opacity_on_click: OptionalNumber = None,
         padding: PaddingValue = None,
         alignment: Optional[Alignment] = None,
@@ -99,6 +100,7 @@ class CupertinoButton(ConstrainedControl):
         self.disabled_color = disabled_color
         self.bgcolor = bgcolor
         self.border_radius = border_radius
+        self.filled = filled
         self.opacity_on_click = opacity_on_click
         self.padding = padding
         self.alignment = alignment
@@ -133,12 +135,21 @@ class CupertinoButton(ConstrainedControl):
 
     # disabled_color
     @property
-    def disabled_color(self):
+    def disabled_color(self) -> Optional[str]:
         return self._get_attr("disabledColor")
 
     @disabled_color.setter
-    def disabled_color(self, value):
+    def disabled_color(self, value: Optional[str]):
         self._set_attr("disabledColor", value)
+
+    # filled
+    @property
+    def filled(self) -> bool:
+        return self._get_attr("filled", data_type="bool", def_value=False)
+
+    @filled.setter
+    def filled(self, value: bool):
+        self._set_attr("filled", value)
 
     # opacity_on_click
     @property
@@ -180,11 +191,11 @@ class CupertinoButton(ConstrainedControl):
 
     # bgcolor
     @property
-    def bgcolor(self):
+    def bgcolor(self) -> Optional[str]:
         return self._get_attr("bgColor")
 
     @bgcolor.setter
-    def bgcolor(self, value):
+    def bgcolor(self, value: Optional[str]):
         self._set_attr("bgColor", value)
 
     # url

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_button.py
@@ -31,6 +31,7 @@ class CupertinoButton(ConstrainedControl):
         disabled_color: Optional[str] = None,
         filled: Optional[bool] = None,
         opacity_on_click: OptionalNumber = None,
+        min_size: OptionalNumber = None,
         padding: PaddingValue = None,
         alignment: Optional[Alignment] = None,
         border_radius: BorderRadiusValue = None,
@@ -100,6 +101,7 @@ class CupertinoButton(ConstrainedControl):
         self.disabled_color = disabled_color
         self.bgcolor = bgcolor
         self.border_radius = border_radius
+        self.min_size = min_size
         self.filled = filled
         self.opacity_on_click = opacity_on_click
         self.padding = padding

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_button.py
@@ -1,0 +1,222 @@
+from typing import Any, Optional, Union
+
+from flet_core.alignment import Alignment
+from flet_core.constrained_control import ConstrainedControl
+from flet_core.control import Control, OptionalNumber
+from flet_core.ref import Ref
+from flet_core.types import (
+    AnimationValue,
+    OffsetValue,
+    ResponsiveNumber,
+    RotateValue,
+    ScaleValue,
+    PaddingValue,
+    BorderRadiusValue,
+)
+
+
+class CupertinoButton(ConstrainedControl):
+    """
+    An iOS-style button.
+
+    -----
+
+    Online docs: https://flet.dev/docs/controls/cupertinobutton
+    """
+
+    def __init__(
+        self,
+        ref: Optional[Ref] = None,
+        key: Optional[str] = None,
+        width: OptionalNumber = None,
+        height: OptionalNumber = None,
+        left: OptionalNumber = None,
+        top: OptionalNumber = None,
+        right: OptionalNumber = None,
+        bottom: OptionalNumber = None,
+        expand: Union[None, bool, int] = None,
+        col: Optional[ResponsiveNumber] = None,
+        opacity: OptionalNumber = None,
+        rotate: RotateValue = None,
+        scale: ScaleValue = None,
+        offset: OffsetValue = None,
+        aspect_ratio: OptionalNumber = None,
+        animate_opacity: AnimationValue = None,
+        animate_size: AnimationValue = None,
+        animate_position: AnimationValue = None,
+        animate_rotation: AnimationValue = None,
+        animate_scale: AnimationValue = None,
+        animate_offset: AnimationValue = None,
+        on_animation_end=None,
+        tooltip: Optional[str] = None,
+        visible: Optional[bool] = None,
+        disabled: Optional[bool] = None,
+        data: Any = None,
+        #
+        # Specific
+        #
+        content: Optional[Control] = None,
+        bgcolor: Optional[str] = None,
+        disabled_color: Optional[str] = None,
+        opacity_on_click: OptionalNumber = None,
+        padding: PaddingValue = None,
+        alignment: Optional[Alignment] = None,
+        border_radius: BorderRadiusValue = None,
+        url: Optional[str] = None,
+        url_target: Optional[str] = None,
+        on_click=None,
+    ):
+        ConstrainedControl.__init__(
+            self,
+            ref=ref,
+            key=key,
+            width=width,
+            height=height,
+            left=left,
+            top=top,
+            right=right,
+            bottom=bottom,
+            expand=expand,
+            col=col,
+            opacity=opacity,
+            rotate=rotate,
+            scale=scale,
+            offset=offset,
+            aspect_ratio=aspect_ratio,
+            animate_opacity=animate_opacity,
+            animate_size=animate_size,
+            animate_position=animate_position,
+            animate_rotation=animate_rotation,
+            animate_scale=animate_scale,
+            animate_offset=animate_offset,
+            on_animation_end=on_animation_end,
+            tooltip=tooltip,
+            visible=visible,
+            disabled=disabled,
+            data=data,
+        )
+
+        self.disabled_color = disabled_color
+        self.bgcolor = bgcolor
+        self.border_radius = border_radius
+        self.opacity_on_click = opacity_on_click
+        self.padding = padding
+        self.alignment = alignment
+        self.content = content
+        self.url = url
+        self.url_target = url_target
+        self.on_click = on_click
+
+    def _get_control_name(self):
+        return "cupertinobutton"
+
+    def _before_build_command(self):
+        super()._before_build_command()
+        self._set_attr_json("padding", self.__padding)
+        self._set_attr_json("borderRadius", self.__border_radius)
+        self._set_attr_json("alignment", self.__alignment)
+
+    def _get_children(self):
+        if self.__content is None:
+            return []
+        self.__content._set_attr_internal("n", "content")
+        return [self.__content]
+
+    # alignment
+    @property
+    def alignment(self) -> Optional[Alignment]:
+        return self.__alignment
+
+    @alignment.setter
+    def alignment(self, value: Optional[Alignment]):
+        self.__alignment = value
+
+    # disabled_color
+    @property
+    def disabled_color(self):
+        return self._get_attr("disabledColor")
+
+    @disabled_color.setter
+    def disabled_color(self, value):
+        self._set_attr("disabledColor", value)
+
+    # opacity_on_click
+    @property
+    def opacity_on_click(self) -> OptionalNumber:
+        return self._get_attr("opacityOnClick", data_type="float", def_value=0.4)
+
+    @opacity_on_click.setter
+    def opacity_on_click(self, value: OptionalNumber):
+        self._set_attr("opacityOnClick", value)
+
+    # border_radius
+    @property
+    def border_radius(self) -> BorderRadiusValue:
+        return self.__border_radius
+
+    @border_radius.setter
+    def border_radius(self, value: BorderRadiusValue):
+        self.__border_radius = value
+
+    # min_size
+    @property
+    def min_size(self) -> OptionalNumber:
+        return self._get_attr("minSize", data_type="float", def_value=44.0)
+
+    @min_size.setter
+    def min_size(self, value: OptionalNumber):
+        self._set_attr("minSize", value)
+
+    # padding
+    @property
+    def padding(self) -> PaddingValue:
+        return self.__padding
+
+    @padding.setter
+    def padding(self, value: PaddingValue):
+        self.__padding = value
+
+    # bgcolor
+    @property
+    def bgcolor(self):
+        return self._get_attr("bgColor")
+
+    @bgcolor.setter
+    def bgcolor(self, value):
+        self._set_attr("bgColor", value)
+
+    # url
+    @property
+    def url(self):
+        return self._get_attr("url")
+
+    @url.setter
+    def url(self, value):
+        self._set_attr("url", value)
+
+    # url_target
+    @property
+    def url_target(self):
+        return self._get_attr("urlTarget")
+
+    @url_target.setter
+    def url_target(self, value):
+        self._set_attr("urlTarget", value)
+
+    # on_click
+    @property
+    def on_click(self):
+        return self._get_event_handler("click")
+
+    @on_click.setter
+    def on_click(self, handler):
+        self._add_event_handler("click", handler)
+
+    # content
+    @property
+    def content(self) -> Optional[Control]:
+        return self.__content
+
+    @content.setter
+    def content(self, value: Optional[Control]):
+        self.__content = value

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_button.py
@@ -147,6 +147,7 @@ class CupertinoButton(ConstrainedControl):
 
     @opacity_on_click.setter
     def opacity_on_click(self, value: OptionalNumber):
+        value = max(0.0, min(value, 1.0))  # make sure 0.0 <= value <= 1.0
         self._set_attr("opacityOnClick", value)
 
     # border_radius

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_button.py
@@ -6,12 +6,12 @@ from flet_core.control import Control, OptionalNumber
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
+    BorderRadiusValue,
     OffsetValue,
+    PaddingValue,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
-    PaddingValue,
-    BorderRadiusValue,
 )
 
 

--- a/sdk/python/packages/flet-core/src/flet_core/elevated_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/elevated_button.py
@@ -1,5 +1,6 @@
-import time
 from typing import Any, Optional, Union
+
+import time
 
 from flet_core.buttons import ButtonStyle
 from flet_core.constrained_control import ConstrainedControl
@@ -77,6 +78,7 @@ class ElevatedButton(ConstrainedControl):
         icon_color: Optional[str] = None,
         content: Optional[Control] = None,
         autofocus: Optional[bool] = None,
+        adaptive: Optional[bool] = None,
         url: Optional[str] = None,
         url_target: Optional[str] = None,
         on_click=None,
@@ -128,6 +130,7 @@ class ElevatedButton(ConstrainedControl):
         self.icon_color = icon_color
         self.content = content
         self.autofocus = autofocus
+        self.adaptive = adaptive
         self.url = url
         self.url_target = url_target
         self.on_click = on_click
@@ -211,6 +214,7 @@ class ElevatedButton(ConstrainedControl):
     @bgcolor.setter
     def bgcolor(self, value):
         self.__bgcolor = value
+        self._set_attr("bgColor", value)
 
     # elevation
     @property
@@ -302,6 +306,15 @@ class ElevatedButton(ConstrainedControl):
     @autofocus.setter
     def autofocus(self, value: Optional[bool]):
         self._set_attr("autofocus", value)
+
+    # adaptive
+    @property
+    def adaptive(self) -> Optional[bool]:
+        return self._get_attr("adaptive", data_type="bool", def_value=False)
+
+    @adaptive.setter
+    def adaptive(self, value: Optional[bool]):
+        self._set_attr("adaptive", value)
 
     # on_hover
     @property


### PR DESCRIPTION
Closes #2377 

Test code:
```python
import flet as ft


def main(page: ft.Page):
    page.theme_mode = ft.ThemeMode.LIGHT
    page.window_always_on_top = True

    page.add(
        ft.CupertinoButton(
            on_click=lambda e: print("CupertinoButton clicked!"),
            alignment=ft.alignment.top_left,
            content=ft.Text("Test", color=ft.colors.YELLOW),
            bgcolor=ft.cupertino_colors.SECONDARY_LABEL,
            border_radius=ft.border_radius.all(15),
            opacity_on_click=None,
            filled=True
        ),
        ft.ElevatedButton(
            width=200,
            bgcolor=ft.cupertino_colors.ACTIVE_ORANGE,
            adaptive=True,
            content=ft.Row(
                [
                    ft.Icon(name=ft.icons.FAVORITE, color="pink"),
                    ft.Icon(name=ft.icons.AUDIOTRACK, color="green"),
                    ft.Icon(name=ft.icons.BEACH_ACCESS, color="blue"),
                ],
                alignment=ft.MainAxisAlignment.SPACE_AROUND,
            ),
        )
    )


ft.app(target=main)
```
