### PR TITLE
Fix #3035 - Use `Text.rich` instead of `RichText`

### DIFF
--- a/packages/flet/lib/src/controls/text.dart
+++ b/packages/flet/lib/src/controls/text.dart
@@ -116,8 +116,9 @@ class TextControl extends StatelessWidget with FletStoreMixin {
                   textAlign: textAlign,
                 )
           : (spans.isNotEmpty)
-              ? RichText(
-                  text: TextSpan(text: text, style: style, children: spans),
+              ? Text.rich(
+                  TextSpan(text: text, style: style, children: spans),
+                  semanticsLabel: semanticsLabel,
                   maxLines: maxLines,
                   softWrap: !noWrap,
                   textAlign: textAlign,


### PR DESCRIPTION
Fix https://github.com/flet-dev/flet/issues/3035.
PR by your request