### PR TITLE
Flet v0.22.0 Fixes

### DIFF
--- a/packages/flet/lib/src/controls/linechart.dart
+++ b/packages/flet/lib/src/controls/linechart.dart
@@ -403,17 +403,18 @@ class _LineChartControlState extends State<LineChartControl> {
   LineChartBarData getBarData(ThemeData theme, Control parent,
       bool interactiveChart, LineChartDataViewModel dataViewModel) {
     Color? aboveLineBgcolor =
-        widget.control.attrColor("aboveLineBgcolor", context);
+        dataViewModel.control.attrColor("aboveLineBgcolor", context);
     Gradient? aboveLineGradient =
         parseGradient(theme, dataViewModel.control, "aboveLineGradient");
     Color? belowLineBgcolor =
-        widget.control.attrColor("belowLineBgcolor", context);
+        dataViewModel.control.attrColor("belowLineBgcolor", context);
     Gradient? belowLineGradient =
         parseGradient(theme, dataViewModel.control, "belowLineGradient");
     var dashPattern = dataViewModel.control.attrString("dashPattern");
     var shadow =
         parseBoxShadow(Theme.of(context), dataViewModel.control, "shadow");
-    Color barColor = widget.control.attrColor("color", context) ?? Colors.cyan;
+    Color barColor =
+        dataViewModel.control.attrColor("color", context) ?? Colors.cyan;
     Gradient? barGradient =
         parseGradient(theme, dataViewModel.control, "gradient");
     FlLine? aboveLine =


### PR DESCRIPTION
- [x] Regression in `LineChartData` colors caused by #2882 