### PR TITLE
`label_style` property for `Checkbox`, `Switch`, and `Radio` 

### DIFF
--- a/packages/flet/lib/src/controls/checkbox.dart
+++ b/packages/flet/lib/src/controls/checkbox.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../flet_control_backend.dart';
 import '../models/control.dart';
 import '../utils/colors.dart';
+import '../utils/text.dart';
 import 'create_control.dart';
 import 'cupertino_checkbox.dart';
 import 'flet_store_mixin.dart';
@@ -107,6 +108,12 @@ class _CheckboxControlState extends State<CheckboxControl> with FletStoreMixin {
         _value = value;
       }
 
+      TextStyle? labelStyle =
+          parseTextStyle(Theme.of(context), widget.control, "labelStyle");
+      if (disabled && labelStyle != null) {
+        labelStyle = labelStyle.apply(color: Theme.of(context).disabledColor);
+      }
+
       var checkbox = Checkbox(
           autofocus: autofocus,
           focusNode: _focusNode,
@@ -137,9 +144,10 @@ class _CheckboxControlState extends State<CheckboxControl> with FletStoreMixin {
       Widget result = checkbox;
       if (label != "") {
         var labelWidget = disabled
-            ? Text(label,
-                style: TextStyle(color: Theme.of(context).disabledColor))
-            : MouseRegion(cursor: SystemMouseCursors.click, child: Text(label));
+            ? Text(label, style: labelStyle)
+            : MouseRegion(
+                cursor: SystemMouseCursors.click,
+                child: Text(label, style: labelStyle));
         result = MergeSemantics(
             child: GestureDetector(
                 onTap: !disabled ? _toggleValue : null,

--- a/packages/flet/lib/src/controls/radio.dart
+++ b/packages/flet/lib/src/controls/radio.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../flet_control_backend.dart';
 import '../models/control.dart';
 import '../utils/colors.dart';
+import '../utils/text.dart';
 import 'create_control.dart';
 import 'cupertino_radio.dart';
 import 'error.dart';
@@ -85,6 +86,12 @@ class _RadioControlState extends State<RadioControl> with FletStoreMixin {
       bool autofocus = widget.control.attrBool("autofocus", false)!;
       bool disabled = widget.control.isDisabled || widget.parentDisabled;
 
+      TextStyle? labelStyle =
+          parseTextStyle(Theme.of(context), widget.control, "labelStyle");
+      if (disabled && labelStyle != null) {
+        labelStyle = labelStyle.apply(color: Theme.of(context).disabledColor);
+      }
+
       return withControlAncestor(widget.control.id, "radiogroup",
           (context, viewModel) {
         debugPrint("Radio StoreConnector build: ${widget.control.id}");
@@ -119,10 +126,10 @@ class _RadioControlState extends State<RadioControl> with FletStoreMixin {
         Widget result = radio;
         if (label != "") {
           var labelWidget = disabled
-              ? Text(label,
-                  style: TextStyle(color: Theme.of(context).disabledColor))
+              ? Text(label, style: labelStyle)
               : MouseRegion(
-                  cursor: SystemMouseCursors.click, child: Text(label));
+                  cursor: SystemMouseCursors.click,
+                  child: Text(label, style: labelStyle));
           result = MergeSemantics(
               child: GestureDetector(
                   onTap: !disabled

--- a/packages/flet/lib/src/controls/switch.dart
+++ b/packages/flet/lib/src/controls/switch.dart
@@ -4,6 +4,7 @@ import '../flet_control_backend.dart';
 import '../models/control.dart';
 import '../utils/colors.dart';
 import '../utils/icons.dart';
+import '../utils/text.dart';
 import 'create_control.dart';
 import 'cupertino_switch.dart';
 import 'flet_store_mixin.dart';
@@ -86,6 +87,12 @@ class _SwitchControlState extends State<SwitchControl> with FletStoreMixin {
       bool autofocus = widget.control.attrBool("autofocus", false)!;
       bool disabled = widget.control.isDisabled || widget.parentDisabled;
 
+      TextStyle? labelStyle =
+          parseTextStyle(Theme.of(context), widget.control, "labelStyle");
+      if (disabled && labelStyle != null) {
+        labelStyle = labelStyle.apply(color: Theme.of(context).disabledColor);
+      }
+
       debugPrint("Switch build: ${widget.control.id}");
 
       bool value = widget.control.attrBool("value", false)!;
@@ -126,9 +133,10 @@ class _SwitchControlState extends State<SwitchControl> with FletStoreMixin {
       Widget result = swtch;
       if (label != "") {
         var labelWidget = disabled
-            ? Text(label,
-                style: TextStyle(color: Theme.of(context).disabledColor))
-            : MouseRegion(cursor: SystemMouseCursors.click, child: Text(label));
+            ? Text(label, style: labelStyle)
+            : MouseRegion(
+                cursor: SystemMouseCursors.click,
+                child: Text(label, style: labelStyle));
         result = MergeSemantics(
             child: GestureDetector(
                 onTap: !disabled

--- a/sdk/python/packages/flet-core/src/flet_core/checkbox.py
+++ b/sdk/python/packages/flet-core/src/flet_core/checkbox.py
@@ -1,9 +1,11 @@
+import dataclasses
 from typing import Any, Dict, Optional, Union
 
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.constrained_control import ConstrainedControl
 from flet_core.control import OptionalNumber
 from flet_core.ref import Ref
+from flet_core.text_style import TextStyle
 from flet_core.types import (
     AnimationValue,
     LabelPosition,
@@ -83,6 +85,7 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
         # Specific
         #
         label: Optional[str] = None,
+        label_style: Optional[TextStyle] = None,
         label_position: LabelPosition = LabelPosition.NONE,
         value: Optional[bool] = None,
         tristate: Optional[bool] = None,
@@ -134,6 +137,7 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
         self.value = value
         self.tristate = tristate
         self.label = label
+        self.label_style = label_style
         self.label_position = label_position
         self.autofocus = autofocus
         self.check_color = check_color
@@ -153,6 +157,8 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
         super()._before_build_command()
         self._set_attr_json("fillColor", self.__fill_color)
         self._set_attr_json("overlayColor", self.__overlay_color)
+        if dataclasses.is_dataclass(self.__label_style):
+            self._set_attr_json("labelStyle", self.__label_style)
 
     # value
     @property
@@ -261,6 +267,15 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
     @overlay_color.setter
     def overlay_color(self, value: Union[None, str, Dict[MaterialState, str]]):
         self.__overlay_color = value
+
+    # label_style
+    @property
+    def label_style(self) -> Optional[TextStyle]:
+        return self.__label_style
+
+    @label_style.setter
+    def label_style(self, value: Optional[TextStyle]):
+        self.__label_style = value
 
     # on_change
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/radio.py
+++ b/sdk/python/packages/flet-core/src/flet_core/radio.py
@@ -1,9 +1,11 @@
+import dataclasses
 from typing import Any, Dict, Optional, Union
 
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.constrained_control import ConstrainedControl
 from flet_core.control import OptionalNumber
 from flet_core.ref import Ref
+from flet_core.text_style import TextStyle
 from flet_core.types import (
     AnimationValue,
     LabelPosition,
@@ -84,6 +86,7 @@ class Radio(ConstrainedControl, AdaptiveControl):
         # Specific
         #
         label: Optional[str] = None,
+        label_style: Optional[TextStyle] = None,
         label_position: LabelPosition = LabelPosition.NONE,
         value: Optional[str] = None,
         autofocus: Optional[bool] = None,
@@ -128,6 +131,7 @@ class Radio(ConstrainedControl, AdaptiveControl):
 
         self.value = value
         self.label = label
+        self.label_style = label_style
         self.label_position = label_position
         self.autofocus = autofocus
         self.fill_color = fill_color
@@ -141,6 +145,8 @@ class Radio(ConstrainedControl, AdaptiveControl):
     def _before_build_command(self):
         super()._before_build_command()
         self._set_attr_json("fillColor", self.__fill_color)
+        if dataclasses.is_dataclass(self.__label_style):
+            self._set_attr_json("labelStyle", self.__label_style)
 
     # value
     @property
@@ -184,6 +190,15 @@ class Radio(ConstrainedControl, AdaptiveControl):
 
     def __set_label_position(self, value: LabelPositionString):
         self._set_attr("labelPosition", value)
+
+    # label_style
+    @property
+    def label_style(self) -> Optional[TextStyle]:
+        return self.__label_style
+
+    @label_style.setter
+    def label_style(self, value: Optional[TextStyle]):
+        self.__label_style = value
 
     # fill_color
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/switch.py
+++ b/sdk/python/packages/flet-core/src/flet_core/switch.py
@@ -1,9 +1,11 @@
+import dataclasses
 from typing import Any, Dict, Optional, Union
 
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.constrained_control import ConstrainedControl
 from flet_core.control import OptionalNumber
 from flet_core.ref import Ref
+from flet_core.text_style import TextStyle
 from flet_core.types import (
     AnimationValue,
     LabelPosition,
@@ -83,6 +85,7 @@ class Switch(ConstrainedControl, AdaptiveControl):
         # Specific
         #
         label: Optional[str] = None,
+        label_style: Optional[TextStyle] = None,
         label_position: LabelPosition = LabelPosition.NONE,
         value: Optional[bool] = None,
         autofocus: Optional[bool] = None,
@@ -134,6 +137,7 @@ class Switch(ConstrainedControl, AdaptiveControl):
 
         self.value = value
         self.label = label
+        self.label_style = label_style
         self.label_position = label_position
         self.autofocus = autofocus
         self.active_color = active_color
@@ -156,6 +160,8 @@ class Switch(ConstrainedControl, AdaptiveControl):
         self._set_attr_json("thumbColor", self.__thumb_color)
         self._set_attr_json("thumbIcon", self.__thumb_icon)
         self._set_attr_json("trackColor", self.__track_color)
+        if dataclasses.is_dataclass(self.__label_style):
+            self._set_attr_json("labelStyle", self.__label_style)
 
     # value
     @property
@@ -174,6 +180,15 @@ class Switch(ConstrainedControl, AdaptiveControl):
     @label.setter
     def label(self, value):
         self._set_attr("label", value)
+
+    # label_style
+    @property
+    def label_style(self) -> Optional[TextStyle]:
+        return self.__label_style
+
+    @label_style.setter
+    def label_style(self, value: Optional[TextStyle]):
+        self.__label_style = value
 
     # label_position
     @property


### PR DESCRIPTION
Closes #2708 

Test code:
```py
import flet as ft


def main(page):

    page.add(
        ft.Checkbox(
            label="Checkbox",
            label_style=ft.TextStyle(color=ft.colors.BLUE, size=20),
        ),
        ft.Switch(label="Switch", value=False, label_style=ft.TextStyle(color=ft.colors.PURPLE, size=20)),
        ft.RadioGroup(
            content=ft.Column(
                [
                    ft.Radio(
                        value="red",
                        label="Red",
                        label_style=ft.TextStyle(color=ft.colors.RED, size=20),
                    ),
                    ft.Radio(
                        value="green",
                        label="Green",
                        label_style=ft.TextStyle(color=ft.colors.GREEN, size=20),
                    ),
                    ft.Radio(
                        value="blue",
                        label="Blue",
                        label_style=ft.TextStyle(color=ft.colors.BLUE, size=20),
                    ),
                ]
            ),
        ),
    )


ft.app(target=main)

```
