### PR TITLE
Fix container.dart for issue #2628

### DIFF
--- a/packages/flet/lib/src/controls/container.dart
+++ b/packages/flet/lib/src/controls/container.dart
@@ -66,6 +66,7 @@ class ContainerControl extends StatelessWidget with FletStoreMixin {
         children.where((c) => c.name == "content" && c.isVisible);
     bool ink = control.attrBool("ink", false)!;
     bool onClick = control.attrBool("onclick", false)!;
+    bool onTap = control.attrBool("ontap", false)!;
     String url = control.attrString("url", "")!;
     String? urlTarget = control.attrString("urlTarget");
     bool onLongPress = control.attrBool("onLongPress", false)!;
@@ -145,7 +146,7 @@ class ContainerControl extends StatelessWidget with FletStoreMixin {
 
       Widget? result;
 
-      if ((onClick || url != "" || onLongPress || onHover) &&
+      if ((onTap || onClick || url != "" || onLongPress || onHover) &&
           ink &&
           !disabled) {
         var ink = Material(
@@ -155,7 +156,12 @@ class ContainerControl extends StatelessWidget with FletStoreMixin {
               // Dummy callback to enable widget
               // see https://github.com/flutter/flutter/issues/50116#issuecomment-582047374
               // and https://github.com/flutter/flutter/blob/eed80afe2c641fb14b82a22279d2d78c19661787/packages/flutter/lib/src/material/ink_well.dart#L1125-L1129
-              onTap: onHover ? () {} : null,
+              onTap: onTap
+                  ? () {
+                      debugPrint("Container ${control.id} Tap!");
+                      backend.triggerControlEvent(control.id, "tap", "");
+                    }
+                  : null,
               onTapDown: onClick || url != ""
                   ? (details) {
                       debugPrint("Container ${control.id} clicked!");
@@ -189,6 +195,8 @@ class ContainerControl extends StatelessWidget with FletStoreMixin {
                     }
                   : null,
               borderRadius: borderRadius,
+              splashColor: HexColor.fromString(
+                  Theme.of(context), control.attrString("inkColor", "")!),
               child: Container(
                 padding: parseEdgeInsets(control, "padding"),
                 alignment: parseAlignment(control, "alignment"),
@@ -249,9 +257,10 @@ class ContainerControl extends StatelessWidget with FletStoreMixin {
                     : null,
                 child: child);
 
-        if ((onClick || onLongPress || onHover || url != "") && !disabled) {
+        if ((onTap || onClick || onLongPress || onHover || url != "") &&
+            !disabled) {
           result = MouseRegion(
-            cursor: onClick || url != ""
+            cursor: onTap || onClick || url != ""
                 ? SystemMouseCursors.click
                 : MouseCursor.defer,
             onEnter: onHover
@@ -269,6 +278,12 @@ class ContainerControl extends StatelessWidget with FletStoreMixin {
                   }
                 : null,
             child: GestureDetector(
+              onTap: onTap
+                  ? () {
+                      debugPrint("Container ${control.id} onTap!");
+                      backend.triggerControlEvent(control.id, "ontap", "");
+                    }
+                  : null,
               onTapDown: onClick || url != ""
                   ? (details) {
                       debugPrint("Container ${control.id} clicked!");

--- a/packages/flet/lib/src/controls/container.dart
+++ b/packages/flet/lib/src/controls/container.dart
@@ -148,8 +148,9 @@ class ContainerControl extends StatelessWidget with FletStoreMixin {
       if ((onClick || url != "" || onLongPress || onHover) &&
           ink &&
           !disabled) {
-        var ink = Ink(
-            decoration: boxDecor,
+        var ink = Material(
+            color: Colors.transparent,
+            borderRadius: boxDecor.borderRadius,
             child: InkWell(
               // Dummy callback to enable widget
               // see https://github.com/flutter/flutter/issues/50116#issuecomment-582047374
@@ -202,6 +203,7 @@ class ContainerControl extends StatelessWidget with FletStoreMixin {
                 height: control.attrDouble("height"),
                 margin: parseEdgeInsets(control, "margin"),
                 clipBehavior: Clip.none,
+                decoration: boxDecor,
                 child: ink,
               )
             : AnimatedContainer(

--- a/sdk/python/packages/flet-core/src/flet_core/container.py
+++ b/sdk/python/packages/flet-core/src/flet_core/container.py
@@ -112,6 +112,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         shape: Optional[BoxShape] = None,
         clip_behavior: Optional[ClipBehavior] = None,
         ink: Optional[bool] = None,
+        ink_color: Optional[str] = None,
         animate: AnimationValue = None,
         blur: Union[
             None, float, int, Tuple[Union[float, int], Union[float, int]], Blur
@@ -121,6 +122,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         url_target: Optional[str] = None,
         theme: Optional[Theme] = None,
         theme_mode: Optional[ThemeMode] = None,
+        on_release=None,
         on_click=None,
         on_long_press=None,
         on_hover=None,
@@ -167,6 +169,8 @@ class Container(ConstrainedControl, AdaptiveControl):
             d = json.loads(e.data)
             return ContainerTapEvent(**d)
 
+        self.__on_release = EventHandler(convert_container_tap_event_data)
+        self._add_event_handler("tap", self.__on_release.get_handler())
         self.__on_click = EventHandler(convert_container_tap_event_data)
         self._add_event_handler("click", self.__on_click.get_handler())
 
@@ -187,6 +191,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         self.shape = shape
         self.clip_behavior = clip_behavior
         self.ink = ink
+        self.ink_color = ink_color
         self.animate = animate
         self.blur = blur
         self.shadow = shadow
@@ -194,6 +199,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         self.url_target = url_target
         self.theme = theme
         self.theme_mode = theme_mode
+        self.on_release = on_release
         self.on_click = on_click
         self.on_long_press = on_long_press
         self.on_hover = on_hover
@@ -430,6 +436,15 @@ class Container(ConstrainedControl, AdaptiveControl):
     def ink(self, value: Optional[bool]):
         self._set_attr("ink", value)
 
+    # ink color
+    @property
+    def ink_color(self):
+        return self._get_attr("inkColor")
+
+    @ink_color.setter
+    def ink_color(self, value):
+        self._set_attr("inkColor", value)
+
     # animate
     @property
     def animate(self) -> AnimationValue:
@@ -475,6 +490,16 @@ class Container(ConstrainedControl, AdaptiveControl):
     def theme_mode(self, value: Optional[ThemeMode]):
         self.__theme_mode = value
         self._set_attr("themeMode", value.value if value is not None else None)
+
+    # on_release
+    @property
+    def on_release(self):
+        return self._get_event_handler("tap")
+
+    @on_release.setter
+    def on_release(self, handler):
+        self._add_event_handler("tap", handler)
+        self._set_attr("onTap", True if handler is not None else None)
 
     # on_click
     @property


### PR DESCRIPTION
**Fix for Issue :** #2628 
The `Ink` or `InkWell` widget must have a [Material](https://api.flutter.dev/flutter/material/Material-class.html) widget as an ancestor.

seems `container.dart` doesn't have:
https://github.com/flet-dev/flet/blob/fe1a4d15fb31065231941ad737da551f8c6e9940/packages/flet/lib/src/controls/container.dart#L151-L153

so i try to wrap `InkWell` with `Material` :
https://github.com/flet-dev/flet/pull/2701/files#diff-3d2babe2e48d8eaf9b1c35294b8c498c905a03e16f8e490258b215a98e5ec568R151-R154

i also remove `Ink` cause Flet already use `Container` as parent, because `Container` can take a `BoxDecoration` as i read [this](https://stackoverflow.com/a/52228086)

This is how i fix this issue, hopefully it will help.