### PR TITLE
Fix issue #2712 and #2828

### DIFF
--- a/packages/flet/lib/src/controls/container.dart
+++ b/packages/flet/lib/src/controls/container.dart
@@ -155,9 +155,8 @@ class ContainerControl extends StatelessWidget with FletStoreMixin {
               // Dummy callback to enable widget
               // see https://github.com/flutter/flutter/issues/50116#issuecomment-582047374
               // and https://github.com/flutter/flutter/blob/eed80afe2c641fb14b82a22279d2d78c19661787/packages/flutter/lib/src/material/ink_well.dart#L1125-L1129
-              onTap: onHover ? () {} : null,
-              onTapDown: onClick || url != ""
-                  ? (details) {
+              onTap: onClick || url != ""
+                  ? () {
                       debugPrint("Container ${control.id} clicked!");
                       if (url != "") {
                         openWebBrowser(url, webWindowName: urlTarget);
@@ -165,13 +164,7 @@ class ContainerControl extends StatelessWidget with FletStoreMixin {
                       if (onClick) {
                         backend.triggerControlEvent(
                             control.id,
-                            "click",
-                            json.encode(ContainerTapEvent(
-                                    localX: details.localPosition.dx,
-                                    localY: details.localPosition.dy,
-                                    globalX: details.globalPosition.dx,
-                                    globalY: details.globalPosition.dy)
-                                .toJson()));
+                            "click");
                       }
                     }
                   : null,
@@ -204,7 +197,7 @@ class ContainerControl extends StatelessWidget with FletStoreMixin {
                 width: control.attrDouble("width"),
                 height: control.attrDouble("height"),
                 margin: parseEdgeInsets(control, "margin"),
-                clipBehavior: Clip.none,
+                clipBehavior: clipBehavior,
                 decoration: boxDecor,
                 child: ink,
               )
@@ -272,8 +265,8 @@ class ContainerControl extends StatelessWidget with FletStoreMixin {
                   }
                 : null,
             child: GestureDetector(
-              onTapDown: onClick || url != ""
-                  ? (details) {
+              onTap: onClick || url != ""
+                  ? () {
                       debugPrint("Container ${control.id} clicked!");
                       if (url != "") {
                         openWebBrowser(url, webWindowName: urlTarget);
@@ -281,13 +274,7 @@ class ContainerControl extends StatelessWidget with FletStoreMixin {
                       if (onClick) {
                         backend.triggerControlEvent(
                             control.id,
-                            "click",
-                            json.encode(ContainerTapEvent(
-                                    localX: details.localPosition.dx,
-                                    localY: details.localPosition.dy,
-                                    globalX: details.globalPosition.dx,
-                                    globalY: details.globalPosition.dy)
-                                .toJson()));
+                            "click");
                       }
                     }
                   : null,

--- a/sdk/python/packages/flet-core/src/flet_core/container.py
+++ b/sdk/python/packages/flet-core/src/flet_core/container.py
@@ -471,11 +471,11 @@ class Container(ConstrainedControl, AdaptiveControl):
     # on_click
     @property
     def on_click(self):
-        return self.__on_click
+        return self._get_event_handler("click")
 
     @on_click.setter
     def on_click(self, handler):
-        self.__on_click.subscribe(handler)
+        self._add_event_handler("click", handler)
         self._set_attr("onClick", True if handler is not None else None)
 
 


### PR DESCRIPTION
- [x] Fix issue #2712 
- [x] Fix issue #2828  

Test code: 
#2712 
```python
import flet as ft

def main(page: ft.Page):
    page.padding = 0
    def on_long_press(e):
        print('on long press')
        page.add(ft.Text('on_long_press triggered'))
    def on_click(e):
        print('on click')
        page.add(ft.Text('on_click triggered'))
    container = ft.Container(
        bgcolor= ft.colors.RED,
        content= ft.Text('Test Long Press'),
        height= 100,
        width= 100,
        on_click= on_click,
        on_long_press= on_long_press 
    )
    page.add(ft.SafeArea(container))
    
ft.app(target=main)
```

#2828 
```python
import flet as ft
def main(page: ft.Page):
    child = ft.Container(
        bgcolor= ft.colors.ORANGE,
        alignment= ft.alignment.center,
        
    )
    container = ft.Container(
        content= child,
        # bgcolor= ft.colors.RED,
        height= 200,
        width= 200,
        border_radius= ft.BorderRadius(
            top_left= 0,
            top_right= 30,
            bottom_left= 30,
            bottom_right= 30
        ),
        alignment = ft.alignment.center,
        on_click= lambda e: print('clicked'),
        ink = True
    )
    page.add(container)
ft.app(target=main)
```