### PR TITLE
Add `code_verifier` and `code_challenge` to `Authorization` class

### DIFF
--- a/sdk/python/packages/flet-runtime/src/flet_runtime/auth/authorization.py
+++ b/sdk/python/packages/flet-runtime/src/flet_runtime/auth/authorization.py
@@ -9,11 +9,12 @@ import httpx
 from flet.version import version
 from flet_core.locks import AsyncNopeLock, NopeLock
 from flet_core.utils import is_asyncio
+from oauthlib.oauth2 import WebApplicationClient
+from oauthlib.oauth2.rfc6749.tokens import OAuth2Token
+
 from flet_runtime.auth.oauth_provider import OAuthProvider
 from flet_runtime.auth.oauth_token import OAuthToken
 from flet_runtime.auth.user import User
-from oauthlib.oauth2 import WebApplicationClient
-from oauthlib.oauth2.rfc6749.tokens import OAuth2Token
 
 
 class Authorization:
@@ -76,6 +77,8 @@ class Authorization:
             self.provider.redirect_url,
             scope=self.scope,
             state=self.state,
+            code_challenge=self.provider.code_challenge,
+            code_challenge_method=self.provider.code_challenge_method,
         )
         return authorization_url, self.state
 
@@ -106,6 +109,7 @@ class Authorization:
             redirect_uri=self.provider.redirect_url,
             client_secret=self.provider.client_secret,
             include_client_id=True,
+            code_verifier=self.provider.code_verifier,
         )
         headers = self.__get_default_headers()
         headers["content-type"] = "application/x-www-form-urlencoded"

--- a/sdk/python/packages/flet-runtime/src/flet_runtime/auth/oauth_provider.py
+++ b/sdk/python/packages/flet-runtime/src/flet_runtime/auth/oauth_provider.py
@@ -17,6 +17,9 @@ class OAuthProvider:
         user_endpoint: Optional[str] = None,
         user_id_fn: Optional[Callable] = None,
         group_scopes: Optional[List[str]] = None,
+        code_challenge: Optional[str] = None,
+        code_challenge_method: Optional[str] = None,
+        code_verifier: Optional[str] = None,
     ) -> None:
         self.client_id = client_id
         self.client_secret = client_secret
@@ -28,6 +31,9 @@ class OAuthProvider:
         self.user_endpoint = user_endpoint
         self.user_id_fn = user_id_fn
         self.group_scopes = group_scopes if group_scopes is not None else []
+        self.code_challenge = code_challenge
+        self.code_challenge_method = code_challenge_method
+        self.code_verifier = code_verifier
 
     def _name(self):
         raise Exception("Not implemented")


### PR DESCRIPTION
Hi,

I was trying to implement Authentication in my felt app with my web application which uses the [django-oauth-toolkit](https://django-oauth-toolkit.readthedocs.io/en/latest/) for OAuth 2.0. I tried setting up the OAuth application with [Authorization flow](https://django-oauth-toolkit.readthedocs.io/en/latest/getting_started.html#authorization-code).
As you can see in the `django-oauth-toolkit` documentation, it needs the following extra parameters:
- `code_challenge`
- `code_challenge_method`
- `code_verifier`

The underlying `oauthlib.oauth2` already has these parameters in the following methods:
- `prepare_request_uri` method has `code_challenge` and `code_challenge_method`
- `prepare_request_body` method has `code_verifier`

With this PR, now we pass these values to the underlying library to use the Authorization flow.
