### PR TITLE
Introduce `Control.on_update()` overridable method

### DIFF
--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -129,6 +129,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  cupertino_icons:
+    dependency: "direct main"
+    description:
+      name: cupertino_icons
+      sha256: d57953e10f9f8327ce64a508a355f0b1ec902193f66288e8cb5070e7c47eeb2d
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.6"
   equatable:
     dependency: transitive
     description:

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -35,6 +35,8 @@ dependencies:
 
   url_strategy: ^0.2.0
   record: ^5.0.4
+  cupertino_icons: ^1.0.6
+  
   integration_test:
     sdk: flutter
 

--- a/sdk/python/packages/flet-core/src/flet_core/control.py
+++ b/sdk/python/packages/flet-core/src/flet_core/control.py
@@ -58,6 +58,9 @@ class Control:
     def _build(self):
         pass
 
+    def on_update(self):
+        pass
+
     def _before_build_command(self):
         self._set_attr_json("col", self.__col)
 
@@ -441,6 +444,8 @@ class Control:
 
     # private methods
     def _build_add_commands(self, indent=0, index=None, added_controls=None):
+        if index:
+            self.page = index["page"]
         self._build()
 
         # remove control from index
@@ -478,6 +483,7 @@ class Control:
             return command
 
         self._before_build_command()
+        self.on_update()
 
         for attrName in sorted(self.__attrs):
             attrName = attrName.lower()

--- a/sdk/python/packages/flet-core/src/flet_core/page.py
+++ b/sdk/python/packages/flet-core/src/flet_core/page.py
@@ -460,7 +460,6 @@ class Page(Control):
             for line in results:
                 for id in line.split(" "):
                     added_controls[n]._Control__uid = id
-                    added_controls[n].page = self
 
                     # add to index
                     self._index[id] = added_controls[n]


### PR DESCRIPTION
* Set `control.page` as soon as possible, so its instance is available in `control.on_update()` method.

Code sample where `on_update()` is used in a custom control:

```python
import flet as ft


def main(page):
    class AdaptiveIconButton(ft.IconButton):
        def __init__(self, ios_icon, android_icon):
            super().__init__()
            self._ios_icon = ios_icon
            self._android_icon = android_icon

        def on_update(self):
            self.icon = (
                self._ios_icon
                if self.page.platform == ft.PagePlatform.IOS
                or self.page.platform == ft.PagePlatform.MACOS
                else self._android_icon
            )

    def set_android(e):
        page.platform = ft.PagePlatform.ANDROID
        page.update()
        print("New platform:", page.platform)

    def set_ios(e):
        page.platform = "ios"
        page.update()
        print("New platform:", page.platform)

    add_icon = AdaptiveIconButton(
        ios_icon=ft.cupertino_icons.AIRPLANE, android_icon=ft.icons.ADD
    )
    page.add(add_icon)
    page.adaptive = True

    page.add(
        ft.Switch(label="Switch A", adaptive=True),
        ft.ElevatedButton(
            "Set Android", on_click=set_android, content=ft.Text("Set Android")
        ),
        ft.ElevatedButton("Set iOS", on_click=set_ios, content=ft.Text("Set iOS")),
    )

    print("Default platform:", page.platform)


ft.app(target=main)
```