### PR TITLE
`TextField.text_vertical_align` property

### DIFF
--- a/package/lib/src/controls/cupertino_textfield.dart
+++ b/package/lib/src/controls/cupertino_textfield.dart
@@ -36,7 +36,6 @@ class CupertinoTextFieldControl extends StatefulWidget {
 class _CupertinoTextFieldControlState extends State<CupertinoTextFieldControl>
     with FletControlStatefulMixin {
   String _value = "";
-  final bool _revealPassword = false;
   bool _focused = false;
   late TextEditingController _controller;
   late final FocusNode _focusNode;
@@ -252,7 +251,7 @@ class _CupertinoTextFieldControlState extends State<CupertinoTextFieldControl>
             : null,
         readOnly: readOnly,
         inputFormatters: inputFormatters.isNotEmpty ? inputFormatters : null,
-        obscureText: password && !_revealPassword,
+        obscureText: password,
         controller: _controller,
         focusNode: focusNode,
         onChanged: (String value) {

--- a/package/lib/src/controls/cupertino_textfield.dart
+++ b/package/lib/src/controls/cupertino_textfield.dart
@@ -173,6 +173,7 @@ class _CupertinoTextFieldControlState extends State<CupertinoTextFieldControl>
 
     double? textVerticalAlign = widget.control.attrDouble("textVerticalAlign");
 
+    bool rtl = widget.control.attrBool("rtl", false)!;
     bool autocorrect = widget.control.attrBool("autocorrect", true)!;
     bool enableSuggestions =
         widget.control.attrBool("enableSuggestions", true)!;
@@ -250,6 +251,7 @@ class _CupertinoTextFieldControlState extends State<CupertinoTextFieldControl>
             ? createControl(widget.control, suffixControls.first.id, disabled)
             : null,
         readOnly: readOnly,
+        textDirection: rtl ? TextDirection.rtl : null,
         inputFormatters: inputFormatters.isNotEmpty ? inputFormatters : null,
         obscureText: password,
         controller: _controller,

--- a/package/lib/src/controls/cupertino_textfield.dart
+++ b/package/lib/src/controls/cupertino_textfield.dart
@@ -172,6 +172,8 @@ class _CupertinoTextFieldControlState extends State<CupertinoTextFieldControl>
       orElse: () => TextAlign.start,
     );
 
+    double? textVerticalAlign = widget.control.attrDouble("textVerticalAlign");
+
     bool autocorrect = widget.control.attrBool("autocorrect", true)!;
     bool enableSuggestions =
         widget.control.attrBool("enableSuggestions", true)!;
@@ -198,6 +200,9 @@ class _CupertinoTextFieldControlState extends State<CupertinoTextFieldControl>
 
     Widget textField = CupertinoTextField(
         style: textStyle,
+        textAlignVertical: textVerticalAlign != null
+            ? TextAlignVertical(y: textVerticalAlign)
+            : null,
         placeholder: widget.control.attrString("placeholderText"),
         placeholderStyle: parseTextStyle(
             Theme.of(context), widget.control, "placeholderStyle"),

--- a/package/lib/src/controls/textfield.dart
+++ b/package/lib/src/controls/textfield.dart
@@ -201,6 +201,9 @@ class _TextFieldControlState extends State<TextFieldControl>
         orElse: () => TextAlign.start,
       );
 
+      double? textVerticalAlign =
+          widget.control.attrDouble("textVerticalAlign");
+
       TextDirection? textDirection = TextDirection.values.firstWhereOrNull(
           ((b) =>
               b.name ==
@@ -237,8 +240,9 @@ class _TextFieldControlState extends State<TextFieldControl>
               revealPasswordIcon,
               _focused),
           showCursor: widget.control.attrBool("showCursor"),
-          textAlignVertical: TextAlignVertical(
-              y: widget.control.attrDouble("textVerticalAlign") ?? 0.0),
+          textAlignVertical: textVerticalAlign != null
+              ? TextAlignVertical(y: textVerticalAlign)
+              : null,
           textDirection: textDirection,
           cursorHeight: widget.control.attrDouble("cursorHeight"),
           cursorWidth: widget.control.attrDouble("cursorWidth") ?? 2.0,

--- a/package/lib/src/controls/textfield.dart
+++ b/package/lib/src/controls/textfield.dart
@@ -231,6 +231,7 @@ class _TextFieldControlState extends State<TextFieldControl>
               revealPasswordIcon,
               _focused),
           showCursor: widget.control.attrBool("showCursor"),
+          textAlignVertical: TextAlignVertical(y: widget.control.attrDouble("textVerticalAlign") ?? 0.0),
           cursorHeight: widget.control.attrDouble("cursorHeight"),
           cursorWidth: widget.control.attrDouble("cursorWidth") ?? 2.0,
           cursorRadius: parseRadius(widget.control, "cursorRadius"),

--- a/package/lib/src/controls/textfield.dart
+++ b/package/lib/src/controls/textfield.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -200,6 +201,11 @@ class _TextFieldControlState extends State<TextFieldControl>
         orElse: () => TextAlign.start,
       );
 
+      TextDirection? textDirection = TextDirection.values.firstWhereOrNull(
+          ((b) =>
+              b.name ==
+              widget.control.attrString("textDirection", "")!.toLowerCase()));
+
       bool autocorrect = widget.control.attrBool("autocorrect", true)!;
       bool enableSuggestions =
           widget.control.attrBool("enableSuggestions", true)!;
@@ -231,7 +237,9 @@ class _TextFieldControlState extends State<TextFieldControl>
               revealPasswordIcon,
               _focused),
           showCursor: widget.control.attrBool("showCursor"),
-          textAlignVertical: TextAlignVertical(y: widget.control.attrDouble("textVerticalAlign") ?? 0.0),
+          textAlignVertical: TextAlignVertical(
+              y: widget.control.attrDouble("textVerticalAlign") ?? 0.0),
+          textDirection: textDirection,
           cursorHeight: widget.control.attrDouble("cursorHeight"),
           cursorWidth: widget.control.attrDouble("cursorWidth") ?? 2.0,
           cursorRadius: parseRadius(widget.control, "cursorRadius"),

--- a/package/lib/src/controls/textfield.dart
+++ b/package/lib/src/controls/textfield.dart
@@ -1,4 +1,3 @@
-import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -204,11 +203,7 @@ class _TextFieldControlState extends State<TextFieldControl>
       double? textVerticalAlign =
           widget.control.attrDouble("textVerticalAlign");
 
-      TextDirection? textDirection = TextDirection.values.firstWhereOrNull(
-          ((b) =>
-              b.name ==
-              widget.control.attrString("textDirection", "")!.toLowerCase()));
-
+      bool rtl = widget.control.attrBool("rtl", false)!;
       bool autocorrect = widget.control.attrBool("autocorrect", true)!;
       bool enableSuggestions =
           widget.control.attrBool("enableSuggestions", true)!;
@@ -243,7 +238,7 @@ class _TextFieldControlState extends State<TextFieldControl>
           textAlignVertical: textVerticalAlign != null
               ? TextAlignVertical(y: textVerticalAlign)
               : null,
-          textDirection: textDirection,
+          textDirection: rtl ? TextDirection.rtl : null,
           cursorHeight: widget.control.attrDouble("cursorHeight"),
           cursorWidth: widget.control.attrDouble("cursorWidth") ?? 2.0,
           cursorRadius: parseRadius(widget.control, "cursorRadius"),

--- a/sdk/python/packages/flet-core/src/flet_core/__init__.py
+++ b/sdk/python/packages/flet-core/src/flet_core/__init__.py
@@ -239,7 +239,6 @@ from flet_core.types import (
     ScrollMode,
     TabAlignment,
     TextAlign,
-    TextDirection,
     ThemeMode,
     VerticalAlignment,
 )

--- a/sdk/python/packages/flet-core/src/flet_core/__init__.py
+++ b/sdk/python/packages/flet-core/src/flet_core/__init__.py
@@ -239,6 +239,7 @@ from flet_core.types import (
     ScrollMode,
     TabAlignment,
     TextAlign,
+    TextDirection,
     ThemeMode,
     VerticalAlignment,
 )

--- a/sdk/python/packages/flet-core/src/flet_core/__init__.py
+++ b/sdk/python/packages/flet-core/src/flet_core/__init__.py
@@ -240,6 +240,7 @@ from flet_core.types import (
     TabAlignment,
     TextAlign,
     ThemeMode,
+    VerticalAlignment,
 )
 from flet_core.user_control import UserControl
 from flet_core.vertical_divider import VerticalDivider

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_textfield.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_textfield.py
@@ -64,6 +64,7 @@ class CupertinoTextField(TextField):
         #
         value: Optional[str] = None,
         keyboard_type: Optional[KeyboardType] = None,
+        rtl: Optional[bool] = None,
         multiline: Optional[bool] = None,
         min_lines: Optional[int] = None,
         max_lines: Optional[int] = None,
@@ -211,6 +212,7 @@ class CupertinoTextField(TextField):
             #
             value=value,
             keyboard_type=keyboard_type,
+            rtl=rtl,
             multiline=multiline,
             min_lines=min_lines,
             max_lines=max_lines,

--- a/sdk/python/packages/flet-core/src/flet_core/form_field_control.py
+++ b/sdk/python/packages/flet-core/src/flet_core/form_field_control.py
@@ -13,6 +13,7 @@ from flet_core.types import (
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
+    VerticalAlignment,
 )
 
 try:
@@ -63,6 +64,7 @@ class FormFieldControl(ConstrainedControl):
         #
         text_size: OptionalNumber = None,
         text_style: Optional[TextStyle] = None,
+        text_vertical_align: Union[VerticalAlignment, OptionalNumber] = None,
         label: Optional[str] = None,
         label_style: Optional[TextStyle] = None,
         icon: Optional[str] = None,
@@ -128,6 +130,7 @@ class FormFieldControl(ConstrainedControl):
 
         self.text_size = text_size
         self.text_style = text_style
+        self.text_vertical_align = text_vertical_align
         self.label = label
         self.label_style = label_style
         self.icon = icon
@@ -289,6 +292,18 @@ class FormFieldControl(ConstrainedControl):
     @border_color.setter
     def border_color(self, value):
         self._set_attr("borderColor", value)
+
+    # text_vertical_align
+    @property
+    def text_vertical_align(self) -> Union[VerticalAlignment, OptionalNumber]:
+        return self._get_attr("textVerticalAlign")
+
+    @text_vertical_align.setter
+    def text_vertical_align(self, value: Union[VerticalAlignment, OptionalNumber]):
+        v = value.value if isinstance(value, VerticalAlignment) else value
+        if v is not None:
+            v = max(-1.0, min(v, 1.0))  # make sure 0.0 <= value <= 1.0
+        self._set_attr("textVerticalAlign", v)
 
     # focused_color
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/textfield.py
+++ b/sdk/python/packages/flet-core/src/flet_core/textfield.py
@@ -18,9 +18,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     TextAlign,
-    TextAlignString,
     VerticalAlignment,
-    TextDirection,
 )
 
 try:
@@ -183,7 +181,7 @@ class TextField(FormFieldControl):
         adaptive: Optional[bool] = None,
         value: Optional[str] = None,
         keyboard_type: Optional[KeyboardType] = None,
-        text_direction: Optional[TextDirection] = None,
+        rtl: Optional[bool] = None,
         multiline: Optional[bool] = None,
         min_lines: Optional[int] = None,
         max_lines: Optional[int] = None,
@@ -278,7 +276,7 @@ class TextField(FormFieldControl):
         self.text_style = text_style
         self.keyboard_type = keyboard_type
         self.text_align = text_align
-        self.text_direction = text_direction
+        self.rtl = rtl
         self.multiline = multiline
         self.min_lines = min_lines
         self.max_lines = max_lines
@@ -356,25 +354,16 @@ class TextField(FormFieldControl):
     @text_align.setter
     def text_align(self, value: TextAlign):
         self.__text_align = value
-        if isinstance(value, TextAlign):
-            self._set_attr("textAlign", value.value)
-        else:
-            self.__set_text_align(value)
+        self._set_attr("textAlign", value.value if isinstance(value, TextAlign) else value)
 
-    # text_direction
+    # rtl
     @property
-    def text_direction(self) -> Optional[TextDirection]:
-        return self.__text_direction
+    def rtl(self) -> Optional[bool]:
+        return self._get_attr("rtl", data_type="bool", def_value=False)
 
-    @text_direction.setter
-    def text_direction(self, value: Optional[TextDirection]):
-        self.__text_direction = value
-        self._set_attr(
-            "textDirection", value.value if isinstance(value, TextDirection) else value
-        )
-
-    def __set_text_align(self, value: TextAlignString):
-        self._set_attr("textAlign", value)
+    @rtl.setter
+    def rtl(self, value: Optional[bool]):
+        self._set_attr("rtl", value)
 
     # multiline
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/textfield.py
+++ b/sdk/python/packages/flet-core/src/flet_core/textfield.py
@@ -1,8 +1,9 @@
 import dataclasses
-import time
 from dataclasses import field
 from enum import Enum
 from typing import Any, Optional, Union
+
+import time
 
 from flet_core.control import Control, OptionalNumber
 from flet_core.form_field_control import FormFieldControl, InputBorder
@@ -18,6 +19,7 @@ from flet_core.types import (
     ScaleValue,
     TextAlign,
     TextAlignString,
+    VerticalAlignment,
 )
 
 try:
@@ -141,6 +143,7 @@ class TextField(FormFieldControl):
         #
         text_size: OptionalNumber = None,
         text_style: Optional[TextStyle] = None,
+        text_vertical_align: Union[VerticalAlignment, OptionalNumber] = None,
         label: Optional[str] = None,
         label_style: Optional[TextStyle] = None,
         icon: Optional[str] = None,
@@ -235,6 +238,7 @@ class TextField(FormFieldControl):
             #
             text_size=text_size,
             text_style=text_style,
+            text_vertical_align=text_vertical_align,
             label=label,
             label_style=label_style,
             icon=icon,

--- a/sdk/python/packages/flet-core/src/flet_core/textfield.py
+++ b/sdk/python/packages/flet-core/src/flet_core/textfield.py
@@ -20,6 +20,7 @@ from flet_core.types import (
     TextAlign,
     TextAlignString,
     VerticalAlignment,
+    TextDirection,
 )
 
 try:
@@ -182,6 +183,7 @@ class TextField(FormFieldControl):
         adaptive: Optional[bool] = None,
         value: Optional[str] = None,
         keyboard_type: Optional[KeyboardType] = None,
+        text_direction: Optional[TextDirection] = None,
         multiline: Optional[bool] = None,
         min_lines: Optional[int] = None,
         max_lines: Optional[int] = None,
@@ -276,6 +278,7 @@ class TextField(FormFieldControl):
         self.text_style = text_style
         self.keyboard_type = keyboard_type
         self.text_align = text_align
+        self.text_direction = text_direction
         self.multiline = multiline
         self.min_lines = min_lines
         self.max_lines = max_lines
@@ -357,6 +360,18 @@ class TextField(FormFieldControl):
             self._set_attr("textAlign", value.value)
         else:
             self.__set_text_align(value)
+
+    # text_direction
+    @property
+    def text_direction(self) -> Optional[TextDirection]:
+        return self.__text_direction
+
+    @text_direction.setter
+    def text_direction(self, value: Optional[TextDirection]):
+        self.__text_direction = value
+        self._set_attr(
+            "textDirection", value.value if isinstance(value, TextDirection) else value
+        )
 
     def __set_text_align(self, value: TextAlignString):
         self._set_attr("textAlign", value)

--- a/sdk/python/packages/flet-core/src/flet_core/types.py
+++ b/sdk/python/packages/flet-core/src/flet_core/types.py
@@ -139,6 +139,13 @@ class CrossAxisAlignment(Enum):
     BASELINE = "baseline"
 
 
+class VerticalAlignment(Enum):
+    NONE = None
+    START = -1.0
+    END = 1.0
+    CENTER = 0.0
+
+
 class TabAlignment(Enum):
     NONE = None
     START = "start"

--- a/sdk/python/packages/flet-core/src/flet_core/types.py
+++ b/sdk/python/packages/flet-core/src/flet_core/types.py
@@ -256,11 +256,6 @@ class ScrollMode(Enum):
     HIDDEN = "hidden"
 
 
-class TextDirection(Enum):
-    LTR = "ltr"
-    RTL = "rtl"
-
-
 ClipBehaviorString = Literal[
     None, "none", "antiAlias", "antiAliasWithSaveLayer", "hardEdge"
 ]

--- a/sdk/python/packages/flet-core/src/flet_core/types.py
+++ b/sdk/python/packages/flet-core/src/flet_core/types.py
@@ -256,6 +256,11 @@ class ScrollMode(Enum):
     HIDDEN = "hidden"
 
 
+class TextDirection(Enum):
+    LTR = "ltr"
+    RTL = "rtl"
+
+
 ClipBehaviorString = Literal[
     None, "none", "antiAlias", "antiAliasWithSaveLayer", "hardEdge"
 ]


### PR DESCRIPTION
Closes #1242 

TestCode:
```python
import flet as ft


def main(page: ft.Page):
    page.theme_mode = ft.ThemeMode.LIGHT
    page.window_always_on_top = True

    page.add(
        ft.TextField(
            value="Hello, World!",
            text_vertical_align=ft.VerticalAlignment.END,
            prefix_icon=ft.icons.EMOJI_EMOTIONS,
        )
    )


ft.app(target=main)
```
