### PR TITLE
Added `Container.on_tap_down` event for backward compatibility with old `on_click` behavior

### DIFF
--- a/packages/flet/lib/src/controls/container.dart
+++ b/packages/flet/lib/src/controls/container.dart
@@ -64,6 +64,7 @@ class ContainerControl extends StatelessWidget with FletStoreMixin {
         children.where((c) => c.name == "content" && c.isVisible);
     bool ink = control.attrBool("ink", false)!;
     bool onClick = control.attrBool("onclick", false)!;
+    bool onTapDown = control.attrBool("onTapDown", false)!;
     String url = control.attrString("url", "")!;
     String? urlTarget = control.attrString("urlTarget");
     bool onLongPress = control.attrBool("onLongPress", false)!;
@@ -160,10 +161,21 @@ class ContainerControl extends StatelessWidget with FletStoreMixin {
                         openWebBrowser(url, webWindowName: urlTarget);
                       }
                       if (onClick) {
-                        backend.triggerControlEvent(
-                            control.id,
-                            "click");
+                        backend.triggerControlEvent(control.id, "click");
                       }
+                    }
+                  : null,
+              onTapDown: onTapDown
+                  ? (details) {
+                      backend.triggerControlEvent(
+                          control.id,
+                          "tap_down",
+                          json.encode(ContainerTapEvent(
+                                  localX: details.localPosition.dx,
+                                  localY: details.localPosition.dy,
+                                  globalX: details.globalPosition.dx,
+                                  globalY: details.globalPosition.dy)
+                              .toJson()));
                     }
                   : null,
               onLongPress: onLongPress
@@ -241,8 +253,7 @@ class ContainerControl extends StatelessWidget with FletStoreMixin {
                     : null,
                 child: child);
 
-        if ((onClick || onLongPress || onHover || url != "") &&
-            !disabled) {
+        if ((onClick || onLongPress || onHover || url != "") && !disabled) {
           result = MouseRegion(
             cursor: onClick || url != ""
                 ? SystemMouseCursors.click
@@ -269,10 +280,21 @@ class ContainerControl extends StatelessWidget with FletStoreMixin {
                         openWebBrowser(url, webWindowName: urlTarget);
                       }
                       if (onClick) {
-                        backend.triggerControlEvent(
-                            control.id,
-                            "click");
+                        backend.triggerControlEvent(control.id, "click");
                       }
+                    }
+                  : null,
+              onTapDown: onTapDown
+                  ? (details) {
+                      backend.triggerControlEvent(
+                          control.id,
+                          "tap_down",
+                          json.encode(ContainerTapEvent(
+                                  localX: details.localPosition.dx,
+                                  localY: details.localPosition.dy,
+                                  globalX: details.globalPosition.dx,
+                                  globalY: details.globalPosition.dy)
+                              .toJson()));
                     }
                   : null,
               onLongPress: onLongPress

--- a/sdk/python/packages/flet-core/src/flet_core/container.py
+++ b/sdk/python/packages/flet-core/src/flet_core/container.py
@@ -89,6 +89,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         theme: Optional[Theme] = None,
         theme_mode: Optional[ThemeMode] = None,
         on_click=None,
+        on_tap_down=None,
         on_long_press=None,
         on_hover=None,
         #
@@ -162,8 +163,8 @@ class Container(ConstrainedControl, AdaptiveControl):
             d = json.loads(e.data)
             return ContainerTapEvent(**d)
 
-        self.__on_click = EventHandler(convert_container_tap_event_data)
-        self._add_event_handler("click", self.__on_click.get_handler())
+        self.__on_tap_down = EventHandler(convert_container_tap_event_data)
+        self._add_event_handler("tap_down", self.__on_tap_down.get_handler())
 
         self.content = content
         self.padding = padding
@@ -191,6 +192,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         self.theme = theme
         self.theme_mode = theme_mode
         self.on_click = on_click
+        self.on_tap_down = on_tap_down
         self.on_long_press = on_long_press
         self.on_hover = on_hover
 
@@ -480,6 +482,16 @@ class Container(ConstrainedControl, AdaptiveControl):
     def on_click(self, handler):
         self._add_event_handler("click", handler)
         self._set_attr("onClick", True if handler is not None else None)
+
+    # on_tap_down
+    @property
+    def on_tap_down(self):
+        return self.__on_tap_down
+
+    @on_tap_down.setter
+    def on_tap_down(self, handler):
+        self.__on_tap_down.subscribe(handler)
+        self._set_attr("onTapDown", True if handler is not None else None)
 
     # on_long_press
     @property


### PR DESCRIPTION
Test code:

```py
import flet as ft


def main(page: ft.Page):
    page.padding = 0

    def on_long_press(e):
        print("on long press")
        page.add(ft.Text("on_long_press triggered"))

    def on_click(e):
        print("on click")
        page.add(ft.Text("on_click triggered"))

    def on_tap_down(e: ft.ContainerTapEvent):
        print("on tap down", e.local_x, e.local_y)
        page.add(ft.Text("on_tap_down triggered"))

    container = ft.Container(
        bgcolor=ft.colors.RED,
        content=ft.Text("Test Long Press"),
        height=100,
        width=100,
        on_click=on_click,
        on_long_press=on_long_press,
        on_tap_down=on_tap_down,
    )
    page.add(ft.SafeArea(container))


ft.app(target=main)
```