### PR TITLE
`AppBar.system_overlay_style` prop

### DIFF
--- a/packages/flet/lib/src/controls/app_bar.dart
+++ b/packages/flet/lib/src/controls/app_bar.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../models/control.dart';
 import '../utils/colors.dart';
+import '../utils/overlay_style.dart';
 import 'create_control.dart';
 import 'cupertino_app_bar.dart';
 import 'flet_store_mixin.dart';
@@ -58,6 +59,8 @@ class AppBarControl extends StatelessWidget
           Theme.of(context), control.attrString("color", "")!);
       var bgcolor = HexColor.fromString(
           Theme.of(context), control.attrString("bgcolor", "")!);
+      var systemOverlayStyle = parseSystemOverlayStyle(
+          Theme.of(context), control, "systemOverlayStyle");
 
       return AppBar(
         leading: leadingCtrls.isNotEmpty
@@ -79,6 +82,7 @@ class AppBarControl extends StatelessWidget
             .map((c) => createControl(control, c.id, control.isDisabled,
                 parentAdaptive: adaptive))
             .toList(),
+        systemOverlayStyle: systemOverlayStyle,
       );
     });
   }

--- a/packages/flet/lib/src/utils/overlay_style.dart
+++ b/packages/flet/lib/src/utils/overlay_style.dart
@@ -1,0 +1,43 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../models/control.dart';
+import '../utils/numbers.dart';
+import 'colors.dart';
+
+SystemUiOverlayStyle? parseSystemOverlayStyle(
+    ThemeData theme, Control control, String propName) {
+  dynamic j;
+  var v = control.attrString(propName, null);
+  if (v == null) {
+    return null;
+  }
+  j = json.decode(v);
+  return overlayStyleFromJson(theme, j);
+}
+
+SystemUiOverlayStyle overlayStyleFromJson(
+    ThemeData theme, Map<String, dynamic> json) {
+  return SystemUiOverlayStyle(
+    statusBarColor: json["status_bar_color"] != null
+        ? HexColor.fromString(theme, json["status_bar_color"] ?? "")
+        : null,
+    systemNavigationBarColor: json["system_navigation_bar_color"] != null
+        ? HexColor.fromString(theme, json["system_navigation_bar_color"] ?? "")
+        : null,
+    systemNavigationBarDividerColor:
+        json["system_navigation_bar_divider_color"] != null
+            ? HexColor.fromString(theme, json["system_navigation_bar_divider_color"] ?? "")
+            : null,
+    systemStatusBarContrastEnforced:
+        json["enforce_system_status_bar_contrast"] != null
+            ? parseBool(json["enforce_system_status_bar_contrast"])
+            : null,
+    systemNavigationBarContrastEnforced:
+        json["enforce_system_navigation_bar_contrast"] != null
+            ? parseBool(json["enforce_system_navigation_bar_contrast"])
+            : null,
+  );
+}

--- a/sdk/python/packages/flet-core/src/flet_core/__init__.py
+++ b/sdk/python/packages/flet-core/src/flet_core/__init__.py
@@ -20,7 +20,7 @@ from flet_core.alert_dialog import AlertDialog
 from flet_core.alignment import Alignment
 from flet_core.animated_switcher import AnimatedSwitcher, AnimatedSwitcherTransition
 from flet_core.animation import Animation, AnimationCurve
-from flet_core.app_bar import AppBar
+from flet_core.app_bar import AppBar, SystemOverlayStyle
 from flet_core.audio import Audio
 from flet_core.audio_recorder import AudioEncoder, AudioRecorder
 from flet_core.badge import Badge

--- a/sdk/python/packages/flet-core/src/flet_core/__init__.py
+++ b/sdk/python/packages/flet-core/src/flet_core/__init__.py
@@ -247,7 +247,7 @@ from flet_core.types import (
 )
 from flet_core.user_control import UserControl
 from flet_core.vertical_divider import VerticalDivider
-from flet_core.video import FilterQuality, Video, VideoMedia
+from flet_core.video import FilterQuality, PlaylistMode, Video, VideoMedia
 from flet_core.view import View
 from flet_core.webview import WebView
 from flet_core.window_drag_area import WindowDragArea

--- a/sdk/python/packages/flet-core/src/flet_core/app_bar.py
+++ b/sdk/python/packages/flet-core/src/flet_core/app_bar.py
@@ -1,8 +1,19 @@
+import dataclasses
+from dataclasses import field
 from typing import List, Optional
 
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.control import Control, OptionalNumber
 from flet_core.ref import Ref
+
+
+@dataclasses.dataclass
+class SystemOverlayStyle:
+    status_bar_color: Optional[str] = field(default=None)
+    system_navigation_bar_color: Optional[str] = field(default=None)
+    system_navigation_bar_divider_color: Optional[str] = field(default=None)
+    enforce_system_navigation_bar_contrast: Optional[bool] = field(default=None)
+    enforce_system_status_bar_contrast: Optional[bool] = field(default=None)
 
 
 class AppBar(AdaptiveControl):
@@ -60,6 +71,7 @@ class AppBar(AdaptiveControl):
         toolbar_height: OptionalNumber = None,
         color: Optional[str] = None,
         bgcolor: Optional[str] = None,
+        system_overlay_style: Optional[SystemOverlayStyle] = None,
         elevation: OptionalNumber = None,
         actions: Optional[List[Control]] = None,
         adaptive: Optional[bool] = None,
@@ -82,9 +94,15 @@ class AppBar(AdaptiveControl):
         self.bgcolor = bgcolor
         self.elevation = elevation
         self.actions = actions
+        self.system_overlay_style = system_overlay_style
 
     def _get_control_name(self):
         return "appbar"
+
+    def _before_build_command(self):
+        super()._before_build_command()
+        if dataclasses.is_dataclass(self.__system_overlay_style):
+            self._set_attr_json("systemOverlayStyle", self.__system_overlay_style)
 
     def _get_children(self):
         children = []
@@ -141,6 +159,15 @@ class AppBar(AdaptiveControl):
     @title.setter
     def title(self, value: Optional[Control]):
         self.__title = value
+
+    # system_overlay_style
+    @property
+    def system_overlay_style(self) -> Optional[SystemOverlayStyle]:
+        return self.__system_overlay_style
+
+    @system_overlay_style.setter
+    def system_overlay_style(self, value: Optional[SystemOverlayStyle]):
+        self.__system_overlay_style = value
 
     # center_title
     @property


### PR DESCRIPTION
Closes https://github.com/flet-dev/flet/issues/2573
**Test Code:**
```py
import flet as ft


def main(page: ft.Page):

    page.appbar = ft.AppBar(
        leading=ft.Icon(ft.icons.PALETTE),
        leading_width=40,
        title=ft.Text("AppBar Example"),
        center_title=False,
        bgcolor=ft.colors.SURFACE_VARIANT,
        system_overlay_style=ft.SystemOverlayStyle(
            status_bar_color=ft.colors.YELLOW,
            system_navigation_bar_color=ft.colors.GREEN,
            system_navigation_bar_divider_color=ft.colors.BLUE_ACCENT,
            enforce_system_navigation_bar_contrast=True,
            enforce_system_status_bar_contrast=True,
        ),
    )
    page.add(ft.Text("Body!"))


ft.app(target=main)
```
<img src="https://github.com/flet-dev/flet/assets/98978078/03f9a15c-ae8f-46fb-ab7c-65ec6c826e35" height=600>

