### PR TITLE
Allow arguments to be passed onto Stack

### DIFF
--- a/sdk/python/packages/flet-core/src/flet_core/user_control.py
+++ b/sdk/python/packages/flet-core/src/flet_core/user_control.py
@@ -8,8 +8,8 @@ class UserControl(Stack):
         version="0.21.0",
         delete_version="1.0",
     )
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     def build(self):
         pass

--- a/sdk/python/packages/flet-core/src/flet_core/user_control.py
+++ b/sdk/python/packages/flet-core/src/flet_core/user_control.py
@@ -8,8 +8,8 @@ class UserControl(Stack):
         version="0.21.0",
         delete_version="1.0",
     )
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
 
     def build(self):
         pass


### PR DESCRIPTION
Fixes the issue where passing arguments to UserControl no longer propagates into Stack subclassing