### PR TITLE
web: patch html title with app_name

### DIFF
--- a/sdk/python/packages/flet-runtime/src/flet_runtime/utils/patch_index.py
+++ b/sdk/python/packages/flet-runtime/src/flet_runtime/utils/patch_index.py
@@ -65,6 +65,11 @@ def patch_index_html(
             r'<meta name="apple-mobile-web-app-title" content="{}">'.format(app_name),
             index,
         )
+        index = re.sub(
+            r"\<title>(.+)</title>",
+            r"<title>{}</title>".format(app_name),
+            index,
+        )
     if app_description:
         index = re.sub(
             r"\<meta name=\"description\" content=\"(.+)\">",


### PR DESCRIPTION
This allows `flet_fastapi` to substitute the generated HTML `<title>` without introducing the custom `index.html`, e.g.,

```
flet_fastapi.app(
            webapp_main,
            app_name="my app",
            app_short_name="myapp",
            app_description="myapp description",
        )
```