### PR TITLE
Rename `NavigationDestination` to `NavigationBarDestination` + some type hinting

### DIFF
--- a/sdk/python/packages/flet-core/src/flet_core/__init__.py
+++ b/sdk/python/packages/flet-core/src/flet_core/__init__.py
@@ -65,7 +65,7 @@ from flet_core.chip import Chip
 from flet_core.circle_avatar import CircleAvatar
 from flet_core.column import Column
 from flet_core.container import Container, ContainerTapEvent
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.control_event import ControlEvent
 from flet_core.cupertino_action_sheet import CupertinoActionSheet
 from flet_core.cupertino_action_sheet_action import CupertinoActionSheetAction
@@ -104,7 +104,12 @@ from flet_core.datatable import (
     DataRow,
     DataTable,
 )
-from flet_core.date_picker import DatePicker, DatePickerEntryMode, DatePickerMode, DatePickerEntryModeChangeEvent
+from flet_core.date_picker import (
+    DatePicker,
+    DatePickerEntryMode,
+    DatePickerEntryModeChangeEvent,
+    DatePickerMode,
+)
 from flet_core.dismissible import (
     Dismissible,
     DismissibleDismissEvent,
@@ -155,7 +160,7 @@ from flet_core.haptic_feedback import HapticFeedback
 from flet_core.icon import Icon
 from flet_core.icon_button import IconButton
 from flet_core.image import Image
-from flet_core.list_tile import ListTile, ListTileTitleAlignment, ListTileStyle
+from flet_core.list_tile import ListTile, ListTileStyle, ListTileTitleAlignment
 from flet_core.list_view import ListView
 from flet_core.lottie import Lottie
 from flet_core.margin import Margin
@@ -164,8 +169,8 @@ from flet_core.menu_bar import MenuBar, MenuStyle
 from flet_core.menu_item_button import MenuItemButton
 from flet_core.navigation_bar import (
     NavigationBar,
-    NavigationBarLabelBehavior,
     NavigationBarDestination,
+    NavigationBarLabelBehavior,
 )
 from flet_core.navigation_drawer import NavigationDrawer, NavigationDrawerDestination
 from flet_core.navigation_rail import (
@@ -177,6 +182,7 @@ from flet_core.outlined_button import OutlinedButton
 from flet_core.padding import Padding
 from flet_core.page import (
     AppLifecycleStateChangeEvent,
+    context,
     KeyboardEvent,
     Locale,
     LocaleConfiguration,
@@ -186,7 +192,6 @@ from flet_core.page import (
     PageMediaData,
     RouteChangeEvent,
     ViewPopEvent,
-    context,
 )
 from flet_core.pagelet import Pagelet
 from flet_core.painting import (
@@ -283,7 +288,11 @@ from flet_core.theme import (
     TimePickerTheme,
     TooltipTheme,
 )
-from flet_core.time_picker import TimePicker, TimePickerEntryMode, TimePickerEntryModeChangeEvent
+from flet_core.time_picker import (
+    TimePicker,
+    TimePickerEntryMode,
+    TimePickerEntryModeChangeEvent,
+)
 from flet_core.tooltip import Tooltip
 from flet_core.transform import Offset, Rotate, Scale
 from flet_core.transparent_pointer import TransparentPointer
@@ -303,6 +312,7 @@ from flet_core.types import (
     MaterialState,
     MouseCursor,
     NotchShape,
+    OptionalNumber,
     Orientation,
     PaddingValue,
     PagePlatform,

--- a/sdk/python/packages/flet-core/src/flet_core/__init__.py
+++ b/sdk/python/packages/flet-core/src/flet_core/__init__.py
@@ -165,7 +165,7 @@ from flet_core.menu_item_button import MenuItemButton
 from flet_core.navigation_bar import (
     NavigationBar,
     NavigationBarLabelBehavior,
-    NavigationDestination,
+    NavigationBarDestination,
 )
 from flet_core.navigation_drawer import NavigationDrawer, NavigationDrawerDestination
 from flet_core.navigation_rail import (

--- a/sdk/python/packages/flet-core/src/flet_core/__init__.py
+++ b/sdk/python/packages/flet-core/src/flet_core/__init__.py
@@ -302,6 +302,8 @@ from flet_core.types import (
     BoxShape,
     Brightness,
     ClipBehavior,
+    ColorStr,
+    ControlEventFunction,
     CrossAxisAlignment,
     FloatingActionButtonLocation,
     FontWeight,

--- a/sdk/python/packages/flet-core/src/flet_core/__init__.py
+++ b/sdk/python/packages/flet-core/src/flet_core/__init__.py
@@ -305,6 +305,7 @@ from flet_core.types import (
     CrossAxisAlignment,
     FloatingActionButtonLocation,
     FontWeight,
+    IconStr,
     ImageFit,
     ImageRepeat,
     LabelPosition,

--- a/sdk/python/packages/flet-core/src/flet_core/alert_dialog.py
+++ b/sdk/python/packages/flet-core/src/flet_core/alert_dialog.py
@@ -3,10 +3,15 @@ from typing import Any, List, Optional
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.alignment import Alignment
 from flet_core.buttons import OutlinedBorder
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.text_style import TextStyle
-from flet_core.types import ClipBehavior, MainAxisAlignment, PaddingValue
+from flet_core.types import (
+    ClipBehavior,
+    MainAxisAlignment,
+    OptionalNumber,
+    PaddingValue,
+)
 
 
 class AlertDialog(AdaptiveControl):
@@ -178,6 +183,7 @@ class AlertDialog(AdaptiveControl):
         return children
 
     # open
+
     @property
     def open(self) -> Optional[bool]:
         return self._get_attr("open", data_type="bool", def_value=False)
@@ -187,6 +193,7 @@ class AlertDialog(AdaptiveControl):
         self._set_attr("open", value)
 
     # bgcolor
+
     @property
     def bgcolor(self) -> Optional[str]:
         return self._get_attr("bgcolor")
@@ -196,6 +203,7 @@ class AlertDialog(AdaptiveControl):
         self._set_attr("bgcolor", value)
 
     # shadow_color
+
     @property
     def shadow_color(self) -> Optional[str]:
         return self._get_attr("shadowColor")
@@ -205,6 +213,7 @@ class AlertDialog(AdaptiveControl):
         self._set_attr("shadowColor", value)
 
     # surface_tint_color
+
     @property
     def surface_tint_color(self) -> Optional[str]:
         return self._get_attr("surfaceTintColor")
@@ -214,6 +223,7 @@ class AlertDialog(AdaptiveControl):
         self._set_attr("surfaceTintColor", value)
 
     # icon_color
+
     @property
     def icon_color(self) -> Optional[str]:
         return self._get_attr("iconColor")
@@ -223,6 +233,7 @@ class AlertDialog(AdaptiveControl):
         self._set_attr("iconColor", value)
 
     # elevation
+
     @property
     def elevation(self) -> OptionalNumber:
         return self._get_attr("elevation", data_type="float")
@@ -232,6 +243,7 @@ class AlertDialog(AdaptiveControl):
         self._set_attr("elevation", value)
 
     # actions_overflow_button_spacing
+
     @property
     def actions_overflow_button_spacing(self) -> OptionalNumber:
         return self._get_attr("actionsOverflowButtonSpacing", data_type="float")
@@ -241,6 +253,7 @@ class AlertDialog(AdaptiveControl):
         self._set_attr("actionsOverflowButtonSpacing", value)
 
     # scrollable
+
     @property
     def scrollable(self) -> Optional[bool]:
         return self._get_attr("scrollable", data_type="bool", def_value=False)
@@ -250,6 +263,7 @@ class AlertDialog(AdaptiveControl):
         self._set_attr("scrollable", value)
 
     # alignment
+
     @property
     def alignment(self) -> Optional[Alignment]:
         return self.__alignment
@@ -259,6 +273,7 @@ class AlertDialog(AdaptiveControl):
         self.__alignment = value
 
     # content_text_style
+
     @property
     def content_text_style(self) -> Optional[TextStyle]:
         return self.__content_text_style
@@ -268,6 +283,7 @@ class AlertDialog(AdaptiveControl):
         self.__content_text_style = value
 
     # title_text_style
+
     @property
     def title_text_style(self) -> Optional[TextStyle]:
         return self.__title_text_style
@@ -277,6 +293,7 @@ class AlertDialog(AdaptiveControl):
         self.__title_text_style = value
 
     # modal
+
     @property
     def modal(self) -> Optional[bool]:
         return self._get_attr("modal", data_type="bool", def_value=False)
@@ -286,6 +303,7 @@ class AlertDialog(AdaptiveControl):
         self._set_attr("modal", value)
 
     # title
+
     @property
     def title(self) -> Optional[Control]:
         return self.__title
@@ -295,6 +313,7 @@ class AlertDialog(AdaptiveControl):
         self.__title = value
 
     # icon
+
     @property
     def icon(self) -> Optional[Control]:
         return self.__icon
@@ -304,6 +323,7 @@ class AlertDialog(AdaptiveControl):
         self.__icon = value
 
     # title_padding
+
     @property
     def title_padding(self) -> PaddingValue:
         return self.__title_padding
@@ -313,6 +333,7 @@ class AlertDialog(AdaptiveControl):
         self.__title_padding = value
 
     # content
+
     @property
     def content(self) -> Optional[Control]:
         return self.__content
@@ -322,6 +343,7 @@ class AlertDialog(AdaptiveControl):
         self.__content = value
 
     # content_padding
+
     @property
     def content_padding(self) -> PaddingValue:
         return self.__content_padding
@@ -331,6 +353,7 @@ class AlertDialog(AdaptiveControl):
         self.__content_padding = value
 
     # actions
+
     @property
     def actions(self) -> Optional[List[Control]]:
         return self.__actions
@@ -340,6 +363,7 @@ class AlertDialog(AdaptiveControl):
         self.__actions = value if value is not None else []
 
     # actions_padding
+
     @property
     def actions_padding(self) -> PaddingValue:
         return self.__actions_padding
@@ -349,6 +373,7 @@ class AlertDialog(AdaptiveControl):
         self.__actions_padding = value
 
     # actions_alignment
+
     @property
     def actions_alignment(self) -> Optional[MainAxisAlignment]:
         return self.__actions_alignment
@@ -362,6 +387,7 @@ class AlertDialog(AdaptiveControl):
         )
 
     # shape
+
     @property
     def shape(self) -> Optional[OutlinedBorder]:
         return self.__shape
@@ -371,6 +397,7 @@ class AlertDialog(AdaptiveControl):
         self.__shape = value
 
     # inset_padding
+
     @property
     def inset_padding(self) -> PaddingValue:
         return self.__inset_padding
@@ -380,6 +407,7 @@ class AlertDialog(AdaptiveControl):
         self.__inset_padding = value
 
     # icon_padding
+
     @property
     def icon_padding(self) -> PaddingValue:
         return self.__icon_padding
@@ -389,6 +417,7 @@ class AlertDialog(AdaptiveControl):
         self.__icon_padding = value
 
     # action_button_padding
+
     @property
     def action_button_padding(self) -> PaddingValue:
         return self.__action_button_padding
@@ -398,6 +427,7 @@ class AlertDialog(AdaptiveControl):
         self.__action_button_padding = value
 
     # semantics_label
+
     @property
     def semantics_label(self) -> Optional[str]:
         return self._get_attr("semanticsLabel")
@@ -407,6 +437,7 @@ class AlertDialog(AdaptiveControl):
         self._set_attr("semanticsLabel", value)
 
     # clip_behavior
+
     @property
     def clip_behavior(self) -> Optional[ClipBehavior]:
         return self._get_attr("clipBehavior")
@@ -418,6 +449,7 @@ class AlertDialog(AdaptiveControl):
         )
 
     # on_dismiss
+
     @property
     def on_dismiss(self):
         return self._get_event_handler("dismiss")

--- a/sdk/python/packages/flet-core/src/flet_core/animated_switcher.py
+++ b/sdk/python/packages/flet-core/src/flet_core/animated_switcher.py
@@ -3,11 +3,12 @@ from typing import Any, Optional, Union
 
 from flet_core.animation import AnimationCurve
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -17,7 +18,6 @@ try:
     from typing import Literal
 except ImportError:
     from typing_extensions import Literal
-
 TransitionValueString = Literal["fade", "rotation", "scale"]
 
 
@@ -166,6 +166,7 @@ class AnimatedSwitcher(ConstrainedControl):
         return children
 
     # content
+
     @property
     def content(self) -> Optional[Control]:
         return self.__content
@@ -175,6 +176,7 @@ class AnimatedSwitcher(ConstrainedControl):
         self.__content = value
 
     # duration
+
     @property
     def duration(self) -> Optional[int]:
         return self._get_attr("duration")
@@ -184,6 +186,7 @@ class AnimatedSwitcher(ConstrainedControl):
         self._set_attr("duration", value)
 
     # reverse_duration
+
     @property
     def reverse_duration(self) -> Optional[int]:
         return self._get_attr("reverseDuration")
@@ -193,6 +196,7 @@ class AnimatedSwitcher(ConstrainedControl):
         self._set_attr("reverseDuration", value)
 
     # switch_in_curve
+
     @property
     def switch_in_curve(self) -> Optional[AnimationCurve]:
         return self.__switch_in_curve
@@ -205,6 +209,7 @@ class AnimatedSwitcher(ConstrainedControl):
         )
 
     # switch_out_curve
+
     @property
     def switch_out_curve(self) -> Optional[AnimationCurve]:
         return self.__switch_out_curve
@@ -218,6 +223,7 @@ class AnimatedSwitcher(ConstrainedControl):
         )
 
     # transition
+
     @property
     def transition(self) -> Optional[AnimatedSwitcherTransition]:
         return self.__transition

--- a/sdk/python/packages/flet-core/src/flet_core/app_bar.py
+++ b/sdk/python/packages/flet-core/src/flet_core/app_bar.py
@@ -2,10 +2,10 @@ from typing import List, Optional
 
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.buttons import OutlinedBorder
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.text_style import TextStyle
-from flet_core.types import ClipBehavior
+from flet_core.types import ClipBehavior, OptionalNumber
 
 
 class AppBar(AdaptiveControl):
@@ -139,6 +139,7 @@ class AppBar(AdaptiveControl):
         return children
 
     # leading
+
     @property
     def leading(self) -> Optional[Control]:
         return self.__leading
@@ -153,6 +154,7 @@ class AppBar(AdaptiveControl):
         self.__leading = value
 
     # leading_width
+
     @property
     def leading_width(self) -> OptionalNumber:
         return self._get_attr("leadingWidth")
@@ -162,6 +164,7 @@ class AppBar(AdaptiveControl):
         self._set_attr("leadingWidth", value)
 
     # title_spacing
+
     @property
     def title_spacing(self) -> OptionalNumber:
         return self._get_attr("titleSpacing", data_type="float")
@@ -171,6 +174,7 @@ class AppBar(AdaptiveControl):
         self._set_attr("titleSpacing", value)
 
     # toolbar_opacity
+
     @property
     def toolbar_opacity(self) -> OptionalNumber:
         return self._get_attr("toolbarOpacity", data_type="float", def_value=1.0)
@@ -180,6 +184,7 @@ class AppBar(AdaptiveControl):
         self._set_attr("toolbarOpacity", value)
 
     # shape
+
     @property
     def shape(self) -> Optional[OutlinedBorder]:
         return self.__shape
@@ -189,6 +194,7 @@ class AppBar(AdaptiveControl):
         self.__shape = value
 
     # title_text_style
+
     @property
     def title_text_style(self) -> Optional[TextStyle]:
         return self.__title_text_style
@@ -198,6 +204,7 @@ class AppBar(AdaptiveControl):
         self.__title_text_style = value
 
     # toolbar_text_style
+
     @property
     def toolbar_text_style(self) -> Optional[TextStyle]:
         return self.__toolbar_text_style
@@ -207,6 +214,7 @@ class AppBar(AdaptiveControl):
         self.__toolbar_text_style = value
 
     # automatically_imply_leading
+
     @property
     def automatically_imply_leading(self) -> Optional[bool]:
         return self._get_attr(
@@ -218,6 +226,7 @@ class AppBar(AdaptiveControl):
         self._set_attr("automaticallyImplyLeading", value)
 
     # title
+
     @property
     def title(self) -> Optional[Control]:
         return self.__title
@@ -227,6 +236,7 @@ class AppBar(AdaptiveControl):
         self.__title = value
 
     # center_title
+
     @property
     def center_title(self) -> Optional[bool]:
         return self._get_attr("centerTitle", data_type="bool", def_value=False)
@@ -236,6 +246,7 @@ class AppBar(AdaptiveControl):
         self._set_attr("centerTitle", value)
 
     # toolbar_height
+
     @property
     def toolbar_height(self) -> OptionalNumber:
         return self._get_attr("toolbarHeight")
@@ -245,6 +256,7 @@ class AppBar(AdaptiveControl):
         self._set_attr("toolbarHeight", value)
 
     # color
+
     @property
     def color(self) -> Optional[str]:
         return self._get_attr("color")
@@ -254,6 +266,7 @@ class AppBar(AdaptiveControl):
         self._set_attr("color", value)
 
     # bgcolor
+
     @property
     def bgcolor(self) -> Optional[str]:
         return self._get_attr("bgcolor")
@@ -263,6 +276,7 @@ class AppBar(AdaptiveControl):
         self._set_attr("bgcolor", value)
 
     # shadow_color
+
     @property
     def shadow_color(self) -> Optional[str]:
         return self._get_attr("shadowColor")
@@ -272,6 +286,7 @@ class AppBar(AdaptiveControl):
         self._set_attr("shadowColor", value)
 
     # surface_tint_color
+
     @property
     def surface_tint_color(self) -> Optional[str]:
         return self._get_attr("surfaceTintColor")
@@ -281,6 +296,7 @@ class AppBar(AdaptiveControl):
         self._set_attr("surfaceTintColor", value)
 
     # is_secondary
+
     @property
     def is_secondary(self) -> Optional[bool]:
         return self._get_attr("isSecondary", data_type="bool", def_value=False)
@@ -290,6 +306,7 @@ class AppBar(AdaptiveControl):
         self._set_attr("isSecondary", value)
 
     # exclude_header_semantics
+
     @property
     def exclude_header_semantics(self) -> Optional[bool]:
         return self._get_attr(
@@ -301,6 +318,7 @@ class AppBar(AdaptiveControl):
         self._set_attr("excludeHeaderSemantics", value)
 
     # force_material_transparency
+
     @property
     def force_material_transparency(self) -> Optional[bool]:
         return self._get_attr(
@@ -312,6 +330,7 @@ class AppBar(AdaptiveControl):
         self._set_attr("forceMaterialTransparency", value)
 
     # elevation
+
     @property
     def elevation(self) -> OptionalNumber:
         return self._get_attr("elevation")
@@ -321,6 +340,7 @@ class AppBar(AdaptiveControl):
         self._set_attr("elevation", value)
 
     # elevation_on_scroll
+
     @property
     def elevation_on_scroll(self) -> OptionalNumber:
         return self._get_attr("elevationOnScroll")
@@ -330,6 +350,7 @@ class AppBar(AdaptiveControl):
         self._set_attr("elevationOnScroll", value)
 
     # clip_behavior
+
     @property
     def clip_behavior(self) -> Optional[ClipBehavior]:
         return self._get_attr("clipBehavior")
@@ -342,6 +363,7 @@ class AppBar(AdaptiveControl):
         )
 
     # actions
+
     @property
     def actions(self) -> Optional[List[Control]]:
         return self.__actions

--- a/sdk/python/packages/flet-core/src/flet_core/audio.py
+++ b/sdk/python/packages/flet-core/src/flet_core/audio.py
@@ -1,8 +1,9 @@
 from enum import Enum
 from typing import Any, Optional
 
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
+from flet_core.types import OptionalNumber
 from flet_core.utils import deprecated
 
 
@@ -174,6 +175,7 @@ class Audio(Control):
         return int(sr) if sr else None
 
     # src
+
     @property
     def src(self):
         return self._get_attr("src")
@@ -183,6 +185,7 @@ class Audio(Control):
         self._set_attr("src", value)
 
     # src_base64
+
     @property
     def src_base64(self):
         return self._get_attr("srcBase64")
@@ -192,6 +195,7 @@ class Audio(Control):
         self._set_attr("srcBase64", value)
 
     # autoplay
+
     @property
     def autoplay(self) -> Optional[bool]:
         return self._get_attr("autoplay", data_type="bool", def_value=False)
@@ -201,6 +205,7 @@ class Audio(Control):
         self._set_attr("autoplay", value)
 
     # volume
+
     @property
     def volume(self) -> OptionalNumber:
         return self._get_attr("volume")
@@ -211,6 +216,7 @@ class Audio(Control):
             self._set_attr("volume", value)
 
     # balance
+
     @property
     def balance(self) -> OptionalNumber:
         return self._get_attr("balance")
@@ -221,6 +227,7 @@ class Audio(Control):
             self._set_attr("balance", value)
 
     # playback_rate
+
     @property
     def playback_rate(self) -> OptionalNumber:
         return self._get_attr("playbackRate")
@@ -231,6 +238,7 @@ class Audio(Control):
             self._set_attr("playbackRate", value)
 
     # release_mode
+
     @property
     def release_mode(self):
         return self._get_attr("releaseMode")
@@ -240,6 +248,7 @@ class Audio(Control):
         self._set_enum_attr("releaseMode", value, ReleaseMode)
 
     # on_loaded
+
     @property
     def on_loaded(self):
         return self._get_event_handler("loaded")
@@ -249,6 +258,7 @@ class Audio(Control):
         self._add_event_handler("loaded", handler)
 
     # on_duration_changed
+
     @property
     def on_duration_changed(self):
         return self._get_event_handler("duration_changed")
@@ -258,6 +268,7 @@ class Audio(Control):
         self._add_event_handler("duration_changed", handler)
 
     # on_state_changed
+
     @property
     def on_state_changed(self):
         return self._get_event_handler("state_changed")
@@ -267,6 +278,7 @@ class Audio(Control):
         self._add_event_handler("state_changed", handler)
 
     # on_position_changed
+
     @property
     def on_position_changed(self):
         return self._get_event_handler("position_changed")
@@ -280,6 +292,7 @@ class Audio(Control):
             self._set_attr("onPositionChanged", None)
 
     # on_seek_complete
+
     @property
     def on_seek_complete(self):
         return self._get_event_handler("seek_complete")

--- a/sdk/python/packages/flet-core/src/flet_core/audio_recorder.py
+++ b/sdk/python/packages/flet-core/src/flet_core/audio_recorder.py
@@ -2,8 +2,9 @@ import json
 from enum import Enum
 from typing import Any, Optional
 
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
+from flet_core.types import OptionalNumber
 from flet_core.utils import deprecated
 
 
@@ -209,6 +210,7 @@ class AudioRecorder(Control):
         return p == "true"
 
     # audio_encoder
+
     @property
     def audio_encoder(self):
         return self._get_attr("audioEncoder")
@@ -218,6 +220,7 @@ class AudioRecorder(Control):
         self._set_enum_attr("audioEncoder", value, AudioEncoder)
 
     # suppress_noise
+
     @property
     def suppress_noise(self) -> Optional[bool]:
         return self._get_attr("suppressNoise", data_type="bool", def_value=False)
@@ -227,6 +230,7 @@ class AudioRecorder(Control):
         self._set_attr("suppressNoise", value)
 
     # cancel_echo
+
     @property
     def cancel_echo(self) -> Optional[bool]:
         return self._get_attr("cancelEcho", data_type="bool", def_value=False)
@@ -236,6 +240,7 @@ class AudioRecorder(Control):
         self._set_attr("cancelEcho", value)
 
     # auto_gain
+
     @property
     def auto_gain(self) -> Optional[bool]:
         return self._get_attr("autoGain", data_type="bool", def_value=False)
@@ -245,6 +250,7 @@ class AudioRecorder(Control):
         self._set_attr("autoGain", value)
 
     # bit_rate
+
     @property
     def bit_rate(self) -> OptionalNumber:
         return self._get_attr("bitRate")
@@ -254,6 +260,7 @@ class AudioRecorder(Control):
         self._set_attr("bitRate", value)
 
     # sample_rate
+
     @property
     def sample_rate(self) -> OptionalNumber:
         return self._get_attr("sampleRate")
@@ -263,6 +270,7 @@ class AudioRecorder(Control):
         self._set_attr("sampleRate", value)
 
     # channels_num
+
     @property
     def channels_num(self) -> OptionalNumber:
         return self._get_attr("channels")
@@ -273,6 +281,7 @@ class AudioRecorder(Control):
             self._set_attr("channels", value)
 
     # on_state_changed
+
     @property
     def on_state_changed(self):
         return self._get_event_handler("state_changed")

--- a/sdk/python/packages/flet-core/src/flet_core/auto_complete.py
+++ b/sdk/python/packages/flet-core/src/flet_core/auto_complete.py
@@ -1,11 +1,12 @@
 import dataclasses
 import json
-from typing import Any, Optional, List
+from typing import Any, List, Optional
 
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.control_event import ControlEvent
 from flet_core.event_handler import EventHandler
 from flet_core.ref import Ref
+from flet_core.types import OptionalNumber
 
 
 @dataclasses.dataclass
@@ -64,6 +65,7 @@ class AutoComplete(Control):
         self._set_attr_json("suggestions", self.__suggestions)
 
     # suggestions_max_height
+
     @property
     def suggestions_max_height(self) -> OptionalNumber:
         return self._get_attr(
@@ -75,6 +77,7 @@ class AutoComplete(Control):
         self._set_attr("suggestionsMaxHeight", value)
 
     # suggestions
+
     @property
     def suggestions(self) -> Optional[List[AutoCompleteSuggestion]]:
         return self.__suggestions
@@ -84,6 +87,7 @@ class AutoComplete(Control):
         self.__suggestions = value or []
 
     # on_select
+
     @property
     def on_select(self):
         return self._get_event_handler("select")

--- a/sdk/python/packages/flet-core/src/flet_core/badge.py
+++ b/sdk/python/packages/flet-core/src/flet_core/badge.py
@@ -22,15 +22,15 @@ class Badge(Control):
         page.title = "Badges in NavigationBar icons"
         page.navigation_bar = ft.NavigationBar(
             destinations=[
-                ft.NavigationDestination(
+                ft.NavigationBarDestination(
                     icon_content=ft.Badge(
                         content=ft.Icon(ft.icons.EXPLORE),
                         small_size=10,
                     ),
                     label="Explore",
                 ),
-                ft.NavigationDestination(icon=ft.icons.COMMUTE, label="Commute"),
-                ft.NavigationDestination(
+                ft.NavigationBarDestination(icon=ft.icons.COMMUTE, label="Commute"),
+                ft.NavigationBarDestination(
                     icon_content=ft.Badge(content=ft.Icon(ft.icons.PHONE), text="10")
                 ),
             ]

--- a/sdk/python/packages/flet-core/src/flet_core/badge.py
+++ b/sdk/python/packages/flet-core/src/flet_core/badge.py
@@ -1,10 +1,10 @@
 from typing import Any, Optional
 
 from flet_core.alignment import Alignment
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.text_style import TextStyle
-from flet_core.types import OffsetValue, PaddingValue
+from flet_core.types import OffsetValue, OptionalNumber, PaddingValue
 
 
 class Badge(Control):
@@ -108,6 +108,7 @@ class Badge(Control):
         return children
 
     # alignment
+
     @property
     def alignment(self) -> Optional[Alignment]:
         """:obj:`Alignment`, optional: Align the child control within the container.
@@ -122,6 +123,7 @@ class Badge(Control):
         self.__alignment = value
 
     # text
+
     @property
     def text(self) -> Optional[str]:
         return self._get_attr("labelText")
@@ -131,6 +133,7 @@ class Badge(Control):
         self._set_attr("labelText", value)
 
     # content
+
     @property
     def content(self) -> Optional[Control]:
         return self.__content
@@ -140,6 +143,7 @@ class Badge(Control):
         self.__content = value
 
     # offset
+
     @property
     def offset(self) -> OffsetValue:
         return self.__offset
@@ -149,6 +153,7 @@ class Badge(Control):
         self.__offset = value
 
     # bgcolor
+
     @property
     def bgcolor(self):
         return self._get_attr("bgColor")
@@ -158,6 +163,7 @@ class Badge(Control):
         self._set_attr("bgColor", value)
 
     # label_visible
+
     @property
     def label_visible(self) -> Optional[bool]:
         return self._get_attr("isLabelVisible")
@@ -167,6 +173,7 @@ class Badge(Control):
         self._set_attr("isLabelVisible", value)
 
     # large_size
+
     @property
     def large_size(self) -> OptionalNumber:
         return self._get_attr("largeSize")
@@ -176,6 +183,7 @@ class Badge(Control):
         self._set_attr("largeSize", value)
 
     # padding
+
     @property
     def padding(self) -> PaddingValue:
         return self.__padding
@@ -185,6 +193,7 @@ class Badge(Control):
         self.__padding = value
 
     # small_size
+
     @property
     def small_size(self) -> OptionalNumber:
         return self._get_attr("smallSize")
@@ -194,6 +203,7 @@ class Badge(Control):
         self._set_attr("smallSize", value)
 
     # text_color
+
     @property
     def text_color(self):
         return self._get_attr("textColor")
@@ -203,6 +213,7 @@ class Badge(Control):
         self._set_attr("textColor", value)
 
     # text_style
+
     @property
     def text_style(self):
         return self.__text_style

--- a/sdk/python/packages/flet-core/src/flet_core/banner.py
+++ b/sdk/python/packages/flet-core/src/flet_core/banner.py
@@ -1,9 +1,9 @@
 from typing import Any, List, Optional
 
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.text_style import TextStyle
-from flet_core.types import PaddingValue, MarginValue
+from flet_core.types import MarginValue, OptionalNumber, PaddingValue
 
 
 class Banner(Control):
@@ -127,6 +127,7 @@ class Banner(Control):
         return children
 
     # open
+
     @property
     def open(self) -> Optional[bool]:
         return self._get_attr("open", data_type="bool", def_value=False)
@@ -136,6 +137,7 @@ class Banner(Control):
         self._set_attr("open", value)
 
     # modal
+
     @property
     def modal(self) -> Optional[bool]:
         return self._get_attr("modal", data_type="bool", def_value=False)
@@ -145,6 +147,7 @@ class Banner(Control):
         self._set_attr("modal", value)
 
     # leading
+
     @property
     def leading(self) -> Optional[Control]:
         return self.__leading
@@ -154,6 +157,7 @@ class Banner(Control):
         self.__leading = value
 
     # leading_padding
+
     @property
     def leading_padding(self) -> PaddingValue:
         return self.__leading_padding
@@ -163,6 +167,7 @@ class Banner(Control):
         self.__leading_padding = value
 
     # content
+
     @property
     def content(self) -> Optional[Control]:
         return self.__content
@@ -172,6 +177,7 @@ class Banner(Control):
         self.__content = value
 
     # content_padding
+
     @property
     def content_padding(self) -> PaddingValue:
         return self.__content_padding
@@ -181,6 +187,7 @@ class Banner(Control):
         self.__content_padding = value
 
     # margin
+
     @property
     def margin(self) -> MarginValue:
         return self.__margin
@@ -190,6 +197,7 @@ class Banner(Control):
         self.__margin = value
 
     # actions
+
     @property
     def actions(self):
         return self.__actions
@@ -199,6 +207,7 @@ class Banner(Control):
         self.__actions = value if value is not None else []
 
     # force_actions_below
+
     @property
     def force_actions_below(self) -> Optional[bool]:
         return self._get_attr("forceActionsBelow", data_type="bool", def_value=False)
@@ -208,6 +217,7 @@ class Banner(Control):
         self._set_attr("forceActionsBelow", value)
 
     # bgcolor
+
     @property
     def bgcolor(self) -> Optional[str]:
         return self._get_attr("bgColor")
@@ -217,6 +227,7 @@ class Banner(Control):
         self._set_attr("bgColor", value)
 
     # content_text_style
+
     @property
     def content_text_style(self) -> Optional[TextStyle]:
         return self.__content_text_style
@@ -226,6 +237,7 @@ class Banner(Control):
         self.__content_text_style = value
 
     # shadow_color
+
     @property
     def shadow_color(self) -> Optional[str]:
         return self._get_attr("shadowColor")
@@ -235,6 +247,7 @@ class Banner(Control):
         self._set_attr("shadowColor", value)
 
     # surface_tint_color
+
     @property
     def surface_tint_color(self) -> Optional[str]:
         return self._get_attr("surfaceTintColor")
@@ -244,6 +257,7 @@ class Banner(Control):
         self._set_attr("surfaceTintColor", value)
 
     # divider_color
+
     @property
     def divider_color(self) -> Optional[str]:
         return self._get_attr("dividerColor")
@@ -253,6 +267,7 @@ class Banner(Control):
         self._set_attr("dividerColor", value)
 
     # elevation
+
     @property
     def elevation(self) -> OptionalNumber:
         return self._get_attr("elevation", data_type="float")
@@ -262,6 +277,7 @@ class Banner(Control):
         self._set_attr("elevation", value)
 
     # on_visible
+
     @property
     def on_visible(self):
         return self._get_event_handler("visible")

--- a/sdk/python/packages/flet-core/src/flet_core/bottom_app_bar.py
+++ b/sdk/python/packages/flet-core/src/flet_core/bottom_app_bar.py
@@ -1,13 +1,14 @@
 from typing import Any, List, Optional, Union
 
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     ClipBehavior,
     NotchShape,
     OffsetValue,
+    OptionalNumber,
     PaddingValue,
     ResponsiveNumber,
     RotateValue,
@@ -122,6 +123,7 @@ class BottomAppBar(ConstrainedControl):
         return children
 
     # content
+
     @property
     def content(self) -> Optional[Control]:
         return self.__content
@@ -131,6 +133,7 @@ class BottomAppBar(ConstrainedControl):
         self.__content = value
 
     # surface_tint_color
+
     @property
     def surface_tint_color(self):
         return self._get_attr("surfaceTintColor")
@@ -140,6 +143,7 @@ class BottomAppBar(ConstrainedControl):
         self._set_attr("surfaceTintColor", value)
 
     # bgcolor
+
     @property
     def bgcolor(self):
         return self._get_attr("bgcolor")
@@ -149,6 +153,7 @@ class BottomAppBar(ConstrainedControl):
         self._set_attr("bgcolor", value)
 
     # shadow_color
+
     @property
     def shadow_color(self):
         return self._get_attr("shadowColor")
@@ -158,6 +163,7 @@ class BottomAppBar(ConstrainedControl):
         self._set_attr("shadowColor", value)
 
     # padding
+
     @property
     def padding(self) -> PaddingValue:
         return self.__padding
@@ -167,6 +173,7 @@ class BottomAppBar(ConstrainedControl):
         self.__padding = value
 
     # shape
+
     @property
     def shape(self):
         return self.__shape
@@ -177,6 +184,7 @@ class BottomAppBar(ConstrainedControl):
         self._set_attr("shape", value.value if isinstance(value, NotchShape) else value)
 
     # clip_behavior
+
     @property
     def clip_behavior(self) -> Optional[ClipBehavior]:
         return self.__clip_behavior
@@ -189,6 +197,7 @@ class BottomAppBar(ConstrainedControl):
         )
 
     # notch_margin
+
     @property
     def notch_margin(self) -> OptionalNumber:
         return self._get_attr("notchMargin")
@@ -198,6 +207,7 @@ class BottomAppBar(ConstrainedControl):
         self._set_attr("notchMargin", value)
 
     # elevation
+
     @property
     def elevation(self) -> OptionalNumber:
         return self._get_attr("elevation")

--- a/sdk/python/packages/flet-core/src/flet_core/bottom_sheet.py
+++ b/sdk/python/packages/flet-core/src/flet_core/bottom_sheet.py
@@ -1,7 +1,8 @@
 from typing import Any, Optional
 
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
+from flet_core.types import OptionalNumber
 
 
 class BottomSheet(Control):
@@ -103,6 +104,7 @@ class BottomSheet(Control):
         return children
 
     # open
+
     @property
     def open(self) -> Optional[bool]:
         return self._get_attr("open", data_type="bool", def_value=False)
@@ -112,6 +114,7 @@ class BottomSheet(Control):
         self._set_attr("open", value)
 
     # elevation
+
     @property
     def elevation(self) -> OptionalNumber:
         return self._get_attr("elevation")
@@ -121,6 +124,7 @@ class BottomSheet(Control):
         self._set_attr("elevation", value)
 
     # bgcolor
+
     @property
     def bgcolor(self):
         return self._get_attr("bgColor")
@@ -130,6 +134,7 @@ class BottomSheet(Control):
         self._set_attr("bgColor", value)
 
     # dismissible
+
     @property
     def dismissible(self) -> Optional[bool]:
         return self._get_attr("dismissible", data_type="bool", def_value=True)
@@ -139,6 +144,7 @@ class BottomSheet(Control):
         self._set_attr("dismissible", value)
 
     # enable_drag
+
     @property
     def enable_drag(self) -> Optional[bool]:
         return self._get_attr("enableDrag", data_type="bool", def_value=False)
@@ -148,6 +154,7 @@ class BottomSheet(Control):
         self._set_attr("enableDrag", value)
 
     # show_drag_handle
+
     @property
     def show_drag_handle(self) -> Optional[bool]:
         return self._get_attr("showDragHandle", data_type="bool", def_value=False)
@@ -157,6 +164,7 @@ class BottomSheet(Control):
         self._set_attr("showDragHandle", value)
 
     # use_safe_area
+
     @property
     def use_safe_area(self) -> Optional[bool]:
         return self._get_attr("useSafeArea", data_type="bool", def_value=True)
@@ -166,6 +174,7 @@ class BottomSheet(Control):
         self._set_attr("useSafeArea", value)
 
     # is_scroll_controlled
+
     @property
     def is_scroll_controlled(self) -> Optional[bool]:
         return self._get_attr("isScrollControlled", data_type="bool", def_value=False)
@@ -175,6 +184,7 @@ class BottomSheet(Control):
         self._set_attr("isScrollControlled", value)
 
     # maintain_bottom_view_insets_padding
+
     @property
     def maintain_bottom_view_insets_padding(self) -> Optional[bool]:
         return self._get_attr(
@@ -186,6 +196,7 @@ class BottomSheet(Control):
         self._set_attr("maintainBottomViewInsetsPadding", value)
 
     # content
+
     @property
     def content(self):
         return self.__content
@@ -195,6 +206,7 @@ class BottomSheet(Control):
         self.__content = value
 
     # on_dismiss
+
     @property
     def on_dismiss(self):
         return self._get_event_handler("dismiss")

--- a/sdk/python/packages/flet-core/src/flet_core/canvas/arc.py
+++ b/sdk/python/packages/flet-core/src/flet_core/canvas/arc.py
@@ -1,8 +1,8 @@
 from typing import Any, Optional
 
 from flet_core.canvas.shape import Shape
-from flet_core.control import OptionalNumber
 from flet_core.painting import Paint
+from flet_core.types import OptionalNumber
 
 
 class Arc(Shape):
@@ -43,6 +43,7 @@ class Arc(Shape):
         self._set_attr_json("paint", self.__paint)
 
     # x
+
     @property
     def x(self) -> OptionalNumber:
         return self._get_attr("x")
@@ -52,6 +53,7 @@ class Arc(Shape):
         self._set_attr("x", value)
 
     # y
+
     @property
     def y(self) -> OptionalNumber:
         return self._get_attr("y")
@@ -61,6 +63,7 @@ class Arc(Shape):
         self._set_attr("y", value)
 
     # width
+
     @property
     def width(self) -> OptionalNumber:
         return self._get_attr("width")
@@ -70,6 +73,7 @@ class Arc(Shape):
         self._set_attr("width", value)
 
     # height
+
     @property
     def height(self) -> OptionalNumber:
         return self._get_attr("height")
@@ -79,6 +83,7 @@ class Arc(Shape):
         self._set_attr("height", value)
 
     # start_angle
+
     @property
     def start_angle(self) -> OptionalNumber:
         return self._get_attr("startAngle")
@@ -88,6 +93,7 @@ class Arc(Shape):
         self._set_attr("startAngle", value)
 
     # sweep_angle
+
     @property
     def sweep_angle(self) -> OptionalNumber:
         return self._get_attr("sweepAngle")
@@ -97,6 +103,7 @@ class Arc(Shape):
         self._set_attr("sweepAngle", value)
 
     # use_center
+
     @property
     def use_center(self) -> Optional[bool]:
         return self._get_attr("useCenter", data_type="bool", def_value=False)
@@ -106,6 +113,7 @@ class Arc(Shape):
         self._set_attr("useCenter", value)
 
     # paint
+
     @property
     def paint(self) -> Optional[Paint]:
         return self.__paint

--- a/sdk/python/packages/flet-core/src/flet_core/canvas/canvas.py
+++ b/sdk/python/packages/flet-core/src/flet_core/canvas/canvas.py
@@ -3,13 +3,14 @@ from typing import Any, List, Optional, Union
 
 from flet_core.canvas.shape import Shape
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.control_event import ControlEvent
 from flet_core.event_handler import EventHandler
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -116,6 +117,7 @@ class Canvas(ConstrainedControl):
         self.clean()
 
     # shapes
+
     @property
     def shapes(self) -> List[Shape]:
         return self.__shapes
@@ -125,6 +127,7 @@ class Canvas(ConstrainedControl):
         self.__shapes = value if value is not None else []
 
     # content
+
     @property
     def content(self) -> Optional[Control]:
         return self.__content
@@ -134,6 +137,7 @@ class Canvas(ConstrainedControl):
         self.__content = value
 
     # resize_interval
+
     @property
     def resize_interval(self) -> OptionalNumber:
         return self._get_attr("resizeInterval")
@@ -143,6 +147,7 @@ class Canvas(ConstrainedControl):
         self._set_attr("resizeInterval", value)
 
     # on_resize
+
     @property
     def on_resize(self):
         return self.__on_resize

--- a/sdk/python/packages/flet-core/src/flet_core/canvas/circle.py
+++ b/sdk/python/packages/flet-core/src/flet_core/canvas/circle.py
@@ -1,8 +1,8 @@
 from typing import Any, Optional
 
 from flet_core.canvas.shape import Shape
-from flet_core.control import OptionalNumber
 from flet_core.painting import Paint
+from flet_core.types import OptionalNumber
 
 
 class Circle(Shape):
@@ -35,6 +35,7 @@ class Circle(Shape):
         self._set_attr_json("paint", self.__paint)
 
     # x
+
     @property
     def x(self) -> OptionalNumber:
         return self._get_attr("x")
@@ -44,6 +45,7 @@ class Circle(Shape):
         self._set_attr("x", value)
 
     # y
+
     @property
     def y(self) -> OptionalNumber:
         return self._get_attr("y")
@@ -53,6 +55,7 @@ class Circle(Shape):
         self._set_attr("y", value)
 
     # radius
+
     @property
     def radius(self) -> OptionalNumber:
         return self._get_attr("radius")
@@ -62,6 +65,7 @@ class Circle(Shape):
         self._set_attr("radius", value)
 
     # paint
+
     @property
     def paint(self) -> Optional[Paint]:
         return self.__paint

--- a/sdk/python/packages/flet-core/src/flet_core/canvas/line.py
+++ b/sdk/python/packages/flet-core/src/flet_core/canvas/line.py
@@ -1,8 +1,8 @@
 from typing import Any, Optional
 
 from flet_core.canvas.shape import Shape
-from flet_core.control import OptionalNumber
 from flet_core.painting import Paint
+from flet_core.types import OptionalNumber
 
 
 class Line(Shape):
@@ -37,6 +37,7 @@ class Line(Shape):
         self._set_attr_json("paint", self.__paint)
 
     # x1
+
     @property
     def x1(self) -> OptionalNumber:
         return self._get_attr("x1")
@@ -46,6 +47,7 @@ class Line(Shape):
         self._set_attr("x1", value)
 
     # y1
+
     @property
     def y1(self) -> OptionalNumber:
         return self._get_attr("y1")
@@ -55,6 +57,7 @@ class Line(Shape):
         self._set_attr("y1", value)
 
     # x2
+
     @property
     def x2(self) -> OptionalNumber:
         return self._get_attr("x2")
@@ -64,6 +67,7 @@ class Line(Shape):
         self._set_attr("x2", value)
 
     # y2
+
     @property
     def y2(self) -> OptionalNumber:
         return self._get_attr("y2")
@@ -73,6 +77,7 @@ class Line(Shape):
         self._set_attr("y2", value)
 
     # paint
+
     @property
     def paint(self) -> Optional[Paint]:
         return self.__paint

--- a/sdk/python/packages/flet-core/src/flet_core/canvas/oval.py
+++ b/sdk/python/packages/flet-core/src/flet_core/canvas/oval.py
@@ -1,8 +1,8 @@
 from typing import Any, Optional
 
 from flet_core.canvas.shape import Shape
-from flet_core.control import OptionalNumber
 from flet_core.painting import Paint
+from flet_core.types import OptionalNumber
 
 
 class Oval(Shape):
@@ -35,6 +35,7 @@ class Oval(Shape):
         self._set_attr_json("paint", self.__paint)
 
     # x
+
     @property
     def x(self) -> OptionalNumber:
         return self._get_attr("x")
@@ -44,6 +45,7 @@ class Oval(Shape):
         self._set_attr("x", value)
 
     # y
+
     @property
     def y(self) -> OptionalNumber:
         return self._get_attr("y")
@@ -53,6 +55,7 @@ class Oval(Shape):
         self._set_attr("y", value)
 
     # width
+
     @property
     def width(self) -> OptionalNumber:
         return self._get_attr("width")
@@ -62,6 +65,7 @@ class Oval(Shape):
         self._set_attr("width", value)
 
     # height
+
     @property
     def height(self) -> OptionalNumber:
         return self._get_attr("height")
@@ -71,6 +75,7 @@ class Oval(Shape):
         self._set_attr("height", value)
 
     # paint
+
     @property
     def paint(self) -> Optional[Paint]:
         return self.__paint

--- a/sdk/python/packages/flet-core/src/flet_core/canvas/rect.py
+++ b/sdk/python/packages/flet-core/src/flet_core/canvas/rect.py
@@ -1,9 +1,8 @@
 from typing import Any, Optional
 
 from flet_core.canvas.shape import Shape
-from flet_core.control import OptionalNumber
 from flet_core.painting import Paint
-from flet_core.types import BorderRadiusValue
+from flet_core.types import BorderRadiusValue, OptionalNumber
 
 
 class Rect(Shape):
@@ -39,6 +38,7 @@ class Rect(Shape):
         self._set_attr_json("paint", self.__paint)
 
     # x
+
     @property
     def x(self) -> OptionalNumber:
         return self._get_attr("x")
@@ -48,6 +48,7 @@ class Rect(Shape):
         self._set_attr("x", value)
 
     # y
+
     @property
     def y(self) -> OptionalNumber:
         return self._get_attr("y")
@@ -57,6 +58,7 @@ class Rect(Shape):
         self._set_attr("y", value)
 
     # width
+
     @property
     def width(self) -> OptionalNumber:
         return self._get_attr("width")
@@ -66,6 +68,7 @@ class Rect(Shape):
         self._set_attr("width", value)
 
     # height
+
     @property
     def height(self) -> OptionalNumber:
         return self._get_attr("height")
@@ -75,6 +78,7 @@ class Rect(Shape):
         self._set_attr("height", value)
 
     # border_radius
+
     @property
     def border_radius(self) -> BorderRadiusValue:
         return self.__border_radius
@@ -84,6 +88,7 @@ class Rect(Shape):
         self.__border_radius = value
 
     # paint
+
     @property
     def paint(self) -> Optional[Paint]:
         return self.__paint

--- a/sdk/python/packages/flet-core/src/flet_core/canvas/shadow.py
+++ b/sdk/python/packages/flet-core/src/flet_core/canvas/shadow.py
@@ -2,7 +2,7 @@ from typing import Any, List, Optional
 
 from flet_core.canvas.path import Path
 from flet_core.canvas.shape import Shape
-from flet_core.control import OptionalNumber
+from flet_core.types import OptionalNumber
 
 
 class Shadow(Shape):
@@ -35,6 +35,7 @@ class Shadow(Shape):
         self._set_attr_json("path", self.__path)
 
     # path
+
     @property
     def path(self):
         return self.__path
@@ -44,6 +45,7 @@ class Shadow(Shape):
         self.__path = value if value is not None else []
 
     # color
+
     @property
     def color(self) -> Optional[str]:
         return self._get_attr("color")
@@ -53,6 +55,7 @@ class Shadow(Shape):
         self._set_attr("color", value)
 
     # elevation
+
     @property
     def elevation(self) -> OptionalNumber:
         return self._get_attr("elevation")
@@ -62,6 +65,7 @@ class Shadow(Shape):
         self._set_attr("elevation", value)
 
     # transparent_occluder
+
     @property
     def transparent_occluder(self) -> Optional[bool]:
         return self._get_attr("transparentOccluder", data_type="bool", def_value=False)

--- a/sdk/python/packages/flet-core/src/flet_core/canvas/text.py
+++ b/sdk/python/packages/flet-core/src/flet_core/canvas/text.py
@@ -2,10 +2,9 @@ from typing import Any, List, Optional
 
 from flet_core.alignment import Alignment
 from flet_core.canvas.shape import Shape
-from flet_core.control import OptionalNumber
 from flet_core.inline_span import InlineSpan
 from flet_core.text_style import TextStyle
-from flet_core.types import TextAlign
+from flet_core.types import OptionalNumber, TextAlign
 
 
 class Text(Shape):
@@ -58,6 +57,7 @@ class Text(Shape):
         self._set_attr_json("alignment", self.__alignment)
 
     # x
+
     @property
     def x(self) -> OptionalNumber:
         return self._get_attr("x")
@@ -67,6 +67,7 @@ class Text(Shape):
         self._set_attr("x", value)
 
     # y
+
     @property
     def y(self) -> OptionalNumber:
         return self._get_attr("y")
@@ -76,6 +77,7 @@ class Text(Shape):
         self._set_attr("y", value)
 
     # text
+
     @property
     def text(self) -> Optional[str]:
         return self._get_attr("text")
@@ -85,6 +87,7 @@ class Text(Shape):
         self._set_attr("text", value)
 
     # style
+
     @property
     def style(self) -> Optional[TextStyle]:
         return self.__style
@@ -94,6 +97,7 @@ class Text(Shape):
         self.__style = value
 
     # spans
+
     @property
     def spans(self) -> Optional[List[InlineSpan]]:
         return self.__spans
@@ -103,6 +107,7 @@ class Text(Shape):
         self.__spans = value if value is not None else []
 
     # alignment
+
     @property
     def alignment(self) -> Optional[Alignment]:
         return self.__alignment
@@ -112,6 +117,7 @@ class Text(Shape):
         self.__alignment = value
 
     # text_align
+
     @property
     def text_align(self) -> Optional[TextAlign]:
         return self.__text_align
@@ -124,6 +130,7 @@ class Text(Shape):
         )
 
     # max_lines
+
     @property
     def max_lines(self) -> Optional[int]:
         return self._get_attr("maxLines")
@@ -133,6 +140,7 @@ class Text(Shape):
         self._set_attr("maxLines", value)
 
     # max_width
+
     @property
     def max_width(self) -> OptionalNumber:
         return self._get_attr("maxWidth")
@@ -142,6 +150,7 @@ class Text(Shape):
         self._set_attr("maxWidth", value)
 
     # ellipsis
+
     @property
     def ellipsis(self) -> Optional[str]:
         return self._get_attr("ellipsis")
@@ -151,6 +160,7 @@ class Text(Shape):
         self._set_attr("ellipsis", value)
 
     # rotate
+
     @property
     def rotate(self) -> OptionalNumber:
         return self._get_attr("rotate")

--- a/sdk/python/packages/flet-core/src/flet_core/card.py
+++ b/sdk/python/packages/flet-core/src/flet_core/card.py
@@ -4,13 +4,14 @@ from typing import Any, Optional, Union
 from flet_core import OutlinedBorder
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     ClipBehavior,
     MarginValue,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -172,6 +173,7 @@ class Card(ConstrainedControl, AdaptiveControl):
         return children
 
     # margin
+
     @property
     def margin(self) -> MarginValue:
         return self.__margin
@@ -181,6 +183,7 @@ class Card(ConstrainedControl, AdaptiveControl):
         self.__margin = value
 
     # elevation
+
     @property
     def elevation(self) -> OptionalNumber:
         return self._get_attr("elevation")
@@ -190,6 +193,7 @@ class Card(ConstrainedControl, AdaptiveControl):
         self._set_attr("elevation", value)
 
     # color
+
     @property
     def color(self):
         return self._get_attr("color")
@@ -199,6 +203,7 @@ class Card(ConstrainedControl, AdaptiveControl):
         self._set_attr("color", value)
 
     # shadow_color
+
     @property
     def shadow_color(self):
         return self._get_attr("shadowColor")
@@ -208,6 +213,7 @@ class Card(ConstrainedControl, AdaptiveControl):
         self._set_attr("shadowColor", value)
 
     # surface_tint_color
+
     @property
     def surface_tint_color(self):
         return self._get_attr("surfaceTintColor")
@@ -217,6 +223,7 @@ class Card(ConstrainedControl, AdaptiveControl):
         self._set_attr("surfaceTintColor", value)
 
     # shape
+
     @property
     def shape(self) -> Optional[OutlinedBorder]:
         return self.__shape
@@ -226,6 +233,7 @@ class Card(ConstrainedControl, AdaptiveControl):
         self.__shape = value
 
     # content
+
     @property
     def content(self) -> Optional[Control]:
         return self.__content
@@ -235,6 +243,7 @@ class Card(ConstrainedControl, AdaptiveControl):
         self.__content = value
 
     # clip_behavior
+
     @property
     def clip_behavior(self) -> Optional[ClipBehavior]:
         return self.__clip_behavior
@@ -248,6 +257,7 @@ class Card(ConstrainedControl, AdaptiveControl):
         )
 
     # is_semantic_container
+
     @property
     def is_semantic_container(self) -> Optional[bool]:
         return self._get_attr("isSemanticContainer", data_type="bool", def_value=True)
@@ -257,6 +267,7 @@ class Card(ConstrainedControl, AdaptiveControl):
         self._set_attr("isSemanticContainer", value)
 
     # show_border_on_foreground
+
     @property
     def show_border_on_foreground(self) -> Optional[bool]:
         return self._get_attr(
@@ -268,6 +279,7 @@ class Card(ConstrainedControl, AdaptiveControl):
         self._set_attr("showBorderOnForeground", value)
 
     # variant
+
     @property
     def variant(self) -> Optional[CardVariant]:
         return self.__variant

--- a/sdk/python/packages/flet-core/src/flet_core/charts/bar_chart.py
+++ b/sdk/python/packages/flet-core/src/flet_core/charts/bar_chart.py
@@ -6,13 +6,13 @@ from flet_core.charts.bar_chart_group import BarChartGroup
 from flet_core.charts.chart_axis import ChartAxis
 from flet_core.charts.chart_grid_lines import ChartGridLines
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import OptionalNumber
 from flet_core.control_event import ControlEvent
 from flet_core.event_handler import EventHandler
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -153,6 +153,7 @@ class BarChart(ConstrainedControl):
         return children
 
     # bar_groups
+
     @property
     def bar_groups(self):
         return self.__bar_groups
@@ -162,6 +163,7 @@ class BarChart(ConstrainedControl):
         self.__bar_groups = value if value is not None else []
 
     # groups_space
+
     @property
     def groups_space(self) -> OptionalNumber:
         return self._get_attr("groupsSpace", data_type="float")
@@ -171,6 +173,7 @@ class BarChart(ConstrainedControl):
         self._set_attr("groupsSpace", value)
 
     # animate
+
     @property
     def animate(self) -> AnimationValue:
         return self.__animate
@@ -180,6 +183,7 @@ class BarChart(ConstrainedControl):
         self.__animate = value
 
     # bgcolor
+
     @property
     def bgcolor(self) -> Optional[str]:
         return self._get_attr("bgcolor")
@@ -189,6 +193,7 @@ class BarChart(ConstrainedControl):
         self._set_attr("bgcolor", value)
 
     # interactive
+
     @property
     def interactive(self) -> Optional[bool]:
         return self._get_attr("interactive", data_type="bool", def_value=True)
@@ -198,6 +203,7 @@ class BarChart(ConstrainedControl):
         self._set_attr("interactive", value)
 
     # tooltip_bgcolor
+
     @property
     def tooltip_bgcolor(self) -> Optional[str]:
         return self._get_attr("tooltipBgcolor")
@@ -207,6 +213,7 @@ class BarChart(ConstrainedControl):
         self._set_attr("tooltipBgcolor", value)
 
     # border
+
     @property
     def border(self) -> Optional[Border]:
         return self.__border
@@ -216,6 +223,7 @@ class BarChart(ConstrainedControl):
         self.__border = value
 
     # horizontal_grid_lines
+
     @property
     def horizontal_grid_lines(self) -> Optional[ChartGridLines]:
         return self.__horizontal_grid_lines
@@ -225,6 +233,7 @@ class BarChart(ConstrainedControl):
         self.__horizontal_grid_lines = value
 
     # vertical_grid_lines
+
     @property
     def vertical_grid_lines(self) -> Optional[ChartGridLines]:
         return self.__vertical_grid_lines
@@ -234,6 +243,7 @@ class BarChart(ConstrainedControl):
         self.__vertical_grid_lines = value
 
     # left_axis
+
     @property
     def left_axis(self) -> Optional[ChartAxis]:
         return self.__left_axis
@@ -243,6 +253,7 @@ class BarChart(ConstrainedControl):
         self.__left_axis = value
 
     # top_axis
+
     @property
     def top_axis(self) -> Optional[ChartAxis]:
         return self.__top_axis
@@ -252,6 +263,7 @@ class BarChart(ConstrainedControl):
         self.__top_axis = value
 
     # right_axis
+
     @property
     def right_axis(self) -> Optional[ChartAxis]:
         return self.__right_axis
@@ -261,6 +273,7 @@ class BarChart(ConstrainedControl):
         self.__right_axis = value
 
     # bottom_axis
+
     @property
     def bottom_axis(self) -> Optional[ChartAxis]:
         return self.__bottom_axis
@@ -270,6 +283,7 @@ class BarChart(ConstrainedControl):
         self.__bottom_axis = value
 
     # baseline_y
+
     @property
     def baseline_y(self) -> OptionalNumber:
         return self._get_attr("baseliney", data_type="float")
@@ -279,6 +293,7 @@ class BarChart(ConstrainedControl):
         self._set_attr("baseliney", value)
 
     # min_y
+
     @property
     def min_y(self) -> OptionalNumber:
         return self._get_attr("miny", data_type="float")
@@ -288,6 +303,7 @@ class BarChart(ConstrainedControl):
         self._set_attr("miny", value)
 
     # max_y
+
     @property
     def max_y(self) -> OptionalNumber:
         return self._get_attr("maxy", data_type="float")
@@ -297,6 +313,7 @@ class BarChart(ConstrainedControl):
         self._set_attr("maxy", value)
 
     # on_chart_event
+
     @property
     def on_chart_event(self):
         return self.__on_chart_event

--- a/sdk/python/packages/flet-core/src/flet_core/charts/bar_chart_group.py
+++ b/sdk/python/packages/flet-core/src/flet_core/charts/bar_chart_group.py
@@ -1,8 +1,9 @@
 from typing import Any, List, Optional
 
 from flet_core.charts.bar_chart_rod import BarChartRod
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
+from flet_core.types import OptionalNumber
 
 
 class BarChartGroup(Control):
@@ -44,6 +45,7 @@ class BarChartGroup(Control):
         return self.__bar_rods
 
     # bar_rods
+
     @property
     def bar_rods(self):
         return self.__bar_rods
@@ -53,6 +55,7 @@ class BarChartGroup(Control):
         self.__bar_rods = value if value is not None else []
 
     # x
+
     @property
     def x(self) -> Optional[int]:
         return self._get_attr("x", data_type="int")
@@ -62,6 +65,7 @@ class BarChartGroup(Control):
         self._set_attr("x", value)
 
     # group_vertically
+
     @property
     def group_vertically(self) -> Optional[bool]:
         return self._get_attr("groupVertically", data_type="bool", def_value=False)
@@ -71,6 +75,7 @@ class BarChartGroup(Control):
         self._set_attr("groupVertically", value)
 
     # bars_space
+
     @property
     def bars_space(self) -> OptionalNumber:
         return self._get_attr("barsSpace", data_type="float")

--- a/sdk/python/packages/flet-core/src/flet_core/charts/bar_chart_rod.py
+++ b/sdk/python/packages/flet-core/src/flet_core/charts/bar_chart_rod.py
@@ -2,11 +2,11 @@ from typing import Any, List, Optional
 
 from flet_core.border import BorderSide
 from flet_core.charts.bar_chart_rod_stack_item import BarChartRodStackItem
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.gradients import Gradient
 from flet_core.ref import Ref
 from flet_core.text_style import TextStyle
-from flet_core.types import BorderRadiusValue, TextAlign
+from flet_core.types import BorderRadiusValue, OptionalNumber, TextAlign
 
 
 class BarChartRod(Control):
@@ -78,6 +78,7 @@ class BarChartRod(Control):
         return self.__rod_stack_items
 
     # rod_stack_items
+
     @property
     def rod_stack_items(self):
         return self.__rod_stack_items
@@ -87,6 +88,7 @@ class BarChartRod(Control):
         self.__rod_stack_items = value if value is not None else []
 
     # from_y
+
     @property
     def from_y(self) -> OptionalNumber:
         return self._get_attr("fromY", data_type="float")
@@ -96,6 +98,7 @@ class BarChartRod(Control):
         self._set_attr("fromY", value)
 
     # to_y
+
     @property
     def to_y(self) -> OptionalNumber:
         return self._get_attr("toY", data_type="float")
@@ -105,6 +108,7 @@ class BarChartRod(Control):
         self._set_attr("toY", value)
 
     # width
+
     @property
     def width(self) -> OptionalNumber:
         return self._get_attr("width", data_type="float")
@@ -114,6 +118,7 @@ class BarChartRod(Control):
         self._set_attr("width", value)
 
     # color
+
     @property
     def color(self) -> Optional[str]:
         return self._get_attr("color")
@@ -123,6 +128,7 @@ class BarChartRod(Control):
         self._set_attr("color", value)
 
     # border_side
+
     @property
     def border_side(self) -> Optional[BorderSide]:
         return self.__border_side
@@ -132,6 +138,7 @@ class BarChartRod(Control):
         self.__border_side = value
 
     # border_radius
+
     @property
     def border_radius(self) -> Optional[BorderRadiusValue]:
         return self.__border_radius
@@ -141,6 +148,7 @@ class BarChartRod(Control):
         self.__border_radius = value
 
     # gradient
+
     @property
     def gradient(self) -> Optional[Gradient]:
         return self.__gradient
@@ -150,6 +158,7 @@ class BarChartRod(Control):
         self.__gradient = value
 
     # bg_from_y
+
     @property
     def bg_from_y(self) -> OptionalNumber:
         return self._get_attr("bgFromY", data_type="float")
@@ -159,6 +168,7 @@ class BarChartRod(Control):
         self._set_attr("bgFromY", value)
 
     # bg_to_y
+
     @property
     def bg_to_y(self) -> OptionalNumber:
         return self._get_attr("bgToY", data_type="float")
@@ -168,6 +178,7 @@ class BarChartRod(Control):
         self._set_attr("bgToY", value)
 
     # bg_color
+
     @property
     def bg_color(self) -> Optional[str]:
         return self._get_attr("bgColor")
@@ -177,6 +188,7 @@ class BarChartRod(Control):
         self._set_attr("bgColor", value)
 
     # bg_gradient
+
     @property
     def bg_gradient(self) -> Optional[Gradient]:
         return self.__bg_gradient
@@ -186,6 +198,7 @@ class BarChartRod(Control):
         self.__bg_gradient = value
 
     # selected
+
     @property
     def selected(self) -> Optional[bool]:
         return self._get_attr("selected", data_type="bool", def_value=False)
@@ -195,6 +208,7 @@ class BarChartRod(Control):
         self._set_attr("selected", value)
 
     # show_tooltip
+
     @property
     def show_tooltip(self) -> Optional[bool]:
         return self._get_attr("showTooltip", data_type="bool", def_value=True)
@@ -204,6 +218,7 @@ class BarChartRod(Control):
         self._set_attr("showTooltip", value)
 
     # tooltip
+
     @property
     def tooltip(self) -> Optional[str]:
         return self._get_attr("tooltip")
@@ -213,6 +228,7 @@ class BarChartRod(Control):
         self._set_attr("tooltip", value)
 
     # tooltip_align
+
     @property
     def tooltip_align(self) -> Optional[TextAlign]:
         return self.__tooltip_align
@@ -225,6 +241,7 @@ class BarChartRod(Control):
         )
 
     # tooltip_style
+
     @property
     def tooltip_style(self):
         return self.__tooltip_style

--- a/sdk/python/packages/flet-core/src/flet_core/charts/bar_chart_rod_stack_item.py
+++ b/sdk/python/packages/flet-core/src/flet_core/charts/bar_chart_rod_stack_item.py
@@ -1,8 +1,9 @@
 from typing import Any, Optional
 
 from flet_core.border import BorderSide
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
+from flet_core.types import OptionalNumber
 
 
 class BarChartRodStackItem(Control):
@@ -42,6 +43,7 @@ class BarChartRodStackItem(Control):
         self._set_attr_json("borderSide", self.__border_side)
 
     # from_y
+
     @property
     def from_y(self) -> OptionalNumber:
         return self._get_attr("fromY", data_type="float")
@@ -51,6 +53,7 @@ class BarChartRodStackItem(Control):
         self._set_attr("fromY", value)
 
     # to_y
+
     @property
     def to_y(self) -> OptionalNumber:
         return self._get_attr("toY", data_type="float")
@@ -60,6 +63,7 @@ class BarChartRodStackItem(Control):
         self._set_attr("toY", value)
 
     # color
+
     @property
     def color(self) -> Optional[str]:
         return self._get_attr("color")
@@ -69,6 +73,7 @@ class BarChartRodStackItem(Control):
         self._set_attr("color", value)
 
     # border_side
+
     @property
     def border_side(self) -> Optional[BorderSide]:
         return self.__border_side

--- a/sdk/python/packages/flet-core/src/flet_core/charts/chart_axis.py
+++ b/sdk/python/packages/flet-core/src/flet_core/charts/chart_axis.py
@@ -1,8 +1,9 @@
 from typing import Any, List, Optional
 
 from flet_core.charts.chart_axis_label import ChartAxisLabel
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
+from flet_core.types import OptionalNumber
 
 
 class ChartAxis(Control):
@@ -52,6 +53,7 @@ class ChartAxis(Control):
         return children
 
     # title
+
     @property
     def title(self) -> Optional[Control]:
         return self.__title
@@ -61,6 +63,7 @@ class ChartAxis(Control):
         self.__title = value
 
     # title_size
+
     @property
     def title_size(self) -> OptionalNumber:
         return self._get_attr("titleSize", data_type="float")
@@ -70,6 +73,7 @@ class ChartAxis(Control):
         self._set_attr("titleSize", value)
 
     # show_labels
+
     @property
     def show_labels(self) -> Optional[bool]:
         return self._get_attr("showLabels", data_type="bool", def_value=True)
@@ -79,6 +83,7 @@ class ChartAxis(Control):
         self._set_attr("showLabels", value)
 
     # labels
+
     @property
     def labels(self):
         return self.__labels
@@ -88,6 +93,7 @@ class ChartAxis(Control):
         self.__labels = value if value is not None else []
 
     # labels_interval
+
     @property
     def labels_interval(self) -> OptionalNumber:
         return self._get_attr("labelsInterval", data_type="float", def_value=1.0)
@@ -97,6 +103,7 @@ class ChartAxis(Control):
         self._set_attr("labelsInterval", value)
 
     # labels_size
+
     @property
     def labels_size(self) -> OptionalNumber:
         return self._get_attr("labelsSize", data_type="float")

--- a/sdk/python/packages/flet-core/src/flet_core/charts/chart_axis_label.py
+++ b/sdk/python/packages/flet-core/src/flet_core/charts/chart_axis_label.py
@@ -1,7 +1,8 @@
 from typing import Any, Optional
 
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
+from flet_core.types import OptionalNumber
 
 
 class ChartAxisLabel(Control):
@@ -39,6 +40,7 @@ class ChartAxisLabel(Control):
         return children
 
     # value
+
     @property
     def value(self) -> OptionalNumber:
         return self._get_attr("value", data_type="float", def_value=1.0)
@@ -48,6 +50,7 @@ class ChartAxisLabel(Control):
         self._set_attr("value", value)
 
     # label
+
     @property
     def label(self) -> Optional[Control]:
         return self.__label

--- a/sdk/python/packages/flet-core/src/flet_core/charts/line_chart.py
+++ b/sdk/python/packages/flet-core/src/flet_core/charts/line_chart.py
@@ -1,18 +1,18 @@
 import json
-from typing import List, Optional, Union, Any
+from typing import Any, List, Optional, Union
 
 from flet_core.border import Border
 from flet_core.charts.chart_axis import ChartAxis
 from flet_core.charts.chart_grid_lines import ChartGridLines
 from flet_core.charts.line_chart_data import LineChartData
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import OptionalNumber
 from flet_core.control_event import ControlEvent
 from flet_core.event_handler import EventHandler
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -161,6 +161,7 @@ class LineChart(ConstrainedControl):
         return children
 
     # data_series
+
     @property
     def data_series(self):
         return self.__data_series
@@ -170,6 +171,7 @@ class LineChart(ConstrainedControl):
         self.__data_series = value if value is not None else []
 
     # animate
+
     @property
     def animate(self) -> AnimationValue:
         return self.__animate
@@ -179,6 +181,7 @@ class LineChart(ConstrainedControl):
         self.__animate = value
 
     # bgcolor
+
     @property
     def bgcolor(self) -> Optional[str]:
         return self._get_attr("bgcolor")
@@ -188,6 +191,7 @@ class LineChart(ConstrainedControl):
         self._set_attr("bgcolor", value)
 
     # interactive
+
     @property
     def interactive(self) -> Optional[bool]:
         return self._get_attr("interactive", data_type="bool", def_value=True)
@@ -197,6 +201,7 @@ class LineChart(ConstrainedControl):
         self._set_attr("interactive", value)
 
     # point_line_start
+
     @property
     def point_line_start(self) -> OptionalNumber:
         return self._get_attr("pointLineStart", data_type="float")
@@ -206,6 +211,7 @@ class LineChart(ConstrainedControl):
         self._set_attr("pointLineStart", value)
 
     # point_line_end
+
     @property
     def point_line_end(self) -> OptionalNumber:
         return self._get_attr("pointLineEnd", data_type="float")
@@ -215,6 +221,7 @@ class LineChart(ConstrainedControl):
         self._set_attr("pointLineEnd", value)
 
     # tooltip_bgcolor
+
     @property
     def tooltip_bgcolor(self) -> Optional[str]:
         return self._get_attr("tooltipBgcolor")
@@ -224,6 +231,7 @@ class LineChart(ConstrainedControl):
         self._set_attr("tooltipBgcolor", value)
 
     # border
+
     @property
     def border(self) -> Optional[Border]:
         return self.__border
@@ -233,6 +241,7 @@ class LineChart(ConstrainedControl):
         self.__border = value
 
     # horizontal_grid_lines
+
     @property
     def horizontal_grid_lines(self) -> Optional[ChartGridLines]:
         return self.__horizontal_grid_lines
@@ -242,6 +251,7 @@ class LineChart(ConstrainedControl):
         self.__horizontal_grid_lines = value
 
     # vertical_grid_lines
+
     @property
     def vertical_grid_lines(self) -> Optional[ChartGridLines]:
         return self.__vertical_grid_lines
@@ -251,6 +261,7 @@ class LineChart(ConstrainedControl):
         self.__vertical_grid_lines = value
 
     # left_axis
+
     @property
     def left_axis(self) -> Optional[ChartAxis]:
         return self.__left_axis
@@ -260,6 +271,7 @@ class LineChart(ConstrainedControl):
         self.__left_axis = value
 
     # top_axis
+
     @property
     def top_axis(self) -> Optional[ChartAxis]:
         return self.__top_axis
@@ -269,6 +281,7 @@ class LineChart(ConstrainedControl):
         self.__top_axis = value
 
     # right_axis
+
     @property
     def right_axis(self) -> Optional[ChartAxis]:
         return self.__right_axis
@@ -278,6 +291,7 @@ class LineChart(ConstrainedControl):
         self.__right_axis = value
 
     # bottom_axis
+
     @property
     def bottom_axis(self) -> Optional[ChartAxis]:
         return self.__bottom_axis
@@ -287,6 +301,7 @@ class LineChart(ConstrainedControl):
         self.__bottom_axis = value
 
     # baseline_x
+
     @property
     def baseline_x(self) -> OptionalNumber:
         return self._get_attr("baselinex", data_type="float")
@@ -296,6 +311,7 @@ class LineChart(ConstrainedControl):
         self._set_attr("baselinex", value)
 
     # baseline_y
+
     @property
     def baseline_y(self) -> OptionalNumber:
         return self._get_attr("baseliney", data_type="float")
@@ -305,6 +321,7 @@ class LineChart(ConstrainedControl):
         self._set_attr("baseliney", value)
 
     # min_x
+
     @property
     def min_x(self) -> OptionalNumber:
         return self._get_attr("minx", data_type="float")
@@ -314,6 +331,7 @@ class LineChart(ConstrainedControl):
         self._set_attr("minx", value)
 
     # max_x
+
     @property
     def max_x(self) -> OptionalNumber:
         return self._get_attr("maxx", data_type="float")
@@ -323,6 +341,7 @@ class LineChart(ConstrainedControl):
         self._set_attr("maxx", value)
 
     # min_y
+
     @property
     def min_y(self) -> OptionalNumber:
         return self._get_attr("miny", data_type="float")
@@ -332,6 +351,7 @@ class LineChart(ConstrainedControl):
         self._set_attr("miny", value)
 
     # max_y
+
     @property
     def max_y(self) -> OptionalNumber:
         return self._get_attr("maxy", data_type="float")
@@ -341,6 +361,7 @@ class LineChart(ConstrainedControl):
         self._set_attr("maxy", value)
 
     # on_chart_event
+
     @property
     def on_chart_event(self):
         return self.__on_chart_event

--- a/sdk/python/packages/flet-core/src/flet_core/charts/line_chart_data.py
+++ b/sdk/python/packages/flet-core/src/flet_core/charts/line_chart_data.py
@@ -3,10 +3,11 @@ from typing import Any, List, Optional, Union
 from flet_core.charts.chart_point_line import ChartPointLine
 from flet_core.charts.chart_point_shape import ChartPointShape
 from flet_core.charts.line_chart_data_point import LineChartDataPoint
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.gradients import Gradient
 from flet_core.ref import Ref
 from flet_core.shadow import BoxShadow
+from flet_core.types import OptionalNumber
 
 
 class LineChartData(Control):
@@ -94,6 +95,7 @@ class LineChartData(Control):
         return self.__data_points
 
     # data_points
+
     @property
     def data_points(self):
         return self.__data_points
@@ -103,6 +105,7 @@ class LineChartData(Control):
         self.__data_points = value if value is not None else []
 
     # stroke_width
+
     @property
     def stroke_width(self) -> OptionalNumber:
         return self._get_attr("strokeWidth", data_type="float", def_value=1.0)
@@ -112,6 +115,7 @@ class LineChartData(Control):
         self._set_attr("strokeWidth", value)
 
     # curved
+
     @property
     def curved(self) -> Optional[bool]:
         return self._get_attr("curved", data_type="bool", def_value=False)
@@ -121,6 +125,7 @@ class LineChartData(Control):
         self._set_attr("curved", value)
 
     # color
+
     @property
     def color(self) -> Optional[str]:
         return self._get_attr("color")
@@ -130,6 +135,7 @@ class LineChartData(Control):
         self._set_attr("color", value)
 
     # gradient
+
     @property
     def gradient(self) -> Optional[Gradient]:
         return self.__gradient
@@ -139,6 +145,7 @@ class LineChartData(Control):
         self.__gradient = value
 
     # stroke_cap_round
+
     @property
     def stroke_cap_round(self) -> Optional[bool]:
         return self._get_attr("strokeCapRound", data_type="bool", def_value=False)
@@ -148,6 +155,7 @@ class LineChartData(Control):
         self._set_attr("strokeCapRound", value)
 
     # prevent_curve_over_shooting
+
     @property
     def prevent_curve_over_shooting(self) -> Optional[bool]:
         return self._get_attr(
@@ -159,6 +167,7 @@ class LineChartData(Control):
         self._set_attr("preventCurveOverShooting", value)
 
     # prevent_curve_over_shooting_threshold
+
     @property
     def prevent_curve_over_shooting_threshold(self) -> OptionalNumber:
         return self._get_attr("preventCurveOverShootingThreshold", data_type="float")
@@ -168,6 +177,7 @@ class LineChartData(Control):
         self._set_attr("preventCurveOverShootingThreshold", value)
 
     # dash_pattern
+
     @property
     def dash_pattern(self):
         return self.__dash_pattern
@@ -177,6 +187,7 @@ class LineChartData(Control):
         self.__dash_pattern = value
 
     # shadow
+
     @property
     def shadow(self):
         return self.__shadow
@@ -186,6 +197,7 @@ class LineChartData(Control):
         self.__shadow = value
 
     # point
+
     @property
     def point(self):
         return self.__point
@@ -195,6 +207,7 @@ class LineChartData(Control):
         self.__point = value
 
     # selected_point
+
     @property
     def selected_point(self):
         return self.__selected_point
@@ -204,6 +217,7 @@ class LineChartData(Control):
         self.__selected_point = value
 
     # above_line_bgcolor
+
     @property
     def above_line_bgcolor(self) -> Optional[str]:
         return self._get_attr("aboveLineBgcolor")
@@ -213,6 +227,7 @@ class LineChartData(Control):
         self._set_attr("aboveLineBgcolor", value)
 
     # above_line_gradient
+
     @property
     def above_line_gradient(self) -> Optional[Gradient]:
         return self.__above_line_gradient
@@ -222,6 +237,7 @@ class LineChartData(Control):
         self.__above_line_gradient = value
 
     # above_line_cutoff_y
+
     @property
     def above_line_cutoff_y(self) -> OptionalNumber:
         return self._get_attr("aboveLineCutoffY", data_type="float")
@@ -231,6 +247,7 @@ class LineChartData(Control):
         self._set_attr("aboveLineCutoffY", value)
 
     # above_line
+
     @property
     def above_line(self) -> Optional[ChartPointLine]:
         return self.__above_line
@@ -240,6 +257,7 @@ class LineChartData(Control):
         self.__above_line = value
 
     # below_line_bgcolor
+
     @property
     def below_line_bgcolor(self) -> Optional[str]:
         return self._get_attr("belowLineBgcolor")
@@ -249,6 +267,7 @@ class LineChartData(Control):
         self._set_attr("belowLineBgcolor", value)
 
     # below_line_gradient
+
     @property
     def below_line_gradient(self) -> Optional[Gradient]:
         return self.__below_line_gradient
@@ -258,6 +277,7 @@ class LineChartData(Control):
         self.__below_line_gradient = value
 
     # below_line_cutoff_y
+
     @property
     def below_line_cutoff_y(self) -> OptionalNumber:
         return self._get_attr("belowLineCutoffY", data_type="float")
@@ -267,6 +287,7 @@ class LineChartData(Control):
         self._set_attr("belowLineCutoffY", value)
 
     # below_line
+
     @property
     def below_line(self) -> Optional[ChartPointLine]:
         return self.__below_line
@@ -276,6 +297,7 @@ class LineChartData(Control):
         self.__below_line = value
 
     # selected_below_line
+
     @property
     def selected_below_line(self) -> Union[None, bool, ChartPointLine]:
         return self.__selected_below_line

--- a/sdk/python/packages/flet-core/src/flet_core/charts/line_chart_data_point.py
+++ b/sdk/python/packages/flet-core/src/flet_core/charts/line_chart_data_point.py
@@ -2,10 +2,10 @@ from typing import Any, Optional, Union
 
 from flet_core.charts.chart_point_line import ChartPointLine
 from flet_core.charts.chart_point_shape import ChartPointShape
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.text_style import TextStyle
-from flet_core.types import TextAlign
+from flet_core.types import OptionalNumber, TextAlign
 
 
 class LineChartDataPoint(Control):
@@ -68,6 +68,7 @@ class LineChartDataPoint(Control):
         return children
 
     # x
+
     @property
     def x(self) -> OptionalNumber:
         return self._get_attr("x", data_type="float", def_value=0)
@@ -77,6 +78,7 @@ class LineChartDataPoint(Control):
         self._set_attr("x", value)
 
     # y
+
     @property
     def y(self) -> OptionalNumber:
         return self._get_attr("y", data_type="float", def_value=0)
@@ -86,6 +88,7 @@ class LineChartDataPoint(Control):
         self._set_attr("y", value)
 
     # selected
+
     @property
     def selected(self) -> Optional[bool]:
         return self._get_attr("selected", data_type="bool", def_value=False)
@@ -95,6 +98,7 @@ class LineChartDataPoint(Control):
         self._set_attr("selected", value)
 
     # show_tooltip
+
     @property
     def show_tooltip(self) -> Optional[bool]:
         return self._get_attr("showTooltip", data_type="bool", def_value=True)
@@ -104,6 +108,7 @@ class LineChartDataPoint(Control):
         self._set_attr("showTooltip", value)
 
     # tooltip
+
     @property
     def tooltip(self) -> Optional[str]:
         return self._get_attr("tooltip")
@@ -113,6 +118,7 @@ class LineChartDataPoint(Control):
         self._set_attr("tooltip", value)
 
     # tooltip_align
+
     @property
     def tooltip_align(self) -> Optional[TextAlign]:
         return self.__tooltip_align
@@ -125,6 +131,7 @@ class LineChartDataPoint(Control):
         )
 
     # tooltip_style
+
     @property
     def tooltip_style(self):
         return self.__tooltip_style
@@ -134,6 +141,7 @@ class LineChartDataPoint(Control):
         self.__tooltip_style = value
 
     # point
+
     @property
     def point(self):
         return self.__point
@@ -143,6 +151,7 @@ class LineChartDataPoint(Control):
         self.__point = value
 
     # selected_point
+
     @property
     def selected_point(self):
         return self.__selected_point
@@ -152,6 +161,7 @@ class LineChartDataPoint(Control):
         self.__selected_point = value
 
     # show_above_line
+
     @property
     def show_above_line(self) -> Optional[bool]:
         return self._get_attr("showAboveLine", data_type="bool", def_value=True)
@@ -161,6 +171,7 @@ class LineChartDataPoint(Control):
         self._set_attr("showAboveLine", value)
 
     # show_below_line
+
     @property
     def show_below_line(self) -> Optional[bool]:
         return self._get_attr("showBelowLine", data_type="bool", def_value=True)
@@ -170,6 +181,7 @@ class LineChartDataPoint(Control):
         self._set_attr("showBelowLine", value)
 
     # selected_below_line
+
     @property
     def selected_below_line(self) -> Union[None, bool, ChartPointLine]:
         return self.__selected_below_line

--- a/sdk/python/packages/flet-core/src/flet_core/charts/pie_chart.py
+++ b/sdk/python/packages/flet-core/src/flet_core/charts/pie_chart.py
@@ -3,13 +3,13 @@ from typing import Any, List, Optional, Union
 
 from flet_core.charts.pie_chart_section import PieChartSection
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import OptionalNumber
 from flet_core.control_event import ControlEvent
 from flet_core.event_handler import EventHandler
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -115,6 +115,7 @@ class PieChart(ConstrainedControl):
         return children
 
     # sections
+
     @property
     def sections(self):
         return self.__sections
@@ -124,6 +125,7 @@ class PieChart(ConstrainedControl):
         self.__sections = value if value is not None else []
 
     # center_space_color
+
     @property
     def center_space_color(self) -> Optional[str]:
         return self._get_attr("centerSpaceColor")
@@ -133,6 +135,7 @@ class PieChart(ConstrainedControl):
         self._set_attr("centerSpaceColor", value)
 
     # center_space_radius
+
     @property
     def center_space_radius(self) -> OptionalNumber:
         return self._get_attr("centerSpaceRadius", data_type="float")
@@ -142,6 +145,7 @@ class PieChart(ConstrainedControl):
         self._set_attr("centerSpaceRadius", value)
 
     # sections_space
+
     @property
     def sections_space(self) -> OptionalNumber:
         return self._get_attr("sectionsSpace", data_type="float")
@@ -151,6 +155,7 @@ class PieChart(ConstrainedControl):
         self._set_attr("sectionsSpace", value)
 
     # start_degree_offset
+
     @property
     def start_degree_offset(self) -> OptionalNumber:
         return self._get_attr("startDegreeOffset", data_type="float")
@@ -160,6 +165,7 @@ class PieChart(ConstrainedControl):
         self._set_attr("startDegreeOffset", value)
 
     # animate
+
     @property
     def animate(self) -> AnimationValue:
         return self.__animate
@@ -169,6 +175,7 @@ class PieChart(ConstrainedControl):
         self.__animate = value
 
     # on_chart_event
+
     @property
     def on_chart_event(self):
         return self.__on_chart_event

--- a/sdk/python/packages/flet-core/src/flet_core/charts/pie_chart_section.py
+++ b/sdk/python/packages/flet-core/src/flet_core/charts/pie_chart_section.py
@@ -1,9 +1,10 @@
 from typing import Any, Optional
 
 from flet_core.border import BorderSide
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.text_style import TextStyle
+from flet_core.types import OptionalNumber
 
 
 class PieChartSection(Control):
@@ -61,6 +62,7 @@ class PieChartSection(Control):
         return children
 
     # value
+
     @property
     def value(self) -> OptionalNumber:
         return self._get_attr("value", data_type="float")
@@ -70,6 +72,7 @@ class PieChartSection(Control):
         self._set_attr("value", value)
 
     # radius
+
     @property
     def radius(self) -> OptionalNumber:
         return self._get_attr("radius", data_type="float")
@@ -79,6 +82,7 @@ class PieChartSection(Control):
         self._set_attr("radius", value)
 
     # border_side
+
     @property
     def border_side(self) -> Optional[BorderSide]:
         return self.__border_side
@@ -88,6 +92,7 @@ class PieChartSection(Control):
         self.__border_side = value
 
     # color
+
     @property
     def color(self) -> Optional[str]:
         return self._get_attr("color")
@@ -97,6 +102,7 @@ class PieChartSection(Control):
         self._set_attr("color", value)
 
     # badge
+
     @property
     def badge(self) -> Optional[Control]:
         return self.__badge
@@ -106,6 +112,7 @@ class PieChartSection(Control):
         self.__badge = value
 
     # badge_position
+
     @property
     def badge_position(self) -> OptionalNumber:
         return self._get_attr("badgePosition", data_type="float")
@@ -115,6 +122,7 @@ class PieChartSection(Control):
         self._set_attr("badgePosition", value)
 
     # title
+
     @property
     def title(self):
         return self._get_attr("title")
@@ -124,6 +132,7 @@ class PieChartSection(Control):
         self._set_attr("title", value)
 
     # title_style
+
     @property
     def title_style(self):
         return self.__title_style
@@ -133,6 +142,7 @@ class PieChartSection(Control):
         self.__title_style = value
 
     # title_position
+
     @property
     def title_position(self) -> OptionalNumber:
         return self._get_attr("titlePosition", data_type="float", def_value=1.0)

--- a/sdk/python/packages/flet-core/src/flet_core/checkbox.py
+++ b/sdk/python/packages/flet-core/src/flet_core/checkbox.py
@@ -4,7 +4,6 @@ from flet_core.adaptive_control import AdaptiveControl
 from flet_core.border import BorderSide
 from flet_core.buttons import OutlinedBorder
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import OptionalNumber
 from flet_core.ref import Ref
 from flet_core.text_style import TextStyle
 from flet_core.theme import ThemeVisualDensity
@@ -14,6 +13,7 @@ from flet_core.types import (
     MaterialState,
     MouseCursor,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -179,6 +179,7 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
             self._set_attr_json("labelStyle", self.__label_style)
 
     # value
+
     @property
     def value(self) -> Optional[bool]:
         return self._get_attr(
@@ -190,6 +191,7 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
         self._set_attr("value", value)
 
     # tristate
+
     @property
     def tristate(self) -> Optional[bool]:
         return self._get_attr("tristate", data_type="bool", def_value=False)
@@ -199,6 +201,7 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
         self._set_attr("tristate", value)
 
     # label
+
     @property
     def label(self) -> Optional[str]:
         return self._get_attr("label")
@@ -208,6 +211,7 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
         self._set_attr("label", value)
 
     # label_position
+
     @property
     def label_position(self) -> Optional[LabelPosition]:
         return self.__label_position
@@ -220,6 +224,7 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
         )
 
     # mouse_cursor
+
     @property
     def mouse_cursor(self) -> Optional[MouseCursor]:
         return self.__mouse_cursor
@@ -233,6 +238,7 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
         )
 
     # visual_density
+
     @property
     def visual_density(self) -> Optional[ThemeVisualDensity]:
         return self.__visual_density
@@ -246,6 +252,7 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
         )
 
     # autofocus
+
     @property
     def autofocus(self) -> Optional[bool]:
         return self._get_attr("autofocus", data_type="bool", def_value=False)
@@ -255,6 +262,7 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
         self._set_attr("autofocus", value)
 
     # check_color
+
     @property
     def check_color(self) -> Optional[str]:
         return self._get_attr("checkColor")
@@ -264,6 +272,7 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
         self._set_attr("checkColor", value)
 
     # active_color
+
     @property
     def active_color(self) -> Optional[str]:
         return self._get_attr("activeColor")
@@ -273,6 +282,7 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
         self._set_attr("activeColor", value)
 
     # focus_color
+
     @property
     def focus_color(self) -> Optional[str]:
         return self._get_attr("focusColor")
@@ -282,6 +292,7 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
         self._set_attr("focusColor", value)
 
     # hover_color
+
     @property
     def hover_color(self) -> Optional[str]:
         return self._get_attr("hoverColor")
@@ -291,6 +302,7 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
         self._set_attr("hoverColor", value)
 
     # fill_color
+
     @property
     def fill_color(self) -> Union[None, str, Dict[MaterialState, str]]:
         return self.__fill_color
@@ -300,6 +312,7 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
         self.__fill_color = value
 
     # overlay_color
+
     @property
     def overlay_color(self) -> Union[None, str, Dict[MaterialState, str]]:
         return self.__overlay_color
@@ -309,6 +322,7 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
         self.__overlay_color = value
 
     # label_style
+
     @property
     def label_style(self) -> Optional[TextStyle]:
         return self.__label_style
@@ -318,6 +332,7 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
         self.__label_style = value
 
     # semantics_label
+
     @property
     def semantics_label(self) -> Optional[str]:
         return self._get_attr("semanticsLabel")
@@ -327,6 +342,7 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
         self._set_attr("semanticsLabel", value)
 
     # shape
+
     @property
     def shape(self) -> Optional[OutlinedBorder]:
         return self.__shape
@@ -336,6 +352,7 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
         self.__shape = value
 
     # splash_radius
+
     @property
     def splash_radius(self) -> Optional[float]:
         return self._get_attr("splashRadius", data_type="float")
@@ -345,6 +362,7 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
         self._set_attr("splashRadius", value)
 
     # is_error
+
     @property
     def is_error(self) -> Optional[bool]:
         return self._get_attr("isError", data_type="bool", def_value=False)
@@ -354,6 +372,7 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
         self._set_attr("isError", value)
 
     # border_side
+
     @property
     def border_side(self) -> Union[None, BorderSide, Dict[MaterialState, BorderSide]]:
         return self.__border_side
@@ -365,6 +384,7 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
         self.__border_side = value
 
     # on_change
+
     @property
     def on_change(self):
         return self._get_event_handler("change")
@@ -374,6 +394,7 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
         self._add_event_handler("change", handler)
 
     # on_focus
+
     @property
     def on_focus(self):
         return self._get_event_handler("focus")
@@ -383,6 +404,7 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
         self._add_event_handler("focus", handler)
 
     # on_blur
+
     @property
     def on_blur(self):
         return self._get_event_handler("blur")

--- a/sdk/python/packages/flet-core/src/flet_core/chip.py
+++ b/sdk/python/packages/flet-core/src/flet_core/chip.py
@@ -1,21 +1,22 @@
-from typing import Any, Optional, Union, Dict
+from typing import Any, Dict, Optional, Union
 
 from flet_core.border import BorderSide
 from flet_core.buttons import OutlinedBorder
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.text_style import TextStyle
 from flet_core.theme import ThemeVisualDensity
 from flet_core.types import (
     AnimationValue,
+    ClipBehavior,
+    MaterialState,
     OffsetValue,
+    OptionalNumber,
     PaddingValue,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
-    ClipBehavior,
-    MaterialState,
 )
 
 
@@ -218,6 +219,7 @@ class Chip(ConstrainedControl):
         return children
 
     # padding
+
     @property
     def padding(self) -> PaddingValue:
         return self.__padding
@@ -227,6 +229,7 @@ class Chip(ConstrainedControl):
         self.__padding = value
 
     # selected
+
     @property
     def selected(self) -> Optional[bool]:
         return self._get_attr("selected", data_type="bool", def_value=False)
@@ -236,6 +239,7 @@ class Chip(ConstrainedControl):
         self._set_attr("selected", value)
 
     # show_checkmark
+
     @property
     def show_checkmark(self) -> Optional[bool]:
         return self._get_attr("showCheckmark")
@@ -245,6 +249,7 @@ class Chip(ConstrainedControl):
         self._set_attr("showCheckmark", value)
 
     # delete_icon_tooltip
+
     @property
     def delete_icon_tooltip(self):
         return self._get_attr("deleteButtonTooltipMessage")
@@ -254,6 +259,7 @@ class Chip(ConstrainedControl):
         self._set_attr("deleteButtonTooltipMessage", value)
 
     # label
+
     @property
     def label(self) -> Control:
         return self.__label
@@ -263,6 +269,7 @@ class Chip(ConstrainedControl):
         self.__label = value
 
     # label_padding
+
     @property
     def label_padding(self) -> PaddingValue:
         return self.__label_padding
@@ -272,6 +279,7 @@ class Chip(ConstrainedControl):
         self.__label_padding = value
 
     # label_style
+
     @property
     def label_style(self):
         return self.__label_style
@@ -281,6 +289,7 @@ class Chip(ConstrainedControl):
         self.__label_style = value
 
     # leading
+
     @property
     def leading(self) -> Optional[Control]:
         return self.__leading
@@ -290,6 +299,7 @@ class Chip(ConstrainedControl):
         self.__leading = value
 
     # delete_icon
+
     @property
     def delete_icon(self) -> Optional[Control]:
         return self.__delete_icon
@@ -299,6 +309,7 @@ class Chip(ConstrainedControl):
         self.__delete_icon = value
 
     # delete_icon_color
+
     @property
     def delete_icon_color(self):
         return self._get_attr("deleteIconColor")
@@ -308,6 +319,7 @@ class Chip(ConstrainedControl):
         self._set_attr("deleteIconColor", value)
 
     # disabled_color
+
     @property
     def disabled_color(self):
         return self._get_attr("disabledColor")
@@ -317,6 +329,7 @@ class Chip(ConstrainedControl):
         self._set_attr("disabledColor", value)
 
     # color
+
     @property
     def color(self) -> Union[None, str, Dict[MaterialState, str]]:
         return self.__color
@@ -326,6 +339,7 @@ class Chip(ConstrainedControl):
         self.__color = value
 
     # autofocus
+
     @property
     def autofocus(self) -> Optional[bool]:
         return self._get_attr("autofocus", data_type="bool", def_value=False)
@@ -335,6 +349,7 @@ class Chip(ConstrainedControl):
         self._set_attr("autofocus", value)
 
     # bgcolor
+
     @property
     def bgcolor(self) -> Optional[str]:
         return self._get_attr("bgcolor")
@@ -344,6 +359,7 @@ class Chip(ConstrainedControl):
         self._set_attr("bgcolor", value)
 
     # check_color
+
     @property
     def check_color(self) -> Optional[str]:
         return self._get_attr("checkColor")
@@ -353,6 +369,7 @@ class Chip(ConstrainedControl):
         self._set_attr("checkColor", value)
 
     # selected_color
+
     @property
     def selected_color(self) -> Optional[str]:
         return self._get_attr("selectedColor")
@@ -362,6 +379,7 @@ class Chip(ConstrainedControl):
         self._set_attr("selectedColor", value)
 
     # selected_shadow_color
+
     @property
     def selected_shadow_color(self) -> Optional[str]:
         return self._get_attr("selectedShadowColor")
@@ -371,6 +389,7 @@ class Chip(ConstrainedControl):
         self._set_attr("selectedShadowColor", value)
 
     # surface_tint_color
+
     @property
     def surface_tint_color(self) -> Optional[str]:
         return self._get_attr("surfaceTintColor")
@@ -380,6 +399,7 @@ class Chip(ConstrainedControl):
         self._set_attr("surfaceTintColor", value)
 
     # shadow_color
+
     @property
     def shadow_color(self) -> Optional[str]:
         return self._get_attr("shadowColor")
@@ -389,6 +409,7 @@ class Chip(ConstrainedControl):
         self._set_attr("shadowColor", value)
 
     # elevation
+
     @property
     def elevation(self) -> OptionalNumber:
         return self._get_attr("elevation", data_type="float")
@@ -398,6 +419,7 @@ class Chip(ConstrainedControl):
         self._set_attr("elevation", value)
 
     # click_elevation
+
     @property
     def click_elevation(self) -> OptionalNumber:
         return self._get_attr("clickElevation", data_type="float")
@@ -407,6 +429,7 @@ class Chip(ConstrainedControl):
         self._set_attr("clickElevation", value)
 
     # shape
+
     @property
     def shape(self) -> Optional[OutlinedBorder]:
         return self.__shape
@@ -416,6 +439,7 @@ class Chip(ConstrainedControl):
         self.__shape = value
 
     # visual_density
+
     @property
     def visual_density(self) -> Optional[ThemeVisualDensity]:
         return self.__visual_density
@@ -429,6 +453,7 @@ class Chip(ConstrainedControl):
         )
 
     # clip_behavior
+
     @property
     def clip_behavior(self) -> Optional[ClipBehavior]:
         return self.__clip_behavior
@@ -441,6 +466,7 @@ class Chip(ConstrainedControl):
         )
 
     # border_side
+
     @property
     def border_side(self) -> Optional[BorderSide]:
         return self.__border_side
@@ -450,6 +476,7 @@ class Chip(ConstrainedControl):
         self.__border_side = value
 
     # on_click
+
     @property
     def on_click(self):
         return self._get_event_handler("click")
@@ -460,6 +487,7 @@ class Chip(ConstrainedControl):
         self._set_attr("onclick", True if handler is not None else None)
 
     # on_delete
+
     @property
     def on_delete(self):
         return self._get_event_handler("delete")
@@ -470,6 +498,7 @@ class Chip(ConstrainedControl):
         self._set_attr("onDelete", True if handler is not None else None)
 
     # on_select
+
     @property
     def on_select(self):
         return self._get_event_handler("select")
@@ -480,6 +509,7 @@ class Chip(ConstrainedControl):
         self._set_attr("onSelect", True if handler is not None else None)
 
     # on_focus
+
     @property
     def on_focus(self):
         return self._get_event_handler("focus")
@@ -489,6 +519,7 @@ class Chip(ConstrainedControl):
         self._add_event_handler("focus", handler)
 
     # on_blur
+
     @property
     def on_blur(self):
         return self._get_event_handler("blur")

--- a/sdk/python/packages/flet-core/src/flet_core/circle_avatar.py
+++ b/sdk/python/packages/flet-core/src/flet_core/circle_avatar.py
@@ -2,11 +2,12 @@ import warnings
 from typing import Any, Optional, Union
 
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -167,6 +168,7 @@ class CircleAvatar(ConstrainedControl):
         return []
 
     # foreground_image_url
+
     @property
     def foreground_image_url(self) -> Optional[str]:
         warnings.warn(
@@ -189,6 +191,7 @@ class CircleAvatar(ConstrainedControl):
             )
 
     # background_image_url
+
     @property
     def background_image_url(self) -> Optional[str]:
         warnings.warn(
@@ -211,6 +214,7 @@ class CircleAvatar(ConstrainedControl):
             )
 
     # foreground_image_src
+
     @property
     def foreground_image_src(self) -> Optional[str]:
         return self._get_attr("foregroundImageSrc")
@@ -220,6 +224,7 @@ class CircleAvatar(ConstrainedControl):
         self._set_attr("foregroundImageSrc", value)
 
     # background_image_src
+
     @property
     def background_image_src(self) -> Optional[str]:
         return self._get_attr("backgroundImageSrc")
@@ -229,6 +234,7 @@ class CircleAvatar(ConstrainedControl):
         self._set_attr("backgroundImageSrc", value)
 
     # radius
+
     @property
     def radius(self) -> OptionalNumber:
         return self._get_attr("radius", data_type="float")
@@ -238,6 +244,7 @@ class CircleAvatar(ConstrainedControl):
         self._set_attr("radius", value)
 
     # min_radius
+
     @property
     def min_radius(self) -> OptionalNumber:
         return self._get_attr("minRadius", data_type="float")
@@ -247,6 +254,7 @@ class CircleAvatar(ConstrainedControl):
         self._set_attr("minRadius", value)
 
     # max_radius
+
     @property
     def max_radius(self) -> OptionalNumber:
         return self._get_attr("maxRadius", data_type="float")
@@ -256,6 +264,7 @@ class CircleAvatar(ConstrainedControl):
         self._set_attr("maxRadius", value)
 
     # color
+
     @property
     def color(self) -> Optional[str]:
         return self._get_attr("color")
@@ -265,6 +274,7 @@ class CircleAvatar(ConstrainedControl):
         self._set_attr("color", value)
 
     # bgcolor
+
     @property
     def bgcolor(self) -> Optional[str]:
         return self._get_attr("bgcolor")
@@ -274,6 +284,7 @@ class CircleAvatar(ConstrainedControl):
         self._set_attr("bgcolor", value)
 
     # content
+
     @property
     def content(self) -> Optional[Control]:
         return self.__content
@@ -283,6 +294,7 @@ class CircleAvatar(ConstrainedControl):
         self.__content = value
 
     # on_image_error
+
     @property
     def on_image_error(self):
         return self._get_event_handler("imageError")

--- a/sdk/python/packages/flet-core/src/flet_core/column.py
+++ b/sdk/python/packages/flet-core/src/flet_core/column.py
@@ -2,7 +2,7 @@ from typing import Any, List, Optional, Union
 
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.scrollable_control import ScrollableControl
 from flet_core.types import (
@@ -10,6 +10,7 @@ from flet_core.types import (
     CrossAxisAlignment,
     MainAxisAlignment,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -170,6 +171,7 @@ class Column(ConstrainedControl, ScrollableControl, AdaptiveControl):
         self.clean()
 
     # tight
+
     @property
     def tight(self) -> Optional[bool]:
         return self._get_attr("tight", data_type="bool", def_value=False)
@@ -179,6 +181,7 @@ class Column(ConstrainedControl, ScrollableControl, AdaptiveControl):
         self._set_attr("tight", value)
 
     # alignment
+
     @property
     def alignment(self) -> MainAxisAlignment:
         return self.__alignment
@@ -191,6 +194,7 @@ class Column(ConstrainedControl, ScrollableControl, AdaptiveControl):
         )
 
     # horizontal_alignment
+
     @property
     def horizontal_alignment(self) -> CrossAxisAlignment:
         return self.__horizontal_alignment
@@ -204,6 +208,7 @@ class Column(ConstrainedControl, ScrollableControl, AdaptiveControl):
         )
 
     # spacing
+
     @property
     def spacing(self) -> OptionalNumber:
         return self._get_attr("spacing")
@@ -213,6 +218,7 @@ class Column(ConstrainedControl, ScrollableControl, AdaptiveControl):
         self._set_attr("spacing", value)
 
     # wrap
+
     @property
     def wrap(self) -> Optional[bool]:
         return self._get_attr("wrap", data_type="bool", def_value=False)
@@ -222,6 +228,7 @@ class Column(ConstrainedControl, ScrollableControl, AdaptiveControl):
         self._set_attr("wrap", value)
 
     # run_spacing
+
     @property
     def run_spacing(self) -> OptionalNumber:
         return self._get_attr("runSpacing")
@@ -231,6 +238,7 @@ class Column(ConstrainedControl, ScrollableControl, AdaptiveControl):
         self._set_attr("runSpacing", value)
 
     # controls
+
     @property
     def controls(self):
         return self.__controls

--- a/sdk/python/packages/flet-core/src/flet_core/constrained_control.py
+++ b/sdk/python/packages/flet-core/src/flet_core/constrained_control.py
@@ -1,10 +1,11 @@
 from typing import Any, Optional, Union
 
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -92,6 +93,7 @@ class ConstrainedControl(Control):
         self._set_attr_json("animateOffset", self.__animate_offset)
 
     # key
+
     @property
     def key(self) -> Optional[str]:
         return self._get_attr("key")
@@ -101,6 +103,7 @@ class ConstrainedControl(Control):
         self._set_attr("key", value)
 
     # width
+
     @property
     def width(self) -> OptionalNumber:
         """
@@ -113,6 +116,7 @@ class ConstrainedControl(Control):
         self._set_attr("width", value)
 
     # height
+
     @property
     def height(self) -> OptionalNumber:
         return self._get_attr("height")
@@ -122,6 +126,7 @@ class ConstrainedControl(Control):
         self._set_attr("height", value)
 
     # left
+
     @property
     def left(self) -> OptionalNumber:
         return self._get_attr("left")
@@ -131,6 +136,7 @@ class ConstrainedControl(Control):
         self._set_attr("left", value)
 
     # top
+
     @property
     def top(self) -> OptionalNumber:
         return self._get_attr("top")
@@ -140,6 +146,7 @@ class ConstrainedControl(Control):
         self._set_attr("top", value)
 
     # right
+
     @property
     def right(self) -> OptionalNumber:
         return self._get_attr("right")
@@ -149,6 +156,7 @@ class ConstrainedControl(Control):
         self._set_attr("right", value)
 
     # bottom
+
     @property
     def bottom(self) -> OptionalNumber:
         return self._get_attr("bottom")
@@ -158,6 +166,7 @@ class ConstrainedControl(Control):
         self._set_attr("bottom", value)
 
     # rotate
+
     @property
     def rotate(self) -> RotateValue:
         return self.__rotate
@@ -167,6 +176,7 @@ class ConstrainedControl(Control):
         self.__rotate = value
 
     # scale
+
     @property
     def scale(self) -> ScaleValue:
         return self.__scale
@@ -176,6 +186,7 @@ class ConstrainedControl(Control):
         self.__scale = value
 
     # offset
+
     @property
     def offset(self) -> OffsetValue:
         return self.__offset
@@ -185,6 +196,7 @@ class ConstrainedControl(Control):
         self.__offset = value
 
     # aspect_ratio
+
     @property
     def aspect_ratio(self) -> OptionalNumber:
         return self._get_attr("aspectRatio")
@@ -194,6 +206,7 @@ class ConstrainedControl(Control):
         self._set_attr("aspectRatio", value)
 
     # animate_opacity
+
     @property
     def animate_opacity(self) -> AnimationValue:
         return self.__animate_opacity
@@ -203,6 +216,7 @@ class ConstrainedControl(Control):
         self.__animate_opacity = value
 
     # animate_size
+
     @property
     def animate_size(self) -> AnimationValue:
         return self.__animate_size
@@ -212,6 +226,7 @@ class ConstrainedControl(Control):
         self.__animate_size = value
 
     # animate_position
+
     @property
     def animate_position(self) -> AnimationValue:
         return self.__animate_position
@@ -221,6 +236,7 @@ class ConstrainedControl(Control):
         self.__animate_position = value
 
     # animate_rotation
+
     @property
     def animate_rotation(self) -> AnimationValue:
         return self.__animate_rotation
@@ -230,6 +246,7 @@ class ConstrainedControl(Control):
         self.__animate_rotation = value
 
     # animate_scale
+
     @property
     def animate_scale(self) -> AnimationValue:
         return self.__animate_scale
@@ -239,6 +256,7 @@ class ConstrainedControl(Control):
         self.__animate_scale = value
 
     # animate_offset
+
     @property
     def animate_offset(self) -> AnimationValue:
         return self.__animate_offset
@@ -248,6 +266,7 @@ class ConstrainedControl(Control):
         self.__animate_offset = value
 
     # on_animation_end
+
     @property
     def on_animation_end(self):
         return self._get_event_handler("animation_end")

--- a/sdk/python/packages/flet-core/src/flet_core/container.py
+++ b/sdk/python/packages/flet-core/src/flet_core/container.py
@@ -6,7 +6,7 @@ from flet_core.alignment import Alignment
 from flet_core.blur import Blur
 from flet_core.border import Border
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.control_event import ControlEvent
 from flet_core.event_handler import EventHandler
 from flet_core.gradients import Gradient
@@ -23,6 +23,7 @@ from flet_core.types import (
     ImageRepeat,
     MarginValue,
     OffsetValue,
+    OptionalNumber,
     PaddingValue,
     ResponsiveNumber,
     RotateValue,
@@ -220,6 +221,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         return children
 
     # alignment
+
     @property
     def alignment(self) -> Optional[Alignment]:
         """:obj:`Alignment`, optional: Align the child control within the container.
@@ -234,6 +236,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         self.__alignment = value
 
     # padding
+
     @property
     def padding(self) -> PaddingValue:
         return self.__padding
@@ -243,6 +246,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         self.__padding = value
 
     # margin
+
     @property
     def margin(self) -> MarginValue:
         return self.__margin
@@ -252,6 +256,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         self.__margin = value
 
     # bgcolor
+
     @property
     def bgcolor(self):
         return self._get_attr("bgColor")
@@ -261,6 +266,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         self._set_attr("bgColor", value)
 
     # gradient
+
     @property
     def gradient(self) -> Optional[Gradient]:
         return self.__gradient
@@ -270,6 +276,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         self.__gradient = value
 
     # blend_mode
+
     @property
     def blend_mode(self) -> Optional[BlendMode]:
         return self.__blend_mode
@@ -282,6 +289,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         )
 
     # blur
+
     @property
     def blur(self):
         return self.__blur
@@ -296,6 +304,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         self.__blur = value
 
     # shadow
+
     @property
     def shadow(self):
         return self.__shadow
@@ -305,6 +314,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         self.__shadow = value if value is not None else []
 
     # border
+
     @property
     def border(self) -> Optional[Border]:
         return self.__border
@@ -314,6 +324,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         self.__border = value
 
     # border_radius
+
     @property
     def border_radius(self) -> BorderRadiusValue:
         return self.__border_radius
@@ -323,6 +334,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         self.__border_radius = value
 
     # image_src
+
     @property
     def image_src(self):
         return self._get_attr("imageSrc")
@@ -332,6 +344,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         self._set_attr("imageSrc", value)
 
     # image_src_base64
+
     @property
     def image_src_base64(self):
         return self._get_attr("imageSrcBase64")
@@ -341,6 +354,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         self._set_attr("imageSrcBase64", value)
 
     # image_fit
+
     @property
     def image_fit(self) -> Optional[ImageFit]:
         return self.__image_fit
@@ -353,6 +367,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         )
 
     # image_repeat
+
     @property
     def image_repeat(self) -> Optional[ImageRepeat]:
         return self.__image_repeat
@@ -365,6 +380,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         )
 
     # image_opacity
+
     @property
     def image_opacity(self) -> OptionalNumber:
         return self._get_attr("imageOpacity", data_type="float", def_value=1.0)
@@ -374,6 +390,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         self._set_attr("imageOpacity", value)
 
     # content
+
     @property
     def content(self) -> Optional[Control]:
         return self.__content
@@ -383,6 +400,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         self.__content = value
 
     # shape
+
     @property
     def shape(self):
         return self.__shape
@@ -393,6 +411,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         self._set_attr("shape", value.value if isinstance(value, BoxShape) else value)
 
     # clip_behavior
+
     @property
     def clip_behavior(self) -> Optional[ClipBehavior]:
         return self.__clip_behavior
@@ -405,6 +424,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         )
 
     # ink
+
     @property
     def ink(self) -> Optional[bool]:
         return self._get_attr("ink", data_type="bool", def_value=False)
@@ -414,6 +434,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         self._set_attr("ink", value)
 
     # ink color
+
     @property
     def ink_color(self):
         return self._get_attr("inkColor")
@@ -423,6 +444,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         self._set_attr("inkColor", value)
 
     # animate
+
     @property
     def animate(self) -> AnimationValue:
         return self.__animate
@@ -432,6 +454,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         self.__animate = value
 
     # url
+
     @property
     def url(self):
         return self._get_attr("url")
@@ -441,6 +464,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         self._set_attr("url", value)
 
     # url_target
+
     @property
     def url_target(self) -> Optional[UrlTarget]:
         return self.__url_target
@@ -453,6 +477,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         )
 
     # theme
+
     @property
     def theme(self) -> Optional[Theme]:
         return self.__theme
@@ -462,6 +487,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         self.__theme = value
 
     # theme_mode
+
     @property
     def theme_mode(self) -> Optional[ThemeMode]:
         return self.__theme_mode
@@ -474,6 +500,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         )
 
     # on_click
+
     @property
     def on_click(self):
         return self._get_event_handler("click")
@@ -484,6 +511,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         self._set_attr("onClick", True if handler is not None else None)
 
     # on_tap_down
+
     @property
     def on_tap_down(self):
         return self.__on_tap_down
@@ -494,6 +522,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         self._set_attr("onTapDown", True if handler is not None else None)
 
     # on_long_press
+
     @property
     def on_long_press(self):
         return self._get_event_handler("long_press")
@@ -504,6 +533,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         self._set_attr("onLongPress", True if handler is not None else None)
 
     # on_hover
+
     @property
     def on_hover(self):
         return self._get_event_handler("hover")

--- a/sdk/python/packages/flet-core/src/flet_core/control.py
+++ b/sdk/python/packages/flet-core/src/flet_core/control.py
@@ -2,18 +2,16 @@ import datetime as dt
 import json
 from difflib import SequenceMatcher
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, Type
+from typing import Any, Dict, List, Optional, Type, TYPE_CHECKING, Union
 
 from flet_core.embed_json_encoder import EmbedJsonEncoder
 from flet_core.protocol import Command
 from flet_core.ref import Ref
-from flet_core.types import ResponsiveNumber
+from flet_core.types import OptionalNumber, ResponsiveNumber
 from flet_core.utils import deprecated
 
 if TYPE_CHECKING:
     from .page import Page
-
-OptionalNumber = Union[None, int, float]
 
 
 class Control:
@@ -85,7 +83,6 @@ class Control:
         name = name.lower()
         if name not in self.__attrs:
             return def_value
-
         s_val = self.__attrs[name][0]
         if data_type == "bool" and s_val is not None and isinstance(s_val, str):
             return s_val.lower() == "true"
@@ -128,10 +125,8 @@ class Control:
 
         if orig_val is None and value is None:
             return
-
         if value is None:
             value = ""
-
         if orig_val is None or orig_val[0] != value:
             self.__attrs[name] = (value, dirty)
 
@@ -170,16 +165,19 @@ class Control:
         )
 
     # event_handlers
+
     @property
     def event_handlers(self):
         return self.__event_handlers
 
     # _previous_children
+
     @property
     def _previous_children(self):
         return self.__previous_children
 
     # _id
+
     @property
     def _id(self):
         return self._get_attr("id")
@@ -189,6 +187,7 @@ class Control:
         self._set_attr("id", value)
 
     # page
+
     @property
     def page(self):
         return self.__page
@@ -198,11 +197,13 @@ class Control:
         self.__page = page
 
     # uid
+
     @property
     def uid(self):
         return self.__uid
 
     # expand
+
     @property
     def expand(self) -> Union[None, bool, int]:
         return self.__expand
@@ -215,6 +216,7 @@ class Control:
         self._set_attr("expand", value if value else None)
 
     # expand_loose
+
     @property
     def expand_loose(self) -> Optional[bool]:
         return self._get_attr("expandLoose", data_type="bool", def_value=False)
@@ -224,6 +226,7 @@ class Control:
         self._set_attr("expandLoose", value)
 
     # rtl
+
     @property
     def rtl(self) -> Optional[bool]:
         return self._get_attr("rtl", data_type="bool", def_value=False)
@@ -233,6 +236,7 @@ class Control:
         self._set_attr("rtl", value)
 
     # col
+
     @property
     def col(self) -> Optional[ResponsiveNumber]:
         return self.__col
@@ -242,6 +246,7 @@ class Control:
         self.__col = value
 
     # opacity
+
     @property
     def opacity(self):
         return self._get_attr("opacity", data_type="float", def_value=1.0)
@@ -253,6 +258,7 @@ class Control:
         self._set_attr("opacity", value)
 
     # tooltip
+
     @property
     def tooltip(self):
         return self._get_attr("tooltip")
@@ -262,6 +268,7 @@ class Control:
         self._set_attr("tooltip", value)
 
     # visible
+
     @property
     def visible(self) -> Optional[bool]:
         return self._get_attr("visible", data_type="bool", def_value=True)
@@ -271,6 +278,7 @@ class Control:
         self._set_attr("visible", value)
 
     # disabled
+
     @property
     def disabled(self) -> Optional[bool]:
         return self._get_attr("disabled", data_type="bool", def_value=False)
@@ -280,6 +288,7 @@ class Control:
         self._set_attr("disabled", value)
 
     # data
+
     @property
     def data(self):
         return self.__data
@@ -289,6 +298,7 @@ class Control:
         self.__data = value
 
     # public methods
+
     def update(self):
         assert self.__page, "Control must be added to the page first."
         self.__page.update(self)
@@ -346,7 +356,6 @@ class Control:
 
             if dirty:
                 continue
-
             val = self.__attrs[attrName][0]
             sval = ""
             if val is None:
@@ -367,11 +376,10 @@ class Control:
         if len(update_cmd.attrs) > 0:
             update_cmd.name = "set"
             commands.append(update_cmd)
-
         if isolated:
             return
-
         # go through children
+
         previous_children = self.__previous_children
         current_children = self._get_children()
 
@@ -382,22 +390,22 @@ class Control:
         for ctrl in previous_children:
             hashes[hash(ctrl)] = ctrl
             previous_ints.append(hash(ctrl))
-
         for ctrl in current_children:
             hashes[hash(ctrl)] = ctrl
             current_ints.append(hash(ctrl))
-
         sm = SequenceMatcher(None, previous_ints, current_ints)
 
         n = 0
         for tag, a1, a2, b1, b2 in sm.get_opcodes():
             if tag == "delete" or tag == "replace":
                 # deleted controls
+
                 ids = []
                 for h in previous_ints[a1:a2]:
                     ctrl = hashes[h]
                     # check if re-added control is being deleted
                     # which means it's a replace
+
                     i = 0
                     replaced = False
                     while i < len(commands):
@@ -406,6 +414,7 @@ class Control:
                             c for c in cmd.commands if c.attrs.get("id") == ctrl.__uid
                         ):
                             # insert delete command before add
+
                             commands.insert(i, Command(0, "remove", [ctrl.__uid]))
                             replaced = True
                             break
@@ -419,6 +428,7 @@ class Control:
                     commands.append(Command(0, "remove", ids))
                 if tag == "replace":
                     # add
+
                     for h in current_ints[b1:b2]:
                         ctrl = hashes[h]
                         innerCmds = ctrl._build_add_commands(
@@ -437,6 +447,7 @@ class Control:
                         n += 1
             elif tag == "equal":
                 # unchanged control
+
                 for h in previous_ints[a1:a2]:
                     ctrl = hashes[h]
                     ctrl.build_update_commands(
@@ -449,6 +460,7 @@ class Control:
                     n += 1
             elif tag == "insert":
                 # add
+
                 for h in current_ints[b1:b2]:
                     ctrl = hashes[h]
                     innerCmds = ctrl._build_add_commands(
@@ -465,7 +477,6 @@ class Control:
                         )
                     )
                     n += 1
-
         self.__previous_children.clear()
         self.__previous_children.extend(current_children)
 
@@ -477,21 +488,20 @@ class Control:
 
             for child in control._get_children():
                 removed_controls.extend(self._remove_control_recursively(index, child))
-
             for child in control._previous_children:
                 removed_controls.extend(self._remove_control_recursively(index, child))
-
             removed_controls.append(control)
-
         return removed_controls
 
     # private methods
+
     def _build_add_commands(self, indent=0, index=None, added_controls=None):
         if index:
             self.page = index["page"]
         content = self.build()
 
         # fix for UserControl
+
         if content is not None:
             if isinstance(content, Control) and hasattr(self, "controls"):
                 self.controls = [content]
@@ -501,14 +511,14 @@ class Control:
                 and all(isinstance(control, Control) for control in content)
             ):
                 self.controls = content
-
         # remove control from index
+
         if self.__uid and index is not None and self.__uid in index:
             del index[self.__uid]
-
         commands = []
 
         # main command
+
         command = self._build_command(False)
         command.indent = indent
         command.values.append(self._get_control_name())
@@ -516,8 +526,8 @@ class Control:
 
         if added_controls is not None:
             added_controls.append(self)
-
         # controls
+
         children = self._get_children()
         for control in children:
             childCmd = control._build_add_commands(
@@ -525,7 +535,6 @@ class Control:
             )
             commands.extend(childCmd)
             control.parent = self  # set as parent
-
         self.__previous_children.clear()
         self.__previous_children.extend(children)
 
@@ -536,7 +545,6 @@ class Control:
 
         if update and not self.__uid:
             return command
-
         self._before_build_command()
         self.before_update()
 
@@ -546,7 +554,6 @@ class Control:
 
             if (update and not dirty) or attrName == "id":
                 continue
-
             val = self.__attrs[attrName][0]
             sval = ""
             if val is None:
@@ -559,7 +566,6 @@ class Control:
                 sval = str(val)
             command.attrs[attrName] = sval
             self.__attrs[attrName] = (val, False)
-
         id = self.__attrs.get("id")
         if not update and self.__uid is not None:
             command.attrs["id"] = self.__uid
@@ -568,7 +574,6 @@ class Control:
         elif update and len(command.attrs) > 0:
             assert self.__uid is not None
             command.values.append(self.__uid)
-
         return command
 
     def _dispose(self):

--- a/sdk/python/packages/flet-core/src/flet_core/control.py
+++ b/sdk/python/packages/flet-core/src/flet_core/control.py
@@ -67,11 +67,11 @@ class Control:
     def will_unmount(self):
         pass
 
-    def _get_children(self):
+    def _get_children(self) -> "List[Control]":
         return []
 
-    def _get_control_name(self):
-        raise Exception("_getControlName must be overridden in inherited class")
+    def _get_control_name(self) -> str:
+        raise Exception("_get_control_name must be overridden in inherited class")
 
     def _add_event_handler(self, event_name, handler):
         self.__event_handlers[event_name] = handler

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_action_sheet.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_action_sheet.py
@@ -1,11 +1,12 @@
 from typing import Any, List, Optional, Union
 
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -117,6 +118,7 @@ class CupertinoActionSheet(ConstrainedControl):
         return children
 
     # cancel
+
     @property
     def cancel(self) -> Optional[Control]:
         return self.__cancel
@@ -126,6 +128,7 @@ class CupertinoActionSheet(ConstrainedControl):
         self.__cancel = value
 
     # title
+
     @property
     def title(self) -> Optional[Control]:
         return self.__title
@@ -135,6 +138,7 @@ class CupertinoActionSheet(ConstrainedControl):
         self.__title = value
 
     # message
+
     @property
     def message(self) -> Optional[Control]:
         return self.__message
@@ -144,6 +148,7 @@ class CupertinoActionSheet(ConstrainedControl):
         self.__message = value
 
     # actions
+
     @property
     def actions(self):
         return self.__actions

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_action_sheet_action.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_action_sheet_action.py
@@ -1,11 +1,12 @@
 from typing import Any, Optional, Union
 
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -110,6 +111,7 @@ class CupertinoActionSheetAction(ConstrainedControl):
         return children
 
     # text
+
     @property
     def text(self):
         return self._get_attr("text")
@@ -119,6 +121,7 @@ class CupertinoActionSheetAction(ConstrainedControl):
         self._set_attr("text", value)
 
     # is_default_action
+
     @property
     def is_default_action(self) -> Optional[bool]:
         return self._get_attr("isDefaultAction")
@@ -128,6 +131,7 @@ class CupertinoActionSheetAction(ConstrainedControl):
         self._set_attr("isDefaultAction", value)
 
     # is_destructive_action
+
     @property
     def is_destructive_action(self) -> Optional[bool]:
         return self._get_attr("isDestructiveAction")
@@ -137,6 +141,7 @@ class CupertinoActionSheetAction(ConstrainedControl):
         self._set_attr("isDestructiveAction", value)
 
     # content
+
     @property
     def content(self) -> Control:
         return self.__content
@@ -146,6 +151,7 @@ class CupertinoActionSheetAction(ConstrainedControl):
         self.__content = value
 
     # on_click
+
     @property
     def on_click(self):
         return self._get_event_handler("click")

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_activity_indicator.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_activity_indicator.py
@@ -1,11 +1,11 @@
 from typing import Any, Optional, Union
 
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import OptionalNumber
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -84,6 +84,7 @@ class CupertinoActivityIndicator(ConstrainedControl):
         return "cupertinoactivityindicator"
 
     # color
+
     @property
     def color(self):
         return self._get_attr("color")
@@ -93,6 +94,7 @@ class CupertinoActivityIndicator(ConstrainedControl):
         self._set_attr("color", value)
 
     # animating
+
     @property
     def animating(self):
         return self._get_attr("animating")
@@ -102,6 +104,7 @@ class CupertinoActivityIndicator(ConstrainedControl):
         self._set_attr("animating", value)
 
     # radius
+
     @property
     def radius(self) -> OptionalNumber:
         return self._get_attr("radius")

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_bottom_sheet.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_bottom_sheet.py
@@ -1,8 +1,8 @@
 from typing import Any, Optional
 
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
-from flet_core.types import PaddingValue
+from flet_core.types import OptionalNumber, PaddingValue
 
 
 class CupertinoBottomSheet(Control):
@@ -64,6 +64,7 @@ class CupertinoBottomSheet(Control):
         return children
 
     # open
+
     @property
     def open(self) -> Optional[bool]:
         return self._get_attr("open", data_type="bool", def_value=False)
@@ -73,6 +74,7 @@ class CupertinoBottomSheet(Control):
         self._set_attr("open", value)
 
     # modal
+
     @property
     def modal(self) -> Optional[bool]:
         return self._get_attr("modal", data_type="bool", def_value=False)
@@ -82,6 +84,7 @@ class CupertinoBottomSheet(Control):
         self._set_attr("modal", value)
 
     # bgcolor
+
     @property
     def bgcolor(self):
         return self._get_attr("bgColor")
@@ -91,6 +94,7 @@ class CupertinoBottomSheet(Control):
         self._set_attr("bgColor", value)
 
     # height
+
     @property
     def height(self) -> OptionalNumber:
         return self._get_attr("height", data_type="float", def_value=220)
@@ -100,6 +104,7 @@ class CupertinoBottomSheet(Control):
         self._set_attr("height", value)
 
     # padding
+
     @property
     def padding(self) -> PaddingValue:
         return self.__padding
@@ -109,6 +114,7 @@ class CupertinoBottomSheet(Control):
         self.__padding = value
 
     # content
+
     @property
     def content(self):
         return self.__content
@@ -118,6 +124,7 @@ class CupertinoBottomSheet(Control):
         self.__content = value
 
     # on_dismiss
+
     @property
     def on_dismiss(self):
         return self._get_event_handler("dismiss")

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_button.py
@@ -2,12 +2,13 @@ from typing import Any, Optional, Union
 
 from flet_core.alignment import Alignment
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     BorderRadiusValue,
     OffsetValue,
+    OptionalNumber,
     PaddingValue,
     ResponsiveNumber,
     RotateValue,
@@ -136,6 +137,7 @@ class CupertinoButton(ConstrainedControl):
         return [self.__content]
 
     # text
+
     @property
     def text(self):
         return self._get_attr("text")
@@ -145,6 +147,7 @@ class CupertinoButton(ConstrainedControl):
         self._set_attr("text", value)
 
     # icon
+
     @property
     def icon(self):
         return self._get_attr("icon")
@@ -154,6 +157,7 @@ class CupertinoButton(ConstrainedControl):
         self._set_attr("icon", value)
 
     # icon_color
+
     @property
     def icon_color(self):
         return self._get_attr("iconColor")
@@ -163,6 +167,7 @@ class CupertinoButton(ConstrainedControl):
         self._set_attr("iconColor", value)
 
     # alignment
+
     @property
     def alignment(self) -> Optional[Alignment]:
         return self.__alignment
@@ -172,6 +177,7 @@ class CupertinoButton(ConstrainedControl):
         self.__alignment = value
 
     # disabled_color
+
     @property
     def disabled_color(self) -> Optional[str]:
         return self._get_attr("disabledColor")
@@ -181,6 +187,7 @@ class CupertinoButton(ConstrainedControl):
         self._set_attr("disabledColor", value)
 
     # opacity_on_click
+
     @property
     def opacity_on_click(self) -> OptionalNumber:
         return self._get_attr("opacityOnClick", data_type="float", def_value=0.4)
@@ -192,6 +199,7 @@ class CupertinoButton(ConstrainedControl):
         self._set_attr("opacityOnClick", value)
 
     # border_radius
+
     @property
     def border_radius(self) -> BorderRadiusValue:
         return self.__border_radius
@@ -201,6 +209,7 @@ class CupertinoButton(ConstrainedControl):
         self.__border_radius = value
 
     # min_size
+
     @property
     def min_size(self) -> OptionalNumber:
         return self._get_attr("minSize", data_type="float", def_value=44.0)
@@ -210,6 +219,7 @@ class CupertinoButton(ConstrainedControl):
         self._set_attr("minSize", value)
 
     # padding
+
     @property
     def padding(self) -> PaddingValue:
         return self.__padding
@@ -219,6 +229,7 @@ class CupertinoButton(ConstrainedControl):
         self.__padding = value
 
     # bgcolor
+
     @property
     def bgcolor(self) -> Optional[str]:
         return self._get_attr("bgColor")
@@ -228,6 +239,7 @@ class CupertinoButton(ConstrainedControl):
         self._set_attr("bgColor", value)
 
     # color
+
     @property
     def color(self) -> Optional[str]:
         return self._get_attr("color")
@@ -237,6 +249,7 @@ class CupertinoButton(ConstrainedControl):
         self._set_attr("color", value)
 
     # url
+
     @property
     def url(self):
         return self._get_attr("url")
@@ -246,6 +259,7 @@ class CupertinoButton(ConstrainedControl):
         self._set_attr("url", value)
 
     # url_target
+
     @property
     def url_target(self) -> Optional[UrlTarget]:
         return self.__url_target
@@ -258,6 +272,7 @@ class CupertinoButton(ConstrainedControl):
         )
 
     # on_click
+
     @property
     def on_click(self):
         return self._get_event_handler("click")
@@ -267,6 +282,7 @@ class CupertinoButton(ConstrainedControl):
         self._add_event_handler("click", handler)
 
     # content
+
     @property
     def content(self) -> Optional[Control]:
         return self.__content

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_checkbox.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_checkbox.py
@@ -1,12 +1,12 @@
 from typing import Any, Optional, Union
 
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import OptionalNumber
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     LabelPosition,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -129,6 +129,7 @@ class CupertinoCheckbox(ConstrainedControl):
         return "cupertinocheckbox"
 
     # value
+
     @property
     def value(self) -> Optional[bool]:
         return self._get_attr(
@@ -140,6 +141,7 @@ class CupertinoCheckbox(ConstrainedControl):
         self._set_attr("value", value)
 
     # tristate
+
     @property
     def tristate(self) -> Optional[bool]:
         return self._get_attr("tristate", data_type="bool", def_value=False)
@@ -149,6 +151,7 @@ class CupertinoCheckbox(ConstrainedControl):
         self._set_attr("tristate", value)
 
     # label
+
     @property
     def label(self):
         return self._get_attr("label")
@@ -158,6 +161,7 @@ class CupertinoCheckbox(ConstrainedControl):
         self._set_attr("label", value)
 
     # label_position
+
     @property
     def label_position(self) -> Optional[LabelPosition]:
         return self.__label_position
@@ -170,6 +174,7 @@ class CupertinoCheckbox(ConstrainedControl):
         )
 
     # autofocus
+
     @property
     def autofocus(self) -> Optional[bool]:
         return self._get_attr("autofocus", data_type="bool", def_value=False)
@@ -179,6 +184,7 @@ class CupertinoCheckbox(ConstrainedControl):
         self._set_attr("autofocus", value)
 
     # check_color
+
     @property
     def check_color(self):
         return self._get_attr("checkColor")
@@ -188,6 +194,7 @@ class CupertinoCheckbox(ConstrainedControl):
         self._set_attr("checkColor", value)
 
     # active_color
+
     @property
     def active_color(self):
         return self._get_attr("activeColor")
@@ -197,6 +204,7 @@ class CupertinoCheckbox(ConstrainedControl):
         self._set_attr("activeColor", value)
 
     # inactive_color
+
     @property
     def inactive_color(self):
         return self._get_attr("inactiveColor")
@@ -206,6 +214,7 @@ class CupertinoCheckbox(ConstrainedControl):
         self._set_attr("inactiveColor", value)
 
     # focus_color
+
     @property
     def focus_color(self):
         return self._get_attr("focusColor")
@@ -215,6 +224,7 @@ class CupertinoCheckbox(ConstrainedControl):
         self._set_attr("focusColor", value)
 
     # on_change
+
     @property
     def on_change(self):
         return self._get_event_handler("change")
@@ -224,6 +234,7 @@ class CupertinoCheckbox(ConstrainedControl):
         self._add_event_handler("change", handler)
 
     # on_focus
+
     @property
     def on_focus(self):
         return self._get_event_handler("focus")
@@ -233,6 +244,7 @@ class CupertinoCheckbox(ConstrainedControl):
         self._add_event_handler("focus", handler)
 
     # on_blur
+
     @property
     def on_blur(self):
         return self._get_event_handler("blur")

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_date_picker.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_date_picker.py
@@ -3,11 +3,11 @@ from enum import Enum
 from typing import Any, Optional, Union
 
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import OptionalNumber
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -129,6 +129,7 @@ class CupertinoDatePicker(ConstrainedControl):
         return "cupertinodatepicker"
 
     # value
+
     @property
     def value(self) -> Optional[datetime]:
         value_string = self._get_attr("value", def_value=None)
@@ -141,6 +142,7 @@ class CupertinoDatePicker(ConstrainedControl):
         self._set_attr("value", value)
 
     # first_date
+
     @property
     def first_date(self) -> Optional[datetime]:
         value_string = self._get_attr("firstDate", def_value=None)
@@ -155,6 +157,7 @@ class CupertinoDatePicker(ConstrainedControl):
         self._set_attr("firstDate", value)
 
     # last_date
+
     @property
     def last_date(self) -> Optional[datetime]:
         value_string = self._get_attr("lastDate", def_value=None)
@@ -169,6 +172,7 @@ class CupertinoDatePicker(ConstrainedControl):
         self._set_attr("lastDate", value)
 
     # bgcolor
+
     @property
     def bgcolor(self) -> Optional[str]:
         return self._get_attr("bgcolor")
@@ -178,6 +182,7 @@ class CupertinoDatePicker(ConstrainedControl):
         self._set_attr("bgcolor", value)
 
     # item_extent
+
     @property
     def item_extent(self) -> OptionalNumber:
         return self._get_attr("itemExtent", data_type="float", def_value=32.0)
@@ -189,6 +194,7 @@ class CupertinoDatePicker(ConstrainedControl):
         self._set_attr("itemExtent", value)
 
     # min_year
+
     @property
     def min_year(self) -> Optional[int]:
         return self._get_attr("minYear", data_type="int", def_value=1)
@@ -198,6 +204,7 @@ class CupertinoDatePicker(ConstrainedControl):
         self._set_attr("minYear", value)
 
     # max_year
+
     @property
     def max_year(self) -> Optional[int]:
         return self._get_attr("maxYear", data_type="int")
@@ -207,6 +214,7 @@ class CupertinoDatePicker(ConstrainedControl):
         self._set_attr("maxYear", value)
 
     # minute_interval
+
     @property
     def minute_interval(self) -> Optional[int]:
         return self._get_attr("minuteInterval", data_type="int", def_value=1)
@@ -218,6 +226,7 @@ class CupertinoDatePicker(ConstrainedControl):
         self._set_attr("minuteInterval", value)
 
     # use_24h_format
+
     @property
     def use_24h_format(self) -> Optional[int]:
         return self._get_attr("use24hFormat", data_type="bool", def_value=False)
@@ -227,6 +236,7 @@ class CupertinoDatePicker(ConstrainedControl):
         self._set_attr("use24hFormat", value)
 
     # date_picker_mode
+
     @property
     def date_picker_mode(self) -> Optional[CupertinoDatePickerMode]:
         return self.__date_picker_mode
@@ -237,6 +247,7 @@ class CupertinoDatePicker(ConstrainedControl):
         self._set_enum_attr("datePickerMode", value, CupertinoDatePickerMode)
 
     # date_order
+
     @property
     def date_order(self) -> Optional[CupertinoDatePickerDateOrder]:
         return self.__date_order
@@ -247,6 +258,7 @@ class CupertinoDatePicker(ConstrainedControl):
         self._set_enum_attr("dateOrder", value, CupertinoDatePickerDateOrder)
 
     # on_change
+
     @property
     def on_change(self):
         return self._get_event_handler("change")

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_dialog_action.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_dialog_action.py
@@ -1,8 +1,9 @@
 from typing import Any, Optional
 
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.text_style import TextStyle
+from flet_core.types import OptionalNumber
 
 
 class CupertinoDialogAction(Control):
@@ -84,6 +85,7 @@ class CupertinoDialogAction(Control):
         return [self.__content]
 
     # text
+
     @property
     def text(self):
         return self._get_attr("text")
@@ -93,6 +95,7 @@ class CupertinoDialogAction(Control):
         self._set_attr("text", value)
 
     # is_default_action
+
     @property
     def is_default_action(self) -> Optional[bool]:
         return self._get_attr("isDefaultAction")
@@ -102,6 +105,7 @@ class CupertinoDialogAction(Control):
         self._set_attr("isDefaultAction", value)
 
     # is_destructive_action
+
     @property
     def is_destructive_action(self) -> Optional[bool]:
         return self._get_attr("isDestructiveAction")
@@ -111,6 +115,7 @@ class CupertinoDialogAction(Control):
         self._set_attr("isDestructiveAction", value)
 
     # on_click
+
     @property
     def on_click(self):
         return self._get_event_handler("click")
@@ -120,6 +125,7 @@ class CupertinoDialogAction(Control):
         self._add_event_handler("click", handler)
 
     # content
+
     @property
     def content(self) -> Optional[Control]:
         return self.__content
@@ -129,6 +135,7 @@ class CupertinoDialogAction(Control):
         self.__content = value
 
     # text_style
+
     @property
     def text_style(self):
         return self.__text_style

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_filled_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_filled_button.py
@@ -1,10 +1,16 @@
 from typing import Any, Optional, Union
 
 from flet_core.alignment import Alignment
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.cupertino_button import CupertinoButton
 from flet_core.ref import Ref
-from flet_core.types import BorderRadiusValue, PaddingValue, ResponsiveNumber, UrlTarget
+from flet_core.types import (
+    BorderRadiusValue,
+    OptionalNumber,
+    PaddingValue,
+    ResponsiveNumber,
+    UrlTarget,
+)
 
 
 class CupertinoFilledButton(CupertinoButton):

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_list_tile.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_list_tile.py
@@ -1,11 +1,12 @@
 from typing import Any, Optional, Union
 
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     OffsetValue,
+    OptionalNumber,
     PaddingValue,
     ResponsiveNumber,
     RotateValue,
@@ -172,6 +173,7 @@ class CupertinoListTile(ConstrainedControl):
         return children
 
     # leading
+
     @property
     def leading(self) -> Optional[Control]:
         return self.__leading
@@ -181,6 +183,7 @@ class CupertinoListTile(ConstrainedControl):
         self.__leading = value
 
     # leading_size
+
     @property
     def leading_size(self) -> OptionalNumber:
         return self._get_attr("leadingSize", data_type="float", def_value=30.0)
@@ -190,6 +193,7 @@ class CupertinoListTile(ConstrainedControl):
         self._set_attr("leadingSize", value)
 
     # leading_to_title
+
     @property
     def leading_to_title(self) -> OptionalNumber:
         return self._get_attr("leadingToTitle", data_type="float", def_value=12.0)
@@ -199,6 +203,7 @@ class CupertinoListTile(ConstrainedControl):
         self._set_attr("leadingToTitle", value)
 
     # title
+
     @property
     def title(self) -> Optional[Control]:
         return self.__title
@@ -208,6 +213,7 @@ class CupertinoListTile(ConstrainedControl):
         self.__title = value
 
     # subtitle
+
     @property
     def subtitle(self) -> Optional[Control]:
         return self.__subtitle
@@ -217,6 +223,7 @@ class CupertinoListTile(ConstrainedControl):
         self.__subtitle = value
 
     # trailing
+
     @property
     def trailing(self) -> Optional[Control]:
         return self.__trailing
@@ -226,6 +233,7 @@ class CupertinoListTile(ConstrainedControl):
         self.__trailing = value
 
     # additional_info
+
     @property
     def additional_info(self) -> Optional[Control]:
         return self.__additional_info
@@ -235,6 +243,7 @@ class CupertinoListTile(ConstrainedControl):
         self.__additional_info = value
 
     # padding
+
     @property
     def padding(self) -> PaddingValue:
         return self.__padding
@@ -244,6 +253,7 @@ class CupertinoListTile(ConstrainedControl):
         self.__padding = value
 
     # notched
+
     @property
     def notched(self) -> Optional[bool]:
         return self._get_attr("notched", data_type="bool", def_value=False)
@@ -253,6 +263,7 @@ class CupertinoListTile(ConstrainedControl):
         self._set_attr("notched", value)
 
     # bgcolor
+
     @property
     def bgcolor(self) -> Optional[str]:
         return self._get_attr("bgcolor")
@@ -262,6 +273,7 @@ class CupertinoListTile(ConstrainedControl):
         self._set_attr("bgcolor", value)
 
     # bgcolor_activated
+
     @property
     def bgcolor_activated(self) -> Optional[str]:
         return self._get_attr("bgcolorActivated")
@@ -271,6 +283,7 @@ class CupertinoListTile(ConstrainedControl):
         self._set_attr("bgcolorActivated", value)
 
     # url
+
     @property
     def url(self) -> Optional[str]:
         return self._get_attr("url")
@@ -280,6 +293,7 @@ class CupertinoListTile(ConstrainedControl):
         self._set_attr("url", value)
 
     # url_target
+
     @property
     def url_target(self) -> Optional[UrlTarget]:
         return self.__url_target
@@ -292,6 +306,7 @@ class CupertinoListTile(ConstrainedControl):
         )
 
     # toggle_inputs
+
     @property
     def toggle_inputs(self) -> Optional[bool]:
         return self._get_attr("toggleInputs", data_type="bool", def_value=False)
@@ -301,6 +316,7 @@ class CupertinoListTile(ConstrainedControl):
         self._set_attr("toggleInputs", value)
 
     # on_click
+
     @property
     def on_click(self):
         return self._get_event_handler("click")

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_navigation_bar.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_navigation_bar.py
@@ -2,12 +2,12 @@ from typing import Any, List, Optional, Union
 
 from flet_core.border import Border
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import OptionalNumber
 from flet_core.navigation_bar import NavigationBarDestination
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -143,6 +143,7 @@ class CupertinoNavigationBar(ConstrainedControl):
         return children
 
     # destinations
+
     @property
     def destinations(self) -> Optional[List[NavigationBarDestination]]:
         return self.__destinations
@@ -152,6 +153,7 @@ class CupertinoNavigationBar(ConstrainedControl):
         self.__destinations = value if value is not None else []
 
     # border
+
     @property
     def border(self) -> Optional[Border]:
         return self.__border
@@ -161,6 +163,7 @@ class CupertinoNavigationBar(ConstrainedControl):
         self.__border = value
 
     # selected_index
+
     @property
     def selected_index(self) -> Optional[int]:
         return self._get_attr("selectedIndex", data_type="int", def_value=0)
@@ -170,6 +173,7 @@ class CupertinoNavigationBar(ConstrainedControl):
         self._set_attr("selectedIndex", value)
 
     # bgcolor
+
     @property
     def bgcolor(self):
         return self._get_attr("bgcolor")
@@ -179,6 +183,7 @@ class CupertinoNavigationBar(ConstrainedControl):
         self._set_attr("bgcolor", value)
 
     # active_color
+
     @property
     def active_color(self):
         return self._get_attr("activeColor")
@@ -188,6 +193,7 @@ class CupertinoNavigationBar(ConstrainedControl):
         self._set_attr("activeColor", value)
 
     # inactive_color
+
     @property
     def inactive_color(self):
         return self._get_attr("inactiveColor")
@@ -197,6 +203,7 @@ class CupertinoNavigationBar(ConstrainedControl):
         self._set_attr("inactiveColor", value)
 
     # icon_size
+
     @property
     def icon_size(self) -> OptionalNumber:
         return self._get_attr("iconSize")
@@ -206,6 +213,7 @@ class CupertinoNavigationBar(ConstrainedControl):
         self._set_attr("iconSize", value)
 
     # on_change
+
     @property
     def on_change(self):
         return self._get_event_handler("change")

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_navigation_bar.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_navigation_bar.py
@@ -3,7 +3,7 @@ from typing import Any, List, Optional, Union
 from flet_core.border import Border
 from flet_core.constrained_control import ConstrainedControl
 from flet_core.control import OptionalNumber
-from flet_core.navigation_bar import NavigationDestination
+from flet_core.navigation_bar import NavigationBarDestination
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
@@ -33,9 +33,9 @@ class CupertinoNavigationBar(ConstrainedControl):
             active_color=ft.colors.BLACK,
             on_change=lambda e: print("Selected tab:", e.control.selected_index),
             destinations=[
-                ft.NavigationDestination(icon=ft.icons.EXPLORE, label="Explore"),
-                ft.NavigationDestination(icon=ft.icons.COMMUTE, label="Commute"),
-                ft.NavigationDestination(
+                ft.NavigationBarDestination(icon=ft.icons.EXPLORE, label="Explore"),
+                ft.NavigationBarDestination(icon=ft.icons.COMMUTE, label="Commute"),
+                ft.NavigationBarDestination(
                     icon=ft.icons.BOOKMARK_BORDER,
                     selected_icon=ft.icons.BOOKMARK,
                     label="Explore",
@@ -55,7 +55,7 @@ class CupertinoNavigationBar(ConstrainedControl):
 
     def __init__(
         self,
-        destinations: Optional[List[NavigationDestination]] = None,
+        destinations: Optional[List[NavigationBarDestination]] = None,
         selected_index: Optional[int] = None,
         bgcolor: Optional[str] = None,
         active_color: Optional[str] = None,
@@ -144,11 +144,11 @@ class CupertinoNavigationBar(ConstrainedControl):
 
     # destinations
     @property
-    def destinations(self) -> Optional[List[NavigationDestination]]:
+    def destinations(self) -> Optional[List[NavigationBarDestination]]:
         return self.__destinations
 
     @destinations.setter
-    def destinations(self, value: Optional[List[NavigationDestination]]):
+    def destinations(self, value: Optional[List[NavigationBarDestination]]):
         self.__destinations = value if value is not None else []
 
     # border

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_picker.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_picker.py
@@ -1,11 +1,12 @@
 from typing import Any, List, Optional, Union
 
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -115,6 +116,7 @@ class CupertinoPicker(ConstrainedControl):
         return self.controls
 
     # squeeze
+
     @property
     def squeeze(self) -> OptionalNumber:
         return self._get_attr("squeeze", data_type="float", def_value=1.45)
@@ -126,6 +128,7 @@ class CupertinoPicker(ConstrainedControl):
         self._set_attr("squeeze", value)
 
     # bgcolor
+
     @property
     def bgcolor(self) -> Optional[str]:
         return self._get_attr("bgcolor")
@@ -135,6 +138,7 @@ class CupertinoPicker(ConstrainedControl):
         self._set_attr("bgcolor", value)
 
     # use_magnifier
+
     @property
     def use_magnifier(self) -> Optional[bool]:
         return self._get_attr("useMagnifier", data_type="bool", def_value=False)
@@ -144,6 +148,7 @@ class CupertinoPicker(ConstrainedControl):
         self._set_attr("useMagnifier", value)
 
     # magnification
+
     @property
     def magnification(self) -> OptionalNumber:
         return self._get_attr("magnification", data_type="float", def_value=1.0)
@@ -155,6 +160,7 @@ class CupertinoPicker(ConstrainedControl):
         self._set_attr("magnification", value)
 
     # item_extent
+
     @property
     def item_extent(self) -> OptionalNumber:
         return self._get_attr("itemExtent", data_type="float")
@@ -166,6 +172,7 @@ class CupertinoPicker(ConstrainedControl):
         self._set_attr("itemExtent", value)
 
     # looping
+
     @property
     def looping(self) -> Optional[bool]:
         return self._get_attr("looping", data_type="bool", def_value=False)
@@ -175,6 +182,7 @@ class CupertinoPicker(ConstrainedControl):
         self._set_attr("looping", value)
 
     # selected_index
+
     @property
     def selected_index(self) -> Optional[int]:
         return self._get_attr("selectedIndex", data_type="int", def_value=0)
@@ -184,6 +192,7 @@ class CupertinoPicker(ConstrainedControl):
         self._set_attr("selectedIndex", value)
 
     # diameter_ratio
+
     @property
     def diameter_ratio(self) -> OptionalNumber:
         return self._get_attr("diameterRatio", data_type="float", def_value=1.07)
@@ -193,6 +202,7 @@ class CupertinoPicker(ConstrainedControl):
         self._set_attr("diameterRatio", value)
 
     # off_axis_fraction
+
     @property
     def off_axis_fraction(self) -> OptionalNumber:
         return self._get_attr("offAxisFraction", data_type="float", def_value=0.0)
@@ -202,6 +212,7 @@ class CupertinoPicker(ConstrainedControl):
         self._set_attr("offAxisFraction", value)
 
     # controls
+
     @property
     def controls(self):
         return self.__controls
@@ -211,6 +222,7 @@ class CupertinoPicker(ConstrainedControl):
         self.__controls = value if value is not None else []
 
     # on_change
+
     @property
     def on_change(self):
         return self._get_event_handler("change")

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_radio.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_radio.py
@@ -1,12 +1,12 @@
 from typing import Any, Optional, Union
 
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import OptionalNumber
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     LabelPosition,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -122,6 +122,7 @@ class CupertinoRadio(ConstrainedControl):
         super().before_update()
 
     # value
+
     @property
     def value(self) -> Optional[str]:
         return self._get_attr("value", def_value="")
@@ -131,6 +132,7 @@ class CupertinoRadio(ConstrainedControl):
         self._set_attr("value", value)
 
     # label
+
     @property
     def label(self) -> Optional[str]:
         return self._get_attr("label")
@@ -140,6 +142,7 @@ class CupertinoRadio(ConstrainedControl):
         self._set_attr("label", value)
 
     # label_position
+
     @property
     def label_position(self) -> Optional[LabelPosition]:
         return self.__label_position
@@ -152,6 +155,7 @@ class CupertinoRadio(ConstrainedControl):
         )
 
     # fill_color
+
     @property
     def fill_color(self) -> Optional[str]:
         return self._get_attr("fillColor")
@@ -161,6 +165,7 @@ class CupertinoRadio(ConstrainedControl):
         self._set_attr("fillColor", value)
 
     # focus_color
+
     @property
     def focus_color(self) -> Optional[str]:
         return self._get_attr("focusColor")
@@ -170,6 +175,7 @@ class CupertinoRadio(ConstrainedControl):
         self._set_attr("focusColor", value)
 
     # toggleable
+
     @property
     def toggleable(self) -> Optional[bool]:
         return self._get_attr("toggleable", data_type="bool", def_value=False)
@@ -179,6 +185,7 @@ class CupertinoRadio(ConstrainedControl):
         self._set_attr("toggleable", value)
 
     # on_focus
+
     @property
     def on_focus(self):
         return self._get_event_handler("focus")
@@ -188,6 +195,7 @@ class CupertinoRadio(ConstrainedControl):
         self._add_event_handler("focus", handler)
 
     # on_blur
+
     @property
     def on_blur(self):
         return self._get_event_handler("blur")
@@ -197,6 +205,7 @@ class CupertinoRadio(ConstrainedControl):
         self._add_event_handler("blur", handler)
 
     # autofocus
+
     @property
     def autofocus(self) -> Optional[bool]:
         return self._get_attr("autofocus", data_type="bool", def_value=False)
@@ -206,6 +215,7 @@ class CupertinoRadio(ConstrainedControl):
         self._set_attr("autofocus", value)
 
     # use_checkmark_style
+
     @property
     def use_checkmark_style(self) -> Optional[bool]:
         return self._get_attr("useCheckmarkStyle", data_type="bool", def_value=False)
@@ -215,6 +225,7 @@ class CupertinoRadio(ConstrainedControl):
         self._set_attr("useCheckmarkStyle", value)
 
     # active_color
+
     @property
     def active_color(self) -> Optional[str]:
         return self._get_attr("activeColor")
@@ -224,6 +235,7 @@ class CupertinoRadio(ConstrainedControl):
         self._set_attr("activeColor", value)
 
     # inactive_color
+
     @property
     def inactive_color(self) -> Optional[str]:
         return self._get_attr("inactiveColor")

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_segmented_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_segmented_button.py
@@ -1,15 +1,16 @@
-from typing import Any, Optional, Union, List
+from typing import Any, List, Optional, Union
 
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import OptionalNumber, Control
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     OffsetValue,
+    OptionalNumber,
+    PaddingValue,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
-    PaddingValue,
 )
 
 
@@ -113,6 +114,7 @@ class CupertinoSegmentedButton(ConstrainedControl):
         self._set_attr_json("padding", self.__padding)
 
     # controls
+
     @property
     def controls(self) -> List[Control]:
         return self.__controls
@@ -122,6 +124,7 @@ class CupertinoSegmentedButton(ConstrainedControl):
         self.__controls = value if value is not None else []
 
     # border_color
+
     @property
     def border_color(self) -> Optional[str]:
         return self._get_attr("borderColor")
@@ -131,6 +134,7 @@ class CupertinoSegmentedButton(ConstrainedControl):
         self._set_attr("borderColor", value)
 
     # selected_index
+
     @property
     def selected_index(self) -> Optional[int]:
         return self._get_attr("selectedIndex", data_type="int", def_value=0)
@@ -142,6 +146,7 @@ class CupertinoSegmentedButton(ConstrainedControl):
         self._set_attr("selectedIndex", value)
 
     # selected_color
+
     @property
     def selected_color(self) -> Optional[str]:
         return self._get_attr("selectedColor")
@@ -151,6 +156,7 @@ class CupertinoSegmentedButton(ConstrainedControl):
         self._set_attr("selectedColor", value)
 
     # unselected_color
+
     @property
     def unselected_color(self) -> Optional[str]:
         return self._get_attr("unselectedColor")
@@ -160,6 +166,7 @@ class CupertinoSegmentedButton(ConstrainedControl):
         self._set_attr("unselectedColor", value)
 
     # click_color
+
     @property
     def click_color(self) -> Optional[str]:
         return self._get_attr("clickColor")
@@ -169,6 +176,7 @@ class CupertinoSegmentedButton(ConstrainedControl):
         self._set_attr("clickColor", value)
 
     # padding
+
     @property
     def padding(self) -> PaddingValue:
         return self.__padding
@@ -178,6 +186,7 @@ class CupertinoSegmentedButton(ConstrainedControl):
         self.__padding = value
 
     # on_change
+
     @property
     def on_change(self):
         return self._get_event_handler("change")

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_slider.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_slider.py
@@ -1,11 +1,11 @@
 from typing import Any, Optional, Union
 
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import OptionalNumber
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -116,10 +116,12 @@ class CupertinoSlider(ConstrainedControl):
         return "cupertinoslider"
 
     # value
+
     @property
     def value(self) -> OptionalNumber:
         v = self._get_attr("value", data_type="float")
         # verify limits
+
         if self.min and v < self.min:
             v = self.min
         elif self.max and v > self.max:
@@ -131,6 +133,7 @@ class CupertinoSlider(ConstrainedControl):
         self._set_attr("value", value)
 
     # min
+
     @property
     def min(self) -> OptionalNumber:
         return self._get_attr("min")
@@ -140,6 +143,7 @@ class CupertinoSlider(ConstrainedControl):
         self._set_attr("min", value)
 
     # max
+
     @property
     def max(self) -> OptionalNumber:
         return self._get_attr("max")
@@ -149,6 +153,7 @@ class CupertinoSlider(ConstrainedControl):
         self._set_attr("max", value)
 
     # divisions
+
     @property
     def divisions(self) -> Optional[int]:
         return self._get_attr("divisions")
@@ -158,6 +163,7 @@ class CupertinoSlider(ConstrainedControl):
         self._set_attr("divisions", value)
 
     # round
+
     @property
     def round(self) -> Optional[int]:
         return self._get_attr("round")
@@ -167,6 +173,7 @@ class CupertinoSlider(ConstrainedControl):
         self._set_attr("round", value)
 
     # active_color
+
     @property
     def active_color(self):
         return self._get_attr("activeColor")
@@ -176,6 +183,7 @@ class CupertinoSlider(ConstrainedControl):
         self._set_attr("activeColor", value)
 
     # thumb_color
+
     @property
     def thumb_color(self):
         return self._get_attr("thumbColor")
@@ -185,6 +193,7 @@ class CupertinoSlider(ConstrainedControl):
         self._set_attr("thumbColor", value)
 
     # on_change
+
     @property
     def on_change(self):
         return self._get_event_handler("change")
@@ -194,6 +203,7 @@ class CupertinoSlider(ConstrainedControl):
         self._add_event_handler("change", handler)
 
     # on_change_start
+
     @property
     def on_change_start(self):
         return self._get_event_handler("change_start")
@@ -203,6 +213,7 @@ class CupertinoSlider(ConstrainedControl):
         self._add_event_handler("change_start", handler)
 
     # on_change_end
+
     @property
     def on_change_end(self):
         return self._get_event_handler("change_end")
@@ -212,6 +223,7 @@ class CupertinoSlider(ConstrainedControl):
         self._add_event_handler("change_end", handler)
 
     # on_focus
+
     @property
     def on_focus(self):
         return self._get_event_handler("focus")
@@ -221,6 +233,7 @@ class CupertinoSlider(ConstrainedControl):
         self._add_event_handler("focus", handler)
 
     # on_blur
+
     @property
     def on_blur(self):
         return self._get_event_handler("blur")

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_sliding_segmented_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_sliding_segmented_button.py
@@ -1,15 +1,16 @@
-from typing import Any, Optional, Union, List
+from typing import Any, List, Optional, Union
 
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import OptionalNumber, Control
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     OffsetValue,
+    OptionalNumber,
+    PaddingValue,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
-    PaddingValue,
 )
 
 
@@ -108,6 +109,7 @@ class CupertinoSlidingSegmentedButton(ConstrainedControl):
         self._set_attr_json("padding", self.__padding)
 
     # controls
+
     @property
     def controls(self):
         return self.__controls
@@ -117,6 +119,7 @@ class CupertinoSlidingSegmentedButton(ConstrainedControl):
         self.__controls = value if value is not None else []
 
     # selected_index
+
     @property
     def selected_index(self) -> Optional[int]:
         return self._get_attr("selectedIndex", data_type="int", def_value=0)
@@ -128,6 +131,7 @@ class CupertinoSlidingSegmentedButton(ConstrainedControl):
         self._set_attr("selectedIndex", value)
 
     # bgcolor
+
     @property
     def bgcolor(self):
         return self._get_attr("bgcolor")
@@ -137,6 +141,7 @@ class CupertinoSlidingSegmentedButton(ConstrainedControl):
         self._set_attr("bgcolor", value)
 
     # thumb_color
+
     @property
     def thumb_color(self):
         return self._get_attr("thumbColor")
@@ -146,6 +151,7 @@ class CupertinoSlidingSegmentedButton(ConstrainedControl):
         self._set_attr("thumbColor", value)
 
     # padding
+
     @property
     def padding(self) -> PaddingValue:
         return self.__padding
@@ -155,6 +161,7 @@ class CupertinoSlidingSegmentedButton(ConstrainedControl):
         self.__padding = value
 
     # on_change
+
     @property
     def on_change(self):
         return self._get_event_handler("change")

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_switch.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_switch.py
@@ -1,12 +1,12 @@
 from typing import Any, Optional, Union
 
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import OptionalNumber
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     LabelPosition,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -138,6 +138,7 @@ class CupertinoSwitch(ConstrainedControl):
         self._set_attr_json("trackColor", self.__track_color)
 
     # value
+
     @property
     def value(self) -> Optional[bool]:
         return self._get_attr("value", data_type="bool", def_value=False)
@@ -147,6 +148,7 @@ class CupertinoSwitch(ConstrainedControl):
         self._set_attr("value", value)
 
     # label
+
     @property
     def label(self) -> Optional[str]:
         return self._get_attr("label")
@@ -156,6 +158,7 @@ class CupertinoSwitch(ConstrainedControl):
         self._set_attr("label", value)
 
     # label_position
+
     @property
     def label_position(self) -> Optional[LabelPosition]:
         return self.__label_position
@@ -168,6 +171,7 @@ class CupertinoSwitch(ConstrainedControl):
         )
 
     # autofocus
+
     @property
     def autofocus(self) -> Optional[bool]:
         return self._get_attr("autofocus", data_type="bool", def_value=False)
@@ -177,6 +181,7 @@ class CupertinoSwitch(ConstrainedControl):
         self._set_attr("autofocus", value)
 
     # active_color
+
     @property
     def active_color(self) -> Optional[str]:
         return self._get_attr("activeColor")
@@ -186,6 +191,7 @@ class CupertinoSwitch(ConstrainedControl):
         self._set_attr("activeColor", value)
 
     # focus_color
+
     @property
     def focus_color(self) -> Optional[str]:
         return self._get_attr("focusColor")
@@ -195,6 +201,7 @@ class CupertinoSwitch(ConstrainedControl):
         self._set_attr("focusColor", value)
 
     # thumb_color
+
     @property
     def thumb_color(self) -> Optional[str]:
         return self.__thumb_color
@@ -204,6 +211,7 @@ class CupertinoSwitch(ConstrainedControl):
         self.__thumb_color = value
 
     # track_color
+
     @property
     def track_color(self) -> Optional[str]:
         return self.__track_color
@@ -213,6 +221,7 @@ class CupertinoSwitch(ConstrainedControl):
         self.__track_color = value
 
     # on_label_color
+
     @property
     def on_label_color(self) -> Optional[str]:
         return self._get_attr("onLabelColor")
@@ -222,6 +231,7 @@ class CupertinoSwitch(ConstrainedControl):
         self._set_attr("onLabelColor", value)
 
     # off_label_color
+
     @property
     def off_label_color(self) -> Optional[str]:
         return self._get_attr("offLabelColor")
@@ -231,6 +241,7 @@ class CupertinoSwitch(ConstrainedControl):
         self._set_attr("offLabelColor", value)
 
     # on_change
+
     @property
     def on_change(self):
         return self._get_event_handler("change")
@@ -240,6 +251,7 @@ class CupertinoSwitch(ConstrainedControl):
         self._add_event_handler("change", handler)
 
     # on_focus
+
     @property
     def on_focus(self):
         return self._get_event_handler("focus")
@@ -249,6 +261,7 @@ class CupertinoSwitch(ConstrainedControl):
         self._add_event_handler("focus", handler)
 
     # on_blur
+
     @property
     def on_blur(self):
         return self._get_event_handler("blur")

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_textfield.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_textfield.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import Any, List, Optional, Union
 
 from flet_core.border import Border
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.gradients import Gradient
 from flet_core.ref import Ref
 from flet_core.shadow import BoxShadow
@@ -13,6 +13,7 @@ from flet_core.types import (
     BlendMode,
     BorderRadiusValue,
     OffsetValue,
+    OptionalNumber,
     PaddingValue,
     ResponsiveNumber,
     RotateValue,
@@ -221,6 +222,7 @@ class CupertinoTextField(TextField):
         self._set_attr_json("border", self.__border)
 
     # placeholder_text
+
     @property
     def placeholder_text(self):
         return self._get_attr("placeholderText")
@@ -230,6 +232,7 @@ class CupertinoTextField(TextField):
         self._set_attr("placeholderText", value)
 
     # placeholder_style
+
     @property
     def placeholder_style(self):
         return self.__placeholder_style
@@ -239,6 +242,7 @@ class CupertinoTextField(TextField):
         self.__placeholder_style = value
 
     # gradient
+
     @property
     def gradient(self) -> Optional[Gradient]:
         return self.__gradient
@@ -248,6 +252,7 @@ class CupertinoTextField(TextField):
         self.__gradient = value
 
     # blend_mode
+
     @property
     def blend_mode(self) -> Optional[BlendMode]:
         return self.__blend_mode
@@ -260,6 +265,7 @@ class CupertinoTextField(TextField):
         )
 
     # shadow
+
     @property
     def shadow(self):
         return self.__shadow
@@ -269,6 +275,7 @@ class CupertinoTextField(TextField):
         self.__shadow = value if value is not None else []
 
     # suffix_visibility_mode
+
     @property
     def suffix_visibility_mode(self) -> Optional[VisibilityMode]:
         return self.__suffix_visibility_mode
@@ -279,6 +286,7 @@ class CupertinoTextField(TextField):
         self._set_enum_attr("suffixVisibilityMode", value, VisibilityMode)
 
     # prefix_visibility_mode
+
     @property
     def prefix_visibility_mode(self) -> Optional[VisibilityMode]:
         return self.__prefix_visibility_mode
@@ -292,6 +300,7 @@ class CupertinoTextField(TextField):
         )
 
     # clear_button_semantics_label
+
     @property
     def clear_button_semantics_label(self):
         return self._get_attr("clearButtonSemanticsLabel")
@@ -301,6 +310,7 @@ class CupertinoTextField(TextField):
         self._set_attr("clearButtonSemanticsLabel", value)
 
     # border
+
     @property
     def border(self) -> Optional[Border]:
         return self.__border

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_timer_picker.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_timer_picker.py
@@ -3,11 +3,11 @@ from typing import Any, Optional, Union
 
 from flet_core.alignment import Alignment
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import OptionalNumber
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -120,6 +120,7 @@ class CupertinoTimerPicker(ConstrainedControl):
         self._set_attr_json("alignment", self.__alignment)
 
     # value
+
     @property
     def value(self) -> Optional[int]:
         return self._get_attr("value", data_type="int", def_value=0)
@@ -129,6 +130,7 @@ class CupertinoTimerPicker(ConstrainedControl):
         self._set_attr("value", value)
 
     # alignment
+
     @property
     def alignment(self) -> Optional[Alignment]:
         return self.__alignment
@@ -138,6 +140,7 @@ class CupertinoTimerPicker(ConstrainedControl):
         self.__alignment = value
 
     # bgcolor
+
     @property
     def bgcolor(self) -> Optional[str]:
         return self._get_attr("bgcolor")
@@ -147,6 +150,7 @@ class CupertinoTimerPicker(ConstrainedControl):
         self._set_attr("bgcolor", value)
 
     # second_interval
+
     @property
     def second_interval(self) -> OptionalNumber:
         return self._get_attr("secondInterval", data_type="int", def_value=1)
@@ -156,6 +160,7 @@ class CupertinoTimerPicker(ConstrainedControl):
         self._set_attr("secondInterval", value)
 
     # item_extent
+
     @property
     def item_extent(self) -> OptionalNumber:
         return self._get_attr("itemExtent", data_type="float", def_value=32.0)
@@ -165,6 +170,7 @@ class CupertinoTimerPicker(ConstrainedControl):
         self._set_attr("itemExtent", value)
 
     # minute_interval
+
     @property
     def minute_interval(self) -> OptionalNumber:
         return self._get_attr("minuteInterval", data_type="int", def_value=1)
@@ -174,6 +180,7 @@ class CupertinoTimerPicker(ConstrainedControl):
         self._set_attr("minuteInterval", value)
 
     # mode
+
     @property
     def mode(self) -> Optional[CupertinoTimerPickerMode]:
         return self.__mode
@@ -184,6 +191,7 @@ class CupertinoTimerPicker(ConstrainedControl):
         self._set_enum_attr("mode", value, CupertinoTimerPickerMode)
 
     # on_change
+
     @property
     def on_change(self):
         return self._get_event_handler("change")

--- a/sdk/python/packages/flet-core/src/flet_core/datatable.py
+++ b/sdk/python/packages/flet-core/src/flet_core/datatable.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from flet_core.border import Border, BorderSide
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.control_event import ControlEvent
 from flet_core.event_handler import EventHandler
 from flet_core.gesture_detector import TapEvent
@@ -13,12 +13,13 @@ from flet_core.text_style import TextStyle
 from flet_core.types import (
     AnimationValue,
     BorderRadiusValue,
+    ClipBehavior,
     MaterialState,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
-    ClipBehavior,
 )
 
 
@@ -66,6 +67,7 @@ class DataColumn(Control):
         return children
 
     # label
+
     @property
     def label(self):
         return self.__label
@@ -75,6 +77,7 @@ class DataColumn(Control):
         self.__label = value
 
     # numeric
+
     @property
     def numeric(self) -> Optional[bool]:
         return self._get_attr("numeric", data_type="bool", def_value=False)
@@ -84,6 +87,7 @@ class DataColumn(Control):
         self._set_attr("numeric", value)
 
     # tooltip
+
     @property
     def tooltip(self):
         return self._get_attr("tooltip")
@@ -93,6 +97,7 @@ class DataColumn(Control):
         self._set_attr("tooltip", value)
 
     # on_sort
+
     @property
     def on_sort(self):
         return self.__on_sort
@@ -143,6 +148,7 @@ class DataCell(Control):
         return [self.__content]
 
     # content
+
     @property
     def content(self):
         return self.__content
@@ -152,6 +158,7 @@ class DataCell(Control):
         self.__content = value
 
     # placeholder
+
     @property
     def placeholder(self) -> Optional[bool]:
         return self._get_attr("placeholder", data_type="bool", def_value=False)
@@ -161,6 +168,7 @@ class DataCell(Control):
         self._set_attr("placeholder", value)
 
     # show_edit_icon
+
     @property
     def show_edit_icon(self) -> Optional[bool]:
         return self._get_attr("showEditIcon", data_type="bool", def_value=False)
@@ -170,6 +178,7 @@ class DataCell(Control):
         self._set_attr("showEditIcon", value)
 
     # on_double_tap
+
     @property
     def on_double_tap(self):
         return self._get_event_handler("double_tap")
@@ -180,6 +189,7 @@ class DataCell(Control):
         self._set_attr("onDoubleTap", True if handler is not None else None)
 
     # on_long_press
+
     @property
     def on_long_press(self):
         return self._get_event_handler("long_press")
@@ -190,6 +200,7 @@ class DataCell(Control):
         self._set_attr("onLongPress", True if handler is not None else None)
 
     # on_tap
+
     @property
     def on_tap(self):
         return self._get_event_handler("tap")
@@ -200,6 +211,7 @@ class DataCell(Control):
         self._set_attr("onTap", True if handler is not None else None)
 
     # on_tap_cancel
+
     @property
     def on_tap_cancel(self):
         return self._get_event_handler("tap_cancel")
@@ -210,6 +222,7 @@ class DataCell(Control):
         self._set_attr("onTapCancel", True if handler is not None else None)
 
     # on_tap_down
+
     @property
     def on_tap_down(self):
         return self.__on_tap_down
@@ -253,6 +266,7 @@ class DataRow(Control):
         return self.__cells
 
     # cells
+
     @property
     def cells(self):
         return self.__cells
@@ -262,6 +276,7 @@ class DataRow(Control):
         self.__cells = value if value is not None else []
 
     # color
+
     @property
     def color(self) -> Union[None, str, Dict[MaterialState, str]]:
         return self.__color
@@ -271,6 +286,7 @@ class DataRow(Control):
         self.__color = value
 
     # selected
+
     @property
     def selected(self) -> Optional[bool]:
         return self._get_attr("selected", data_type="bool", def_value=False)
@@ -280,6 +296,7 @@ class DataRow(Control):
         self._set_attr("selected", value)
 
     # on_long_press
+
     @property
     def on_long_press(self):
         return self._get_event_handler("long_press")
@@ -290,6 +307,7 @@ class DataRow(Control):
         self._set_attr("onLongPress", True if handler is not None else None)
 
     # on_select_changed
+
     @property
     def on_select_changed(self):
         return self._get_event_handler("select_changed")
@@ -438,6 +456,7 @@ class DataTable(ConstrainedControl):
         return children
 
     # columns
+
     @property
     def columns(self):
         return self.__columns
@@ -447,6 +466,7 @@ class DataTable(ConstrainedControl):
         self.__columns = value if value is not None else []
 
     # rows
+
     @property
     def rows(self):
         return self.__rows
@@ -456,6 +476,7 @@ class DataTable(ConstrainedControl):
         self.__rows = value if value is not None else []
 
     # border
+
     @property
     def border(self) -> Optional[Border]:
         return self.__border
@@ -465,6 +486,7 @@ class DataTable(ConstrainedControl):
         self.__border = value
 
     # border_radius
+
     @property
     def border_radius(self) -> BorderRadiusValue:
         return self.__border_radius
@@ -474,6 +496,7 @@ class DataTable(ConstrainedControl):
         self.__border_radius = value
 
     # horizontal_lines
+
     @property
     def horizontal_lines(self) -> Optional[BorderSide]:
         return self.__horizontal_lines
@@ -483,6 +506,7 @@ class DataTable(ConstrainedControl):
         self.__horizontal_lines = value
 
     # vertical_lines
+
     @property
     def vertical_lines(self) -> Optional[BorderSide]:
         return self.__vertical_lines
@@ -492,6 +516,7 @@ class DataTable(ConstrainedControl):
         self.__vertical_lines = value
 
     # checkbox_horizontal_margin
+
     @property
     def checkbox_horizontal_margin(self) -> OptionalNumber:
         return self._get_attr("checkboxHorizontalMargin")
@@ -501,6 +526,7 @@ class DataTable(ConstrainedControl):
         self._set_attr("checkboxHorizontalMargin", value)
 
     # column_spacing
+
     @property
     def column_spacing(self) -> OptionalNumber:
         return self._get_attr("columnSpacing")
@@ -510,6 +536,7 @@ class DataTable(ConstrainedControl):
         self._set_attr("columnSpacing", value)
 
     # divider_thickness
+
     @property
     def divider_thickness(self) -> OptionalNumber:
         return self._get_attr("dividerThickness", data_type="float", def_value=1.0)
@@ -519,6 +546,7 @@ class DataTable(ConstrainedControl):
         self._set_attr("dividerThickness", value)
 
     # horizontal_margin
+
     @property
     def horizontal_margin(self) -> OptionalNumber:
         return self._get_attr("horizontalMargin")
@@ -528,6 +556,7 @@ class DataTable(ConstrainedControl):
         self._set_attr("horizontalMargin", value)
 
     # data_row_color
+
     @property
     def data_row_color(self) -> Union[None, str, Dict[MaterialState, str]]:
         return self.__data_row_color
@@ -537,6 +566,7 @@ class DataTable(ConstrainedControl):
         self.__data_row_color = value
 
     # data_row_min_height
+
     @property
     def data_row_min_height(self) -> OptionalNumber:
         return self._get_attr("dataRowMinHeight")
@@ -546,6 +576,7 @@ class DataTable(ConstrainedControl):
         self._set_attr("dataRowMinHeight", value)
 
     # data_row_max_height
+
     @property
     def data_row_max_height(self) -> OptionalNumber:
         return self._get_attr("dataRowMaxHeight")
@@ -555,6 +586,7 @@ class DataTable(ConstrainedControl):
         self._set_attr("dataRowMaxHeight", value)
 
     # data_text_style
+
     @property
     def data_text_style(self):
         return self.__data_text_style
@@ -564,6 +596,7 @@ class DataTable(ConstrainedControl):
         self.__data_text_style = value
 
     # bgcolor
+
     @property
     def bgcolor(self):
         return self._get_attr("bgColor")
@@ -573,6 +606,7 @@ class DataTable(ConstrainedControl):
         self._set_attr("bgColor", value)
 
     # gradient
+
     @property
     def gradient(self) -> Optional[Gradient]:
         return self.__gradient
@@ -582,6 +616,7 @@ class DataTable(ConstrainedControl):
         self.__gradient = value
 
     # heading_row_color
+
     @property
     def heading_row_color(self) -> Union[None, str, Dict[MaterialState, str]]:
         return self.__heading_row_color
@@ -591,6 +626,7 @@ class DataTable(ConstrainedControl):
         self.__heading_row_color = value
 
     # heading_row_height
+
     @property
     def heading_row_height(self) -> OptionalNumber:
         return self._get_attr("headingRowHeight")
@@ -600,6 +636,7 @@ class DataTable(ConstrainedControl):
         self._set_attr("headingRowHeight", value)
 
     # heading_text_style
+
     @property
     def heading_text_style(self):
         return self.__heading_text_style
@@ -609,6 +646,7 @@ class DataTable(ConstrainedControl):
         self.__heading_text_style = value
 
     # show_bottom_border
+
     @property
     def show_bottom_border(self) -> Optional[bool]:
         return self._get_attr("showBottomBorder", data_type="bool", def_value=False)
@@ -618,6 +656,7 @@ class DataTable(ConstrainedControl):
         self._set_attr("showBottomBorder", value)
 
     # show_checkbox_column
+
     @property
     def show_checkbox_column(self) -> Optional[bool]:
         return self._get_attr("showCheckboxColumn", data_type="bool", def_value=False)
@@ -627,6 +666,7 @@ class DataTable(ConstrainedControl):
         self._set_attr("showCheckboxColumn", value)
 
     # sort_ascending
+
     @property
     def sort_ascending(self) -> Optional[bool]:
         return self._get_attr("sortAscending", data_type="bool", def_value=False)
@@ -636,6 +676,7 @@ class DataTable(ConstrainedControl):
         self._set_attr("sortAscending", value)
 
     # sort_column_index
+
     @property
     def sort_column_index(self) -> Optional[int]:
         return self._get_attr("sortColumnIndex")
@@ -645,6 +686,7 @@ class DataTable(ConstrainedControl):
         self._set_attr("sortColumnIndex", value)
 
     # clip_behavior
+
     @property
     def clip_behavior(self) -> Optional[ClipBehavior]:
         return self.__clip_behavior
@@ -657,6 +699,7 @@ class DataTable(ConstrainedControl):
         )
 
     # on_select_all
+
     @property
     def on_select_all(self):
         return self._get_event_handler("select_all")
@@ -676,14 +719,12 @@ class Item(Control):
     def _set_attr(self, name, value, dirty=True):
         if value is None:
             return
-
         orig_val = self._get_attr(name)
         if orig_val is not None:
             if isinstance(orig_val, bool):
                 value = str(value).lower() == "true"
             elif isinstance(orig_val, float):
                 value = float(str(value))
-
         self._set_attr_internal(name, value, dirty=False)
         if isinstance(self.obj, dict):
             self.obj[name] = value
@@ -692,6 +733,7 @@ class Item(Control):
 
     def _fetch_attrs(self):
         # reflection
+
         obj = self.obj if isinstance(self.obj, dict) else vars(self.obj)
 
         for name, val in obj.items():

--- a/sdk/python/packages/flet-core/src/flet_core/date_picker.py
+++ b/sdk/python/packages/flet-core/src/flet_core/date_picker.py
@@ -3,17 +3,12 @@ from enum import Enum
 from typing import Any, Optional, Union
 
 from flet_core import ControlEvent
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.event_handler import EventHandler
 from flet_core.ref import Ref
 from flet_core.textfield import KeyboardType
-from flet_core.types import ResponsiveNumber
+from flet_core.types import OptionalNumber, ResponsiveNumber
 from flet_core.utils import deprecated
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
 
 
 class DatePickerMode(Enum):
@@ -127,7 +122,9 @@ class DatePicker(Control):
             data=data,
         )
 
-        self.__on_entry_mode_change = EventHandler(lambda e: DatePickerEntryModeChangeEvent(e.data))
+        self.__on_entry_mode_change = EventHandler(
+            lambda e: DatePickerEntryModeChangeEvent(e.data)
+        )
         self._add_event_handler(
             "entryModeChange", self.__on_entry_mode_change.get_handler()
         )
@@ -172,6 +169,7 @@ class DatePicker(Control):
         self.pick_date()
 
     # open
+
     @property
     def open(self) -> Optional[bool]:
         return self._get_attr("open", data_type="bool", def_value=False)
@@ -181,6 +179,7 @@ class DatePicker(Control):
         self._set_attr("open", value)
 
     # value
+
     @property
     def value(self) -> Optional[datetime]:
         value_string = self._get_attr("value", def_value=None)
@@ -193,6 +192,7 @@ class DatePicker(Control):
         self._set_attr("value", value)
 
     # first_date
+
     @property
     def first_date(self) -> Optional[datetime]:
         value_string = self._get_attr("firstDate", def_value=None)
@@ -207,6 +207,7 @@ class DatePicker(Control):
         self._set_attr("firstDate", value)
 
     # last_date
+
     @property
     def last_date(self) -> Optional[datetime]:
         value_string = self._get_attr("lastDate", def_value=None)
@@ -221,6 +222,7 @@ class DatePicker(Control):
         self._set_attr("lastDate", value)
 
     # current_date
+
     @property
     def current_date(self) -> Optional[datetime]:
         value_string = self._get_attr("currentDate", def_value=None)
@@ -235,6 +237,7 @@ class DatePicker(Control):
         self._set_attr("currentDate", value)
 
     # field_hint_text
+
     @property
     def field_hint_text(self) -> Optional[str]:
         return self._get_attr("fieldHintText", def_value=None)
@@ -244,6 +247,7 @@ class DatePicker(Control):
         self._set_attr("fieldHintText", value)
 
     # field_label_text
+
     @property
     def field_label_text(self) -> Optional[str]:
         return self._get_attr("fieldLabelText", def_value=None)
@@ -253,6 +257,7 @@ class DatePicker(Control):
         self._set_attr("fieldLabelText", value)
 
     # help_text
+
     @property
     def help_text(self) -> Optional[str]:
         return self._get_attr("helpText", def_value=None)
@@ -262,6 +267,7 @@ class DatePicker(Control):
         self._set_attr("helpText", value)
 
     # cancel_text
+
     @property
     def cancel_text(self) -> Optional[str]:
         return self._get_attr("cancelText", def_value=None)
@@ -271,6 +277,7 @@ class DatePicker(Control):
         self._set_attr("cancelText", value)
 
     # confirm_text
+
     @property
     def confirm_text(self) -> Optional[str]:
         return self._get_attr("confirmText", def_value=None)
@@ -280,6 +287,7 @@ class DatePicker(Control):
         self._set_attr("confirmText", value)
 
     # error_format_text
+
     @property
     def error_format_text(self) -> Optional[str]:
         return self._get_attr("errorFormatText", def_value=None)
@@ -289,6 +297,7 @@ class DatePicker(Control):
         self._set_attr("errorFormatText", value)
 
     # error_invalid_text
+
     @property
     def error_invalid_text(self) -> Optional[str]:
         return self._get_attr("errorInvalidText", def_value=None)
@@ -298,6 +307,7 @@ class DatePicker(Control):
         self._set_attr("errorInvalidText", value)
 
     # keyboard_type
+
     @property
     def keyboard_type(self) -> Optional[KeyboardType]:
         return self.__keyboard_type
@@ -310,6 +320,7 @@ class DatePicker(Control):
         )
 
     # date_picker_mode
+
     @property
     def date_picker_mode(self) -> Optional[DatePickerMode]:
         return self.__date_picker_mode
@@ -320,6 +331,7 @@ class DatePicker(Control):
         self._set_enum_attr("datePickerMode", value, DatePickerMode)
 
     # date_picker_entry_mode
+
     @property
     def date_picker_entry_mode(self) -> Optional[DatePickerEntryMode]:
         return self.__date_picker_entry_mode
@@ -333,6 +345,7 @@ class DatePicker(Control):
         )
 
     # switch_to_calendar_icon
+
     @property
     def switch_to_calendar_icon(self):
         return self._get_attr("switchToCalendarEntryModeIcon")
@@ -342,6 +355,7 @@ class DatePicker(Control):
         self._set_attr("switchToCalendarEntryModeIcon", value)
 
     # switch_to_input_icon
+
     @property
     def switch_to_input_icon(self):
         return self._get_attr("switchToInputEntryModeIcon")
@@ -351,6 +365,7 @@ class DatePicker(Control):
         self._set_attr("switchToInputEntryModeIcon", value)
 
     # on_change
+
     @property
     def on_change(self):
         return self._get_event_handler("change")
@@ -360,6 +375,7 @@ class DatePicker(Control):
         self._add_event_handler("change", handler)
 
     # on_dismiss
+
     @property
     def on_dismiss(self):
         return self._get_event_handler("dismiss")
@@ -369,6 +385,7 @@ class DatePicker(Control):
         self._add_event_handler("dismiss", handler)
 
     # on_entry_mode_change
+
     @property
     def on_entry_mode_change(self):
         return self.__on_entry_mode_change

--- a/sdk/python/packages/flet-core/src/flet_core/dismissible.py
+++ b/sdk/python/packages/flet-core/src/flet_core/dismissible.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Optional, Union
 
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.control_event import ControlEvent
 from flet_core.event_handler import EventHandler
 from flet_core.ref import Ref
@@ -11,6 +11,7 @@ from flet_core.snack_bar import DismissDirection
 from flet_core.types import (
     AnimationValue,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -173,6 +174,7 @@ class Dismissible(ConstrainedControl, AdaptiveControl):
         self.confirm_dismiss(dismiss)
 
     # content
+
     @property
     def content(self) -> Control:
         return self.__content
@@ -182,6 +184,7 @@ class Dismissible(ConstrainedControl, AdaptiveControl):
         self.__content = value
 
     # background
+
     @property
     def background(self) -> Optional[Control]:
         return self.__background
@@ -191,6 +194,7 @@ class Dismissible(ConstrainedControl, AdaptiveControl):
         self.__background = value
 
     # secondary_background
+
     @property
     def secondary_background(self) -> Optional[Control]:
         return self.__secondary_background
@@ -200,6 +204,7 @@ class Dismissible(ConstrainedControl, AdaptiveControl):
         self.__secondary_background = value
 
     # movementDuration
+
     @property
     def movement_duration(self) -> Optional[int]:
         return self._get_attr("movementDuration")
@@ -209,6 +214,7 @@ class Dismissible(ConstrainedControl, AdaptiveControl):
         self._set_attr("movementDuration", value)
 
     # resizeDuration
+
     @property
     def resize_duration(self) -> Optional[int]:
         return self._get_attr("resizeDuration")
@@ -218,6 +224,7 @@ class Dismissible(ConstrainedControl, AdaptiveControl):
         self._set_attr("resizeDuration", value)
 
     # crossAxisEndOffset
+
     @property
     def cross_axis_end_offset(self) -> OptionalNumber:
         return self._get_attr("crossAxisEndOffset")
@@ -227,6 +234,7 @@ class Dismissible(ConstrainedControl, AdaptiveControl):
         self._set_attr("crossAxisEndOffset", value)
 
     # dismissDirection
+
     @property
     def dismiss_direction(self) -> Optional[DismissDirection]:
         return self.__dismiss_direction
@@ -240,6 +248,7 @@ class Dismissible(ConstrainedControl, AdaptiveControl):
         )
 
     # dismissThresholds
+
     @property
     def dismiss_thresholds(self) -> Optional[Dict[DismissDirection, OptionalNumber]]:
         return self.__dismiss_thresholds
@@ -251,6 +260,7 @@ class Dismissible(ConstrainedControl, AdaptiveControl):
         self.__dismiss_thresholds = value
 
     # on_dismiss
+
     @property
     def on_dismiss(self):
         return self._get_event_handler("dismiss")
@@ -261,6 +271,7 @@ class Dismissible(ConstrainedControl, AdaptiveControl):
         self._set_attr("onDismiss", True if handler is not None else None)
 
     # on_confirm_dismiss
+
     @property
     def on_confirm_dismiss(self):
         return self._get_event_handler("confirm_dismiss")
@@ -271,6 +282,7 @@ class Dismissible(ConstrainedControl, AdaptiveControl):
         self._set_attr("onConfirmDismiss", True if handler is not None else None)
 
     # on_update
+
     @property
     def on_update(self):
         return self._get_event_handler("update")
@@ -281,6 +293,7 @@ class Dismissible(ConstrainedControl, AdaptiveControl):
         self._set_attr("onUpdate", True if handler is not None else None)
 
     # on_resize
+
     @property
     def on_resize(self):
         return self._get_event_handler("resize")

--- a/sdk/python/packages/flet-core/src/flet_core/divider.py
+++ b/sdk/python/packages/flet-core/src/flet_core/divider.py
@@ -1,7 +1,8 @@
 from typing import Any, Optional
 
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
+from flet_core.types import OptionalNumber
 
 
 class Divider(Control):
@@ -79,6 +80,7 @@ class Divider(Control):
         return "divider"
 
     # height
+
     @property
     def height(self) -> OptionalNumber:
         return self._get_attr("height", data_type="float")
@@ -88,6 +90,7 @@ class Divider(Control):
         self._set_attr("height", value)
 
     # thickness
+
     @property
     def thickness(self) -> OptionalNumber:
         return self._get_attr("thickness", data_type="float")
@@ -97,6 +100,7 @@ class Divider(Control):
         self._set_attr("thickness", value)
 
     # color
+
     @property
     def color(self) -> Optional[str]:
         return self._get_attr("color")
@@ -106,6 +110,7 @@ class Divider(Control):
         self._set_attr("color", value)
 
     # leading_indent
+
     @property
     def leading_indent(self) -> OptionalNumber:
         return self._get_attr("leadingIndent", data_type="float")
@@ -115,6 +120,7 @@ class Divider(Control):
         self._set_attr("leadingIndent", value)
 
     # trailing_indent
+
     @property
     def trailing_indent(self) -> OptionalNumber:
         return self._get_attr("trailingIndent", data_type="float")

--- a/sdk/python/packages/flet-core/src/flet_core/dropdown.py
+++ b/sdk/python/packages/flet-core/src/flet_core/dropdown.py
@@ -1,8 +1,8 @@
 import time
-from typing import Any, Optional, Union, List
+from typing import Any, List, Optional, Union
 
 from flet_core.alignment import Alignment
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.form_field_control import FormFieldControl, InputBorder
 from flet_core.ref import Ref
 from flet_core.text_style import TextStyle
@@ -10,6 +10,7 @@ from flet_core.types import (
     AnimationValue,
     BorderRadiusValue,
     OffsetValue,
+    OptionalNumber,
     PaddingValue,
     ResponsiveNumber,
     RotateValue,
@@ -48,6 +49,7 @@ class Option(Control):
         self._set_attr_json("alignment", self.__alignment)
 
     # key
+
     @property
     def key(self):
         return self._get_attr("key")
@@ -57,6 +59,7 @@ class Option(Control):
         self._set_attr("key", value)
 
     # text
+
     @property
     def text(self):
         return self._get_attr("text")
@@ -66,6 +69,7 @@ class Option(Control):
         self._set_attr("text", value)
 
     # alignment
+
     @property
     def alignment(self) -> Optional[Alignment]:
         return self.__alignment
@@ -75,6 +79,7 @@ class Option(Control):
         self.__alignment = value
 
     # on_click
+
     @property
     def on_click(self):
         return self._get_event_handler("click")
@@ -327,6 +332,7 @@ class Dropdown(FormFieldControl):
         self.focus()
 
     # options
+
     @property
     def options(self):
         return self.__options
@@ -336,6 +342,7 @@ class Dropdown(FormFieldControl):
         self.__options = value if value is not None else []
 
     # icon_content
+
     @property
     def icon_content(self) -> Optional[Control]:
         return self.__icon_content
@@ -345,6 +352,7 @@ class Dropdown(FormFieldControl):
         self.__icon_content = value
 
     # hint_content
+
     @property
     def hint_content(self) -> Optional[Control]:
         return self.__hint_content
@@ -354,6 +362,7 @@ class Dropdown(FormFieldControl):
         self.__hint_content = value
 
     # value
+
     @property
     def value(self) -> Optional[str]:
         return self._get_attr("value")
@@ -363,6 +372,7 @@ class Dropdown(FormFieldControl):
         self._set_attr("value", value)
 
     # icon_enabled_color
+
     @property
     def icon_enabled_color(self) -> Optional[str]:
         return self._get_attr("iconEnabledColor")
@@ -372,6 +382,7 @@ class Dropdown(FormFieldControl):
         self._set_attr("iconEnabledColor", value)
 
     # icon_disabled_color
+
     @property
     def icon_disabled_color(self) -> Optional[str]:
         return self._get_attr("iconDisabledColor")
@@ -381,6 +392,7 @@ class Dropdown(FormFieldControl):
         self._set_attr("iconDisabledColor", value)
 
     # item_height
+
     @property
     def item_height(self) -> OptionalNumber:
         return self._get_attr("itemHeight", data_type="float")
@@ -390,6 +402,7 @@ class Dropdown(FormFieldControl):
         self._set_attr("itemHeight", value)
 
     # menu_max_height
+
     @property
     def menu_max_height(self) -> OptionalNumber:
         return self._get_attr("menuMaxHeight", data_type="float")
@@ -399,6 +412,7 @@ class Dropdown(FormFieldControl):
         self._set_attr("menuMaxHeight", value)
 
     # icon_size
+
     @property
     def icon_size(self) -> OptionalNumber:
         return self._get_attr("iconSize", data_type="float", def_value=24.0)
@@ -408,6 +422,7 @@ class Dropdown(FormFieldControl):
         self._set_attr("iconSize", value)
 
     # padding
+
     @property
     def padding(self) -> PaddingValue:
         return self.__padding
@@ -417,6 +432,7 @@ class Dropdown(FormFieldControl):
         self.__padding = value
 
     # autofocus
+
     @property
     def autofocus(self) -> Optional[bool]:
         return self._get_attr("autofocus", data_type="bool", def_value=False)
@@ -426,6 +442,7 @@ class Dropdown(FormFieldControl):
         self._set_attr("autofocus", value)
 
     # enable_feedback
+
     @property
     def enable_feedback(self) -> Optional[bool]:
         return self._get_attr("enableFeedback", data_type="bool", def_value=True)
@@ -435,6 +452,7 @@ class Dropdown(FormFieldControl):
         self._set_attr("enableFeedback", value)
 
     # elevation
+
     @property
     def elevation(self) -> OptionalNumber:
         return self._get_attr("elevation", data_type="float", def_value=8)
@@ -444,6 +462,7 @@ class Dropdown(FormFieldControl):
         self._set_attr("elevation", value)
 
     # alignment
+
     @property
     def alignment(self) -> Optional[Alignment]:
         return self.__alignment
@@ -453,6 +472,7 @@ class Dropdown(FormFieldControl):
         self.__alignment = value
 
     # on_change
+
     @property
     def on_change(self):
         return self._get_event_handler("change")
@@ -462,6 +482,7 @@ class Dropdown(FormFieldControl):
         self._add_event_handler("change", handler)
 
     # on_focus
+
     @property
     def on_focus(self):
         return self._get_event_handler("focus")
@@ -471,6 +492,7 @@ class Dropdown(FormFieldControl):
         self._add_event_handler("focus", handler)
 
     # on_blur
+
     @property
     def on_blur(self):
         return self._get_event_handler("blur")
@@ -480,6 +502,7 @@ class Dropdown(FormFieldControl):
         self._add_event_handler("blur", handler)
 
     # on_click
+
     @property
     def on_click(self):
         return self._get_event_handler("click")

--- a/sdk/python/packages/flet-core/src/flet_core/elevated_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/elevated_button.py
@@ -4,15 +4,16 @@ from typing import Any, Optional, Union
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.buttons import ButtonStyle
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
+    ClipBehavior,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
-    ClipBehavior,
     UrlTarget,
 )
 from flet_core.utils import deprecated
@@ -161,6 +162,7 @@ class ElevatedButton(ConstrainedControl, AdaptiveControl):
                 self.__style = ButtonStyle()
             if self.__style.color != self.__color or self.disabled:
                 # if the color is set through the style, use it
+
                 if not (
                     self.__class__.__name__ in ["FilledButton", "FilledTonalButton"]
                     and self.__style.color
@@ -169,6 +171,7 @@ class ElevatedButton(ConstrainedControl, AdaptiveControl):
                     self.__style.color = self.__color if not self.disabled else None
             if self.__style.bgcolor != self.__bgcolor or self.disabled:
                 # if the bgcolor is set through the style, use it
+
                 if not (
                     self.__class__.__name__ in ["FilledButton", "FilledTonalButton"]
                     and self.__style.bgcolor
@@ -202,6 +205,7 @@ class ElevatedButton(ConstrainedControl, AdaptiveControl):
         self.focus()
 
     # text
+
     @property
     def text(self):
         return self._get_attr("text")
@@ -211,6 +215,7 @@ class ElevatedButton(ConstrainedControl, AdaptiveControl):
         self._set_attr("text", value)
 
     # color
+
     @property
     def color(self):
         return self.__color
@@ -220,6 +225,7 @@ class ElevatedButton(ConstrainedControl, AdaptiveControl):
         self.__color = value
 
     # bgcolor
+
     @property
     def bgcolor(self):
         return self.__bgcolor
@@ -230,6 +236,7 @@ class ElevatedButton(ConstrainedControl, AdaptiveControl):
         self._set_attr("bgColor", value)
 
     # elevation
+
     @property
     def elevation(self) -> OptionalNumber:
         return self.__elevation
@@ -239,6 +246,7 @@ class ElevatedButton(ConstrainedControl, AdaptiveControl):
         self.__elevation = value
 
     # style
+
     @property
     def style(self) -> Optional[ButtonStyle]:
         return self.__style
@@ -248,6 +256,7 @@ class ElevatedButton(ConstrainedControl, AdaptiveControl):
         self.__style = value
 
     # icon
+
     @property
     def icon(self):
         return self._get_attr("icon")
@@ -257,6 +266,7 @@ class ElevatedButton(ConstrainedControl, AdaptiveControl):
         self._set_attr("icon", value)
 
     # icon_color
+
     @property
     def icon_color(self):
         return self._get_attr("iconColor")
@@ -266,6 +276,7 @@ class ElevatedButton(ConstrainedControl, AdaptiveControl):
         self._set_attr("iconColor", value)
 
     # url
+
     @property
     def url(self):
         return self._get_attr("url")
@@ -275,6 +286,7 @@ class ElevatedButton(ConstrainedControl, AdaptiveControl):
         self._set_attr("url", value)
 
     # url_target
+
     @property
     def url_target(self) -> Optional[UrlTarget]:
         return self.__url_target
@@ -287,6 +299,7 @@ class ElevatedButton(ConstrainedControl, AdaptiveControl):
         )
 
     # on_click
+
     @property
     def on_click(self):
         return self._get_event_handler("click")
@@ -296,6 +309,7 @@ class ElevatedButton(ConstrainedControl, AdaptiveControl):
         self._add_event_handler("click", handler)
 
     # on_long_press
+
     @property
     def on_long_press(self):
         return self._get_event_handler("long_press")
@@ -306,6 +320,7 @@ class ElevatedButton(ConstrainedControl, AdaptiveControl):
         self._set_attr("onLongPress", True if handler is not None else None)
 
     # content
+
     @property
     def content(self) -> Optional[Control]:
         return self.__content
@@ -315,6 +330,7 @@ class ElevatedButton(ConstrainedControl, AdaptiveControl):
         self.__content = value
 
     # autofocus
+
     @property
     def autofocus(self) -> Optional[bool]:
         return self._get_attr("autofocus", data_type="bool", def_value=False)
@@ -324,6 +340,7 @@ class ElevatedButton(ConstrainedControl, AdaptiveControl):
         self._set_attr("autofocus", value)
 
     # clip_behavior
+
     @property
     def clip_behavior(self) -> Optional[ClipBehavior]:
         return self._get_attr("clipBehavior")
@@ -335,6 +352,7 @@ class ElevatedButton(ConstrainedControl, AdaptiveControl):
         )
 
     # on_hover
+
     @property
     def on_hover(self):
         return self._get_event_handler("hover")
@@ -345,6 +363,7 @@ class ElevatedButton(ConstrainedControl, AdaptiveControl):
         self._set_attr("onHover", True if handler is not None else None)
 
     # on_focus
+
     @property
     def on_focus(self):
         return self._get_event_handler("focus")
@@ -354,6 +373,7 @@ class ElevatedButton(ConstrainedControl, AdaptiveControl):
         self._add_event_handler("focus", handler)
 
     # on_blur
+
     @property
     def on_blur(self):
         return self._get_event_handler("blur")

--- a/sdk/python/packages/flet-core/src/flet_core/expansion_panel.py
+++ b/sdk/python/packages/flet-core/src/flet_core/expansion_panel.py
@@ -2,11 +2,12 @@ from typing import Any, List, Optional, Union
 
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     OffsetValue,
+    OptionalNumber,
     PaddingValue,
     ResponsiveNumber,
     RotateValue,
@@ -119,6 +120,7 @@ class ExpansionPanel(ConstrainedControl, AdaptiveControl):
         return children
 
     # bgcolor
+
     @property
     def bgcolor(self):
         return self._get_attr("bgColor")
@@ -128,6 +130,7 @@ class ExpansionPanel(ConstrainedControl, AdaptiveControl):
         self._set_attr("bgColor", value)
 
     # expanded
+
     @property
     def expanded(self) -> Optional[bool]:
         return self._get_attr("expanded", data_type="bool", def_value=False)
@@ -137,6 +140,7 @@ class ExpansionPanel(ConstrainedControl, AdaptiveControl):
         self._set_attr("expanded", value)
 
     # can_tap_header
+
     @property
     def can_tap_header(self) -> Optional[bool]:
         return self._get_attr("canTapHeader", data_type="bool", def_value=False)
@@ -146,6 +150,7 @@ class ExpansionPanel(ConstrainedControl, AdaptiveControl):
         self._set_attr("canTapHeader", value)
 
     # content
+
     @property
     def content(self) -> Optional[Control]:
         return self.__content
@@ -155,6 +160,7 @@ class ExpansionPanel(ConstrainedControl, AdaptiveControl):
         self.__content = value
 
     # header
+
     @property
     def header(self) -> Optional[Control]:
         return self.__header
@@ -265,6 +271,7 @@ class ExpansionPanelList(ConstrainedControl):
         return children
 
     # divider_color
+
     @property
     def divider_color(self):
         return self._get_attr("dividerColor")
@@ -274,6 +281,7 @@ class ExpansionPanelList(ConstrainedControl):
         self._set_attr("dividerColor", value)
 
     # expanded_icon_color
+
     @property
     def expanded_icon_color(self):
         return self._get_attr("expandedIconColor")
@@ -283,6 +291,7 @@ class ExpansionPanelList(ConstrainedControl):
         self._set_attr("expandedIconColor", value)
 
     # expanded_header_padding
+
     @property
     def expanded_header_padding(self) -> PaddingValue:
         return self.__expanded_header_padding
@@ -292,6 +301,7 @@ class ExpansionPanelList(ConstrainedControl):
         self.__expanded_header_padding = value
 
     # elevation
+
     @property
     def elevation(self) -> OptionalNumber:
         return self._get_attr("elevation")
@@ -301,6 +311,7 @@ class ExpansionPanelList(ConstrainedControl):
         self._set_attr("elevation", value)
 
     # spacing
+
     @property
     def spacing(self) -> OptionalNumber:
         return self._get_attr("spacing")
@@ -310,6 +321,7 @@ class ExpansionPanelList(ConstrainedControl):
         self._set_attr("spacing", value)
 
     # controls
+
     @property
     def controls(self):
         return self.__controls
@@ -319,6 +331,7 @@ class ExpansionPanelList(ConstrainedControl):
         self.__controls = value if value is not None else []
 
     # on_change
+
     @property
     def on_change(self):
         return self._get_event_handler("change")

--- a/sdk/python/packages/flet-core/src/flet_core/expansion_tile.py
+++ b/sdk/python/packages/flet-core/src/flet_core/expansion_tile.py
@@ -5,7 +5,7 @@ from flet_core.adaptive_control import AdaptiveControl
 from flet_core.alignment import Alignment
 from flet_core.buttons import OutlinedBorder
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.theme import ThemeVisualDensity
 from flet_core.types import (
@@ -13,6 +13,7 @@ from flet_core.types import (
     ClipBehavior,
     CrossAxisAlignment,
     OffsetValue,
+    OptionalNumber,
     PaddingValue,
     ResponsiveNumber,
     RotateValue,
@@ -188,6 +189,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
         return children
 
     # controls
+
     @property
     def controls(self):
         return self.__controls
@@ -197,6 +199,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
         self.__controls = value if value is not None else []
 
     # controls_padding
+
     @property
     def controls_padding(self) -> PaddingValue:
         return self.__controls_padding
@@ -206,6 +209,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
         self.__controls_padding = value
 
     # tile_padding
+
     @property
     def tile_padding(self) -> PaddingValue:
         return self.__tile_padding
@@ -215,6 +219,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
         self.__tile_padding = value
 
     # expanded_alignment
+
     @property
     def expanded_alignment(self) -> Optional[Alignment]:
         return self.__expanded_alignment
@@ -224,6 +229,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
         self.__expanded_alignment = value
 
     # expanded_cross_axis_alignment
+
     @property
     def expanded_cross_axis_alignment(self) -> Optional[CrossAxisAlignment]:
         return self.__expanded_cross_axis_alignment
@@ -237,6 +243,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
         )
 
     # affinity
+
     @property
     def affinity(self) -> Optional[TileAffinity]:
         return self.__affinity
@@ -247,6 +254,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
         self._set_enum_attr("affinity", value, TileAffinity)
 
     # leading
+
     @property
     def leading(self) -> Optional[Control]:
         return self.__leading
@@ -256,6 +264,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
         self.__leading = value
 
     # title
+
     @property
     def title(self) -> Optional[Control]:
         return self.__title
@@ -265,6 +274,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
         self.__title = value
 
     # subtitle
+
     @property
     def subtitle(self) -> Optional[Control]:
         return self.__subtitle
@@ -274,6 +284,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
         self.__subtitle = value
 
     # trailing
+
     @property
     def trailing(self) -> Optional[Control]:
         return self.__trailing
@@ -283,6 +294,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
         self.__trailing = value
 
     # dense
+
     @property
     def dense(self) -> Optional[bool]:
         return self._get_attr("dense", data_type="bool")
@@ -292,6 +304,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
         self._set_attr("dense", value)
 
     # enable_feedback
+
     @property
     def enable_feedback(self) -> Optional[bool]:
         return self._get_attr("enableFeedback", data_type="bool", def_value=True)
@@ -301,6 +314,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
         self._set_attr("enableFeedback", value)
 
     # clip_behavior
+
     @property
     def clip_behavior(self) -> Optional[ClipBehavior]:
         return self.__clip_behavior
@@ -313,6 +327,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
         )
 
     # visual_density
+
     @property
     def visual_density(self) -> Optional[ThemeVisualDensity]:
         return self.__visual_density
@@ -326,6 +341,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
         )
 
     # maintain_state
+
     @property
     def maintain_state(self) -> Optional[bool]:
         return self._get_attr("maintainState", data_type="bool", def_value=False)
@@ -335,6 +351,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
         self._set_attr("maintainState", value)
 
     # initially_expanded
+
     @property
     def initially_expanded(self) -> Optional[bool]:
         return self._get_attr("initiallyExpanded", data_type="bool", def_value=False)
@@ -344,6 +361,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
         self._set_attr("initiallyExpanded", value)
 
     # shape
+
     @property
     def shape(self) -> Optional[OutlinedBorder]:
         return self.__shape
@@ -353,6 +371,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
         self.__shape = value
 
     # text_color
+
     @property
     def text_color(self) -> Optional[str]:
         return self._get_attr("textColor")
@@ -362,6 +381,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
         self._set_attr("textColor", value)
 
     # icon_color
+
     @property
     def icon_color(self) -> Optional[str]:
         return self._get_attr("iconColor")
@@ -371,6 +391,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
         self._set_attr("iconColor", value)
 
     # bgcolor
+
     @property
     def bgcolor(self) -> Optional[str]:
         return self._get_attr("bgColor")
@@ -380,6 +401,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
         self._set_attr("bgColor", value)
 
     # collapsed_bgcolor
+
     @property
     def collapsed_bgcolor(self) -> Optional[str]:
         return self._get_attr("collapsedBgColor")
@@ -389,6 +411,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
         self._set_attr("collapsedBgColor", value)
 
     # collapsed_icon_color
+
     @property
     def collapsed_icon_color(self) -> Optional[str]:
         return self._get_attr("collapsedIconColor")
@@ -398,6 +421,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
         self._set_attr("collapsedIconColor", value)
 
     # collapsed_text_color
+
     @property
     def collapsed_text_color(self) -> Optional[str]:
         return self._get_attr("collapsedTextColor")
@@ -407,6 +431,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
         self._set_attr("collapsedTextColor", value)
 
     # collapsed_shape
+
     @property
     def collapsed_shape(self) -> Optional[OutlinedBorder]:
         return self.__collapsed_shape
@@ -416,6 +441,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
         self.__collapsed_shape = value
 
     # on_change
+
     @property
     def on_change(self):
         return self._get_event_handler("change")

--- a/sdk/python/packages/flet-core/src/flet_core/filled_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/filled_button.py
@@ -1,10 +1,10 @@
 from typing import Any, Optional, Union
 
 from flet_core.buttons import ButtonStyle
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.elevated_button import ElevatedButton
 from flet_core.ref import Ref
-from flet_core.types import ResponsiveNumber, UrlTarget
+from flet_core.types import OptionalNumber, ResponsiveNumber, UrlTarget
 
 
 class FilledButton(ElevatedButton):

--- a/sdk/python/packages/flet-core/src/flet_core/filled_tonal_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/filled_tonal_button.py
@@ -1,10 +1,10 @@
 from typing import Any, Optional, Union
 
 from flet_core.buttons import ButtonStyle
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.elevated_button import ElevatedButton
 from flet_core.ref import Ref
-from flet_core.types import ResponsiveNumber, UrlTarget
+from flet_core.types import OptionalNumber, ResponsiveNumber, UrlTarget
 
 
 class FilledTonalButton(ElevatedButton):

--- a/sdk/python/packages/flet-core/src/flet_core/flet_app.py
+++ b/sdk/python/packages/flet-core/src/flet_core/flet_app.py
@@ -1,9 +1,14 @@
 from typing import Any, Optional, Union
 
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import OptionalNumber
 from flet_core.ref import Ref
-from flet_core.types import AnimationValue, OffsetValue, RotateValue, ScaleValue
+from flet_core.types import (
+    AnimationValue,
+    OffsetValue,
+    OptionalNumber,
+    RotateValue,
+    ScaleValue,
+)
 
 
 class FletApp(ConstrainedControl):
@@ -80,6 +85,7 @@ class FletApp(ConstrainedControl):
         return "fletapp"
 
     # url
+
     @property
     def url(self):
         return self._get_attr("url")
@@ -89,6 +95,7 @@ class FletApp(ConstrainedControl):
         self._set_attr("url", value)
 
     # reconnect_interval_ms
+
     @property
     def reconnect_interval_ms(self) -> Optional[int]:
         return self._get_attr("reconnectIntervalMs")
@@ -98,6 +105,7 @@ class FletApp(ConstrainedControl):
         self._set_attr("reconnectIntervalMs", value)
 
     # reconnect_timeout_ms
+
     @property
     def reconnect_timeout_ms(self) -> Optional[int]:
         return self._get_attr("reconnectTimeoutMs")
@@ -107,6 +115,7 @@ class FletApp(ConstrainedControl):
         self._set_attr("reconnectTimeoutMs", value)
 
     # on_error
+
     @property
     def on_error(self):
         return self._get_event_handler("error")

--- a/sdk/python/packages/flet-core/src/flet_core/floating_action_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/floating_action_button.py
@@ -2,13 +2,14 @@ from typing import Any, Optional, Union
 
 from flet_core.buttons import OutlinedBorder
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     ClipBehavior,
     MouseCursor,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -184,6 +185,7 @@ class FloatingActionButton(ConstrainedControl):
         return [self.__content]
 
     # text
+
     @property
     def text(self):
         return self._get_attr("text")
@@ -193,6 +195,7 @@ class FloatingActionButton(ConstrainedControl):
         self._set_attr("text", value)
 
     # icon
+
     @property
     def icon(self):
         return self._get_attr("icon")
@@ -202,6 +205,7 @@ class FloatingActionButton(ConstrainedControl):
         self._set_attr("icon", value)
 
     # bgcolor
+
     @property
     def bgcolor(self):
         return self._get_attr("bgcolor")
@@ -211,6 +215,7 @@ class FloatingActionButton(ConstrainedControl):
         self._set_attr("bgcolor", value)
 
     # url
+
     @property
     def url(self):
         return self._get_attr("url")
@@ -220,6 +225,7 @@ class FloatingActionButton(ConstrainedControl):
         self._set_attr("url", value)
 
     # url_target
+
     @property
     def url_target(self) -> Optional[UrlTarget]:
         return self.__url_target
@@ -232,6 +238,7 @@ class FloatingActionButton(ConstrainedControl):
         )
 
     # mouse_cursor
+
     @property
     def mouse_cursor(self) -> Optional[MouseCursor]:
         return self.__mouse_cursor
@@ -244,6 +251,7 @@ class FloatingActionButton(ConstrainedControl):
         )
 
     # on_click
+
     @property
     def on_click(self):
         return self._get_event_handler("click")
@@ -253,6 +261,7 @@ class FloatingActionButton(ConstrainedControl):
         self._add_event_handler("click", handler)
 
     # content
+
     @property
     def content(self) -> Optional[Control]:
         return self.__content
@@ -262,6 +271,7 @@ class FloatingActionButton(ConstrainedControl):
         self.__content = value
 
     # autofocus
+
     @property
     def autofocus(self) -> Optional[bool]:
         return self._get_attr("autofocus", data_type="bool", def_value=False)
@@ -271,6 +281,7 @@ class FloatingActionButton(ConstrainedControl):
         self._set_attr("autofocus", value)
 
     # shape
+
     @property
     def shape(self) -> Optional[OutlinedBorder]:
         return self.__shape
@@ -280,6 +291,7 @@ class FloatingActionButton(ConstrainedControl):
         self.__shape = value
 
     # mini
+
     @property
     def mini(self) -> Optional[bool]:
         return self._get_attr("mini", data_type="bool", def_value=False)
@@ -289,6 +301,7 @@ class FloatingActionButton(ConstrainedControl):
         self._set_attr("mini", value)
 
     # elevation
+
     @property
     def elevation(self):
         return self._get_attr("elevation", data_type="float")
@@ -298,6 +311,7 @@ class FloatingActionButton(ConstrainedControl):
         self._set_attr("elevation", value)
 
     # disabled_elevation
+
     @property
     def disabled_elevation(self):
         return self._get_attr("disabledElevation", data_type="float")
@@ -307,6 +321,7 @@ class FloatingActionButton(ConstrainedControl):
         self._set_attr("disabledElevation", value)
 
     # enable_feedback
+
     @property
     def enable_feedback(self):
         return self._get_attr("enableFeedback", data_type="bool", def_value=True)
@@ -316,6 +331,7 @@ class FloatingActionButton(ConstrainedControl):
         self._set_attr("enableFeedback", value)
 
     # focus_color
+
     @property
     def focus_color(self):
         return self._get_attr("focusColor")
@@ -325,6 +341,7 @@ class FloatingActionButton(ConstrainedControl):
         self._set_attr("focusColor", value)
 
     # focus_elevation
+
     @property
     def focus_elevation(self):
         return self._get_attr("focusElevation", data_type="float")
@@ -334,6 +351,7 @@ class FloatingActionButton(ConstrainedControl):
         self._set_attr("focusElevation", value)
 
     # foreground_color
+
     @property
     def foreground_color(self):
         return self._get_attr("foregroundColor")
@@ -343,6 +361,7 @@ class FloatingActionButton(ConstrainedControl):
         self._set_attr("foregroundColor", value)
 
     # highlight_elevation
+
     @property
     def highlight_elevation(self):
         return self._get_attr("highlightElevation", data_type="float")
@@ -352,6 +371,7 @@ class FloatingActionButton(ConstrainedControl):
         self._set_attr("highlightElevation", value)
 
     # hover_elevation
+
     @property
     def hover_elevation(self):
         return self._get_attr("hoverElevation", data_type="float")
@@ -361,6 +381,7 @@ class FloatingActionButton(ConstrainedControl):
         self._set_attr("hoverElevation", value)
 
     # clip_behavior
+
     @property
     def clip_behavior(self) -> Optional[ClipBehavior]:
         return self.__clip_behavior

--- a/sdk/python/packages/flet-core/src/flet_core/form_field_control.py
+++ b/sdk/python/packages/flet-core/src/flet_core/form_field_control.py
@@ -2,24 +2,20 @@ from enum import Enum
 from typing import Any, Optional, Union
 
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.text_style import TextStyle
 from flet_core.types import (
     AnimationValue,
     BorderRadiusValue,
     OffsetValue,
+    OptionalNumber,
     PaddingValue,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
     VerticalAlignment,
 )
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
 
 
 class InputBorder(Enum):
@@ -194,6 +190,7 @@ class FormFieldControl(ConstrainedControl):
         return children
 
     # text_size
+
     @property
     def text_size(self) -> OptionalNumber:
         return self._get_attr("textSize")
@@ -203,6 +200,7 @@ class FormFieldControl(ConstrainedControl):
         self._set_attr("textSize", value)
 
     # text_style
+
     @property
     def text_style(self) -> Optional[TextStyle]:
         return self.__text_style
@@ -212,6 +210,7 @@ class FormFieldControl(ConstrainedControl):
         self.__text_style = value
 
     # label
+
     @property
     def label(self) -> Optional[str]:
         return self._get_attr("label")
@@ -221,6 +220,7 @@ class FormFieldControl(ConstrainedControl):
         self._set_attr("label", value)
 
     # label_style
+
     @property
     def label_style(self) -> Optional[TextStyle]:
         return self.__label_style
@@ -230,6 +230,7 @@ class FormFieldControl(ConstrainedControl):
         self.__label_style = value
 
     # icon
+
     @property
     def icon(self) -> Optional[str]:
         return self._get_attr("icon")
@@ -239,6 +240,7 @@ class FormFieldControl(ConstrainedControl):
         self._set_attr("icon", value)
 
     # border
+
     @property
     def border(self) -> Optional[InputBorder]:
         return self.__border
@@ -249,6 +251,7 @@ class FormFieldControl(ConstrainedControl):
         self._set_enum_attr("border", value, InputBorder)
 
     # color
+
     @property
     def color(self) -> Optional[str]:
         return self._get_attr("color")
@@ -258,6 +261,7 @@ class FormFieldControl(ConstrainedControl):
         self._set_attr("color", value)
 
     # bgcolor
+
     @property
     def bgcolor(self) -> Optional[str]:
         return self._get_attr("bgcolor")
@@ -267,6 +271,7 @@ class FormFieldControl(ConstrainedControl):
         self._set_attr("bgcolor", value)
 
     # border_radius
+
     @property
     def border_radius(self) -> BorderRadiusValue:
         return self.__border_radius
@@ -276,6 +281,7 @@ class FormFieldControl(ConstrainedControl):
         self.__border_radius = value
 
     # border_width
+
     @property
     def border_width(self) -> OptionalNumber:
         return self._get_attr("borderWidth")
@@ -285,6 +291,7 @@ class FormFieldControl(ConstrainedControl):
         self._set_attr("borderWidth", value)
 
     # border_color
+
     @property
     def border_color(self) -> Optional[str]:
         return self._get_attr("borderColor")
@@ -294,6 +301,7 @@ class FormFieldControl(ConstrainedControl):
         self._set_attr("borderColor", value)
 
     # text_vertical_align
+
     @property
     def text_vertical_align(self) -> Union[VerticalAlignment, OptionalNumber]:
         return self._get_attr("textVerticalAlign")
@@ -306,6 +314,7 @@ class FormFieldControl(ConstrainedControl):
         self._set_attr("textVerticalAlign", v)
 
     # focused_color
+
     @property
     def focused_color(self) -> Optional[str]:
         return self._get_attr("focusedColor")
@@ -315,6 +324,7 @@ class FormFieldControl(ConstrainedControl):
         self._set_attr("focusedColor", value)
 
     # focused_bgcolor
+
     @property
     def focused_bgcolor(self) -> Optional[str]:
         return self._get_attr("focusedBgcolor")
@@ -324,6 +334,7 @@ class FormFieldControl(ConstrainedControl):
         self._set_attr("focusedBgcolor", value)
 
     # focused_border_width
+
     @property
     def focused_border_width(self) -> OptionalNumber:
         return self._get_attr("focusedBorderWidth")
@@ -333,6 +344,7 @@ class FormFieldControl(ConstrainedControl):
         self._set_attr("focusedBorderWidth", value)
 
     # focused_border_color
+
     @property
     def focused_border_color(self) -> Optional[str]:
         return self._get_attr("focusedBorderColor")
@@ -342,6 +354,7 @@ class FormFieldControl(ConstrainedControl):
         self._set_attr("focusedBorderColor", value)
 
     # content_padding
+
     @property
     def content_padding(self) -> PaddingValue:
         return self.__content_padding
@@ -351,6 +364,7 @@ class FormFieldControl(ConstrainedControl):
         self.__content_padding = value
 
     # dense
+
     @property
     def dense(self) -> Optional[bool]:
         return self._get_attr("dense")
@@ -360,6 +374,7 @@ class FormFieldControl(ConstrainedControl):
         self._set_attr("dense", value)
 
     # filled
+
     @property
     def filled(self) -> Optional[bool]:
         return self._get_attr("filled", data_type=bool)
@@ -369,6 +384,7 @@ class FormFieldControl(ConstrainedControl):
         self._set_attr("filled", value)
 
     # hint_text
+
     @property
     def hint_text(self) -> Optional[str]:
         return self._get_attr("hintText")
@@ -378,6 +394,7 @@ class FormFieldControl(ConstrainedControl):
         self._set_attr("hintText", value)
 
     # hint_style
+
     @property
     def hint_style(self) -> Optional[TextStyle]:
         return self.__hint_style
@@ -387,6 +404,7 @@ class FormFieldControl(ConstrainedControl):
         self.__hint_style = value
 
     # helper_text
+
     @property
     def helper_text(self) -> Optional[str]:
         return self._get_attr("helperText")
@@ -396,6 +414,7 @@ class FormFieldControl(ConstrainedControl):
         self._set_attr("helperText", value)
 
     # helper_style
+
     @property
     def helper_style(self) -> Optional[TextStyle]:
         return self.__helper_style
@@ -405,6 +424,7 @@ class FormFieldControl(ConstrainedControl):
         self.__helper_style = value
 
     # counter_text
+
     @property
     def counter_text(self) -> Optional[str]:
         return self._get_attr("counterText")
@@ -414,6 +434,7 @@ class FormFieldControl(ConstrainedControl):
         self._set_attr("counterText", value)
 
     # counter_style
+
     @property
     def counter_style(self) -> Optional[TextStyle]:
         return self.__counter_style
@@ -423,6 +444,7 @@ class FormFieldControl(ConstrainedControl):
         self.__counter_style = value
 
     # error_text
+
     @property
     def error_text(self) -> Optional[str]:
         return self._get_attr("errorText")
@@ -432,6 +454,7 @@ class FormFieldControl(ConstrainedControl):
         self._set_attr("errorText", value)
 
     # error_style
+
     @property
     def error_style(self) -> Optional[TextStyle]:
         return self.__error_style
@@ -441,6 +464,7 @@ class FormFieldControl(ConstrainedControl):
         self.__error_style = value
 
     # prefix
+
     @property
     def prefix(self) -> Optional[Control]:
         return self.__prefix
@@ -450,6 +474,7 @@ class FormFieldControl(ConstrainedControl):
         self.__prefix = value
 
     # prefix_icon
+
     @property
     def prefix_icon(self) -> Optional[str]:
         return self._get_attr("prefixIcon")
@@ -459,6 +484,7 @@ class FormFieldControl(ConstrainedControl):
         self._set_attr("prefixIcon", value)
 
     # prefix_text
+
     @property
     def prefix_text(self) -> Optional[str]:
         return self._get_attr("prefixText")
@@ -468,6 +494,7 @@ class FormFieldControl(ConstrainedControl):
         self._set_attr("prefixText", value)
 
     # prefix_style
+
     @property
     def prefix_style(self) -> Optional[TextStyle]:
         return self.__prefix_style
@@ -477,6 +504,7 @@ class FormFieldControl(ConstrainedControl):
         self.__prefix_style = value
 
     # suffix
+
     @property
     def suffix(self) -> Optional[Control]:
         return self.__suffix
@@ -486,6 +514,7 @@ class FormFieldControl(ConstrainedControl):
         self.__suffix = value
 
     # suffix_icon
+
     @property
     def suffix_icon(self) -> Optional[str]:
         return self._get_attr("suffixIcon")
@@ -495,6 +524,7 @@ class FormFieldControl(ConstrainedControl):
         self._set_attr("suffixIcon", value)
 
     # suffix_text
+
     @property
     def suffix_text(self) -> Optional[str]:
         return self._get_attr("suffixText")
@@ -504,6 +534,7 @@ class FormFieldControl(ConstrainedControl):
         self._set_attr("suffixText", value)
 
     # suffix_style
+
     @property
     def suffix_style(self) -> Optional[TextStyle]:
         return self.__suffix_style
@@ -513,6 +544,7 @@ class FormFieldControl(ConstrainedControl):
         self.__suffix_style = value
 
     # fill_color
+
     @property
     def fill_color(self) -> Optional[str]:
         return self._get_attr("fillColor")
@@ -522,6 +554,7 @@ class FormFieldControl(ConstrainedControl):
         self._set_attr("fillColor", value)
 
     # hover_color
+
     @property
     def hover_color(self) -> Optional[str]:
         return self._get_attr("hoverColor")

--- a/sdk/python/packages/flet-core/src/flet_core/gesture_detector.py
+++ b/sdk/python/packages/flet-core/src/flet_core/gesture_detector.py
@@ -4,7 +4,7 @@ from typing import Any, Optional, Union
 
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.control_event import ControlEvent
 from flet_core.event_handler import EventHandler
 from flet_core.ref import Ref
@@ -12,6 +12,7 @@ from flet_core.types import (
     AnimationValue,
     MouseCursor,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -312,6 +313,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         self._add_event_handler("exit", self.__on_exit.get_handler())
 
         # on_scroll
+
         self.__on_scroll = EventHandler(lambda e: ScrollEvent(**json.loads(e.data)))
         self._add_event_handler("scroll", self.__on_scroll.get_handler())
 
@@ -362,6 +364,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         return children
 
     # content
+
     @property
     def content(self) -> Optional[Control]:
         return self.__content
@@ -371,6 +374,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         self.__content = value
 
     # mouse_cursor
+
     @property
     def mouse_cursor(self):
         return self.__mouse_cursor
@@ -381,6 +385,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         self._set_enum_attr("mouseCursor", value, MouseCursor)
 
     # drag_interval
+
     @property
     def drag_interval(self) -> Optional[int]:
         return self._get_attr("dragInterval")
@@ -390,6 +395,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         self._set_attr("dragInterval", value)
 
     # hover_interval
+
     @property
     def hover_interval(self) -> Optional[int]:
         return self._get_attr("hoverInterval")
@@ -399,6 +405,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         self._set_attr("hoverInterval", value)
 
     # on_tap
+
     @property
     def on_tap(self):
         return self._get_event_handler("tap")
@@ -409,6 +416,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         self._set_attr("onTap", True if handler is not None else None)
 
     # on_tap_down
+
     @property
     def on_tap_down(self):
         return self.__on_tap_down
@@ -419,6 +427,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         self._set_attr("onTapDown", True if handler is not None else None)
 
     # on_tap_up
+
     @property
     def on_tap_up(self):
         return self.__on_tap_up
@@ -429,6 +438,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         self._set_attr("onTapUp", True if handler is not None else None)
 
     # on_multi_tap
+
     @property
     def on_multi_tap(self):
         return self.__on_multi_tap
@@ -439,6 +449,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         self._set_attr("onMultiTap", True if handler is not None else None)
 
     # multi_tap_touches
+
     @property
     def multi_tap_touches(self) -> Optional[int]:
         return self._get_attr("multiTapTouches")
@@ -448,6 +459,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         self._set_attr("multiTapTouches", value)
 
     # on_multi_long_press
+
     @property
     def on_multi_long_press(self):
         return self._get_event_handler("multi_long_press")
@@ -458,6 +470,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         self._set_attr("onMultiLongPress", True if handler is not None else None)
 
     # on_secondary_tap
+
     @property
     def on_secondary_tap(self):
         return self._get_event_handler("secondary_tap")
@@ -468,6 +481,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         self._set_attr("onSecondaryTap", True if handler is not None else None)
 
     # on_tap_down
+
     @property
     def on_secondary_tap_down(self):
         return self.__on_secondary_tap_down
@@ -478,6 +492,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         self._set_attr("onSecondaryTapDown", True if handler is not None else None)
 
     # on_secondary_tap_up
+
     @property
     def on_secondary_tap_up(self):
         return self.__on_secondary_tap_up
@@ -488,6 +503,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         self._set_attr("onSecondaryTapUp", True if handler is not None else None)
 
     # on_long_press_start
+
     @property
     def on_long_press_start(self):
         return self.__on_long_press_start
@@ -498,6 +514,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         self._set_attr("onLongPressStart", True if handler is not None else None)
 
     # on_long_press_end
+
     @property
     def on_long_press_end(self):
         return self.__on_long_press_end
@@ -508,6 +525,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         self._set_attr("onLongPressEnd", True if handler is not None else None)
 
     # on_secondary_long_press_start
+
     @property
     def on_secondary_long_press_start(self):
         return self.__on_secondary_long_press_start
@@ -520,6 +538,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         )
 
     # on_secondary_long_press_end
+
     @property
     def on_secondary_long_press_end(self):
         return self.__on_secondary_long_press_end
@@ -530,6 +549,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         self._set_attr("onSecondaryLongPressEnd", True if handler is not None else None)
 
     # on_double_tap
+
     @property
     def on_double_tap(self):
         return self._get_event_handler("double_tap")
@@ -540,6 +560,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         self._set_attr("onDoubleTap", True if handler is not None else None)
 
     # on_double_tap_down
+
     @property
     def on_double_tap_down(self):
         return self.__on_double_tap_down
@@ -550,6 +571,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         self._set_attr("onDoubleTapDown", True if handler is not None else None)
 
     # on_horizontal_drag_start
+
     @property
     def on_horizontal_drag_start(self):
         return self.__on_horizontal_drag_start
@@ -560,6 +582,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         self._set_attr("onHorizontalDragStart", True if handler is not None else None)
 
     # on_horizontal_drag_update
+
     @property
     def on_horizontal_drag_update(self):
         return self.__on_horizontal_drag_update
@@ -570,6 +593,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         self._set_attr("onHorizontalDragUpdate", True if handler is not None else None)
 
     # on_horizontal_drag_end
+
     @property
     def on_horizontal_drag_end(self):
         return self.__on_horizontal_drag_end
@@ -580,6 +604,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         self._set_attr("onHorizontalDragEnd", True if handler is not None else None)
 
     # on_vertical_drag_start
+
     @property
     def on_vertical_drag_start(self):
         return self.__on_vertical_drag_start
@@ -590,6 +615,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         self._set_attr("onVerticalDragStart", True if handler is not None else None)
 
     # on_vertical_drag_update
+
     @property
     def on_vertical_drag_update(self):
         return self.__on_vertical_drag_update
@@ -600,6 +626,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         self._set_attr("onVerticalDragUpdate", True if handler is not None else None)
 
     # on_vertical_drag_end
+
     @property
     def on_vertical_drag_end(self):
         return self.__on_vertical_drag_end
@@ -610,6 +637,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         self._set_attr("onVerticalDragEnd", True if handler is not None else None)
 
     # on_pan_start
+
     @property
     def on_pan_start(self):
         return self.__on_pan_start
@@ -620,6 +648,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         self._set_attr("onPanStart", True if handler is not None else None)
 
     # on_pan_updatevertical_drag
+
     @property
     def on_pan_update(self):
         return self.__on_pan_update
@@ -630,6 +659,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         self._set_attr("onPanUpdate", True if handler is not None else None)
 
     # on_pan_end
+
     @property
     def on_pan_end(self):
         return self.__on_pan_end
@@ -640,6 +670,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         self._set_attr("onPanEnd", True if handler is not None else None)
 
     # on_scale_start
+
     @property
     def on_scale_start(self):
         return self.__on_scale_start
@@ -650,6 +681,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         self._set_attr("onScaleStart", True if handler is not None else None)
 
     # on_scale_update
+
     @property
     def on_scale_update(self):
         return self.__on_scale_update
@@ -660,6 +692,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         self._set_attr("onScaleUpdate", True if handler is not None else None)
 
     # on_scale_end
+
     @property
     def on_scale_end(self):
         return self.__on_scale_end
@@ -670,6 +703,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         self._set_attr("onScaleEnd", True if handler is not None else None)
 
     # on_hover
+
     @property
     def on_hover(self):
         return self.__on_hover
@@ -680,6 +714,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         self._set_attr("onHover", True if handler is not None else None)
 
     # on_enter
+
     @property
     def on_enter(self):
         return self.__on_enter
@@ -690,6 +725,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         self._set_attr("onEnter", True if handler is not None else None)
 
     # on_exit
+
     @property
     def on_exit(self):
         return self.__on_exit
@@ -700,6 +736,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         self._set_attr("onExit", True if handler is not None else None)
 
     # on_scroll
+
     @property
     def on_scroll(self):
         return self.__on_scroll

--- a/sdk/python/packages/flet-core/src/flet_core/grid_view.py
+++ b/sdk/python/packages/flet-core/src/flet_core/grid_view.py
@@ -2,17 +2,18 @@ from typing import Any, List, Optional, Union
 
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.scrollable_control import ScrollableControl
 from flet_core.types import (
     AnimationValue,
+    ClipBehavior,
     OffsetValue,
+    OptionalNumber,
     PaddingValue,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
-    ClipBehavior,
 )
 from flet_core.utils import deprecated
 
@@ -194,6 +195,7 @@ class GridView(ConstrainedControl, ScrollableControl, AdaptiveControl):
         self.clean()
 
     # horizontal
+
     @property
     def horizontal(self) -> Optional[bool]:
         return self._get_attr("horizontal")
@@ -203,6 +205,7 @@ class GridView(ConstrainedControl, ScrollableControl, AdaptiveControl):
         self._set_attr("horizontal", value)
 
     # cache_extent
+
     @property
     def cache_extent(self) -> OptionalNumber:
         return self._get_attr("cacheExtent")
@@ -212,6 +215,7 @@ class GridView(ConstrainedControl, ScrollableControl, AdaptiveControl):
         self._set_attr("cacheExtent", value)
 
     # runs_count
+
     @property
     def runs_count(self) -> Optional[int]:
         return self._get_attr("runsCount")
@@ -221,6 +225,7 @@ class GridView(ConstrainedControl, ScrollableControl, AdaptiveControl):
         self._set_attr("runsCount", value)
 
     # max_extent
+
     @property
     def max_extent(self) -> OptionalNumber:
         return self._get_attr("maxExtent")
@@ -230,6 +235,7 @@ class GridView(ConstrainedControl, ScrollableControl, AdaptiveControl):
         self._set_attr("maxExtent", value)
 
     # spacing
+
     @property
     def spacing(self) -> OptionalNumber:
         return self._get_attr("spacing")
@@ -239,6 +245,7 @@ class GridView(ConstrainedControl, ScrollableControl, AdaptiveControl):
         self._set_attr("spacing", value)
 
     # run_spacing
+
     @property
     def run_spacing(self) -> OptionalNumber:
         return self._get_attr("runSpacing")
@@ -248,6 +255,7 @@ class GridView(ConstrainedControl, ScrollableControl, AdaptiveControl):
         self._set_attr("runSpacing", value)
 
     # child_aspect_ratio
+
     @property
     def child_aspect_ratio(self) -> OptionalNumber:
         return self._get_attr("childAspectRatio")
@@ -257,6 +265,7 @@ class GridView(ConstrainedControl, ScrollableControl, AdaptiveControl):
         self._set_attr("childAspectRatio", value)
 
     # padding
+
     @property
     def padding(self) -> PaddingValue:
         return self.__padding
@@ -266,6 +275,7 @@ class GridView(ConstrainedControl, ScrollableControl, AdaptiveControl):
         self.__padding = value
 
     # controls
+
     @property
     def controls(self):
         return self.__controls
@@ -275,6 +285,7 @@ class GridView(ConstrainedControl, ScrollableControl, AdaptiveControl):
         self.__controls = value if value is not None else []
 
     # clip_behavior
+
     @property
     def clip_behavior(self) -> Optional[ClipBehavior]:
         return self._get_attr("clipBehavior")
@@ -286,6 +297,7 @@ class GridView(ConstrainedControl, ScrollableControl, AdaptiveControl):
         )
 
     # semantic_child_count
+
     @property
     def semantic_child_count(self) -> Optional[int]:
         return self._get_attr("semanticChildCount", data_type="int")

--- a/sdk/python/packages/flet-core/src/flet_core/icon.py
+++ b/sdk/python/packages/flet-core/src/flet_core/icon.py
@@ -1,11 +1,11 @@
 from typing import Any, Optional, Union
 
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import OptionalNumber
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -108,6 +108,7 @@ class Icon(ConstrainedControl):
         return "icon"
 
     # name
+
     @property
     def name(self):
         return self._get_attr("name")
@@ -117,6 +118,7 @@ class Icon(ConstrainedControl):
         self._set_attr("name", value)
 
     # color
+
     @property
     def color(self):
         return self._get_attr("color")
@@ -126,6 +128,7 @@ class Icon(ConstrainedControl):
         self._set_attr("color", value)
 
     # size
+
     @property
     def size(self) -> OptionalNumber:
         return self._get_attr("size")
@@ -135,6 +138,7 @@ class Icon(ConstrainedControl):
         self._set_attr("size", value)
 
     # semantics_label
+
     @property
     def semantics_label(self):
         return self._get_attr("semanticsLabel")

--- a/sdk/python/packages/flet-core/src/flet_core/icon_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/icon_button.py
@@ -5,13 +5,14 @@ from flet_core.adaptive_control import AdaptiveControl
 from flet_core.alignment import Alignment
 from flet_core.buttons import ButtonStyle
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.theme import ThemeVisualDensity
 from flet_core.types import (
     AnimationValue,
     MouseCursor,
     OffsetValue,
+    OptionalNumber,
     PaddingValue,
     ResponsiveNumber,
     RotateValue,
@@ -211,6 +212,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
         self.focus()
 
     # icon
+
     @property
     def icon(self):
         return self._get_attr("icon")
@@ -220,6 +222,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
         self._set_attr("icon", value)
 
     # selected_icon
+
     @property
     def selected_icon(self):
         return self._get_attr("selectedIcon")
@@ -229,6 +232,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
         self._set_attr("selectedIcon", value)
 
     # icon_size
+
     @property
     def icon_size(self):
         return self._get_attr("iconSize")
@@ -238,6 +242,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
         self._set_attr("iconSize", value)
 
     # splash_radius
+
     @property
     def splash_radius(self):
         return self._get_attr("splashRadius")
@@ -247,6 +252,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
         self._set_attr("splashRadius", value)
 
     # splash_color
+
     @property
     def splash_color(self):
         return self._get_attr("splashColor")
@@ -256,6 +262,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
         self._set_attr("splashColor", value)
 
     # icon_color
+
     @property
     def icon_color(self):
         return self._get_attr("iconColor")
@@ -265,6 +272,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
         self._set_attr("iconColor", value)
 
     # highlight_color
+
     @property
     def highlight_color(self):
         return self._get_attr("highlightColor")
@@ -274,6 +282,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
         self._set_attr("highlightColor", value)
 
     # selected_icon_color
+
     @property
     def selected_icon_color(self):
         return self._get_attr("selectedIconColor")
@@ -283,6 +292,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
         self._set_attr("selectedIconColor", value)
 
     # bgcolor
+
     @property
     def bgcolor(self):
         return self._get_attr("bgcolor")
@@ -292,6 +302,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
         self._set_attr("bgcolor", value)
 
     # hover_color
+
     @property
     def hover_color(self):
         return self._get_attr("hoverColor")
@@ -301,6 +312,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
         self._set_attr("hoverColor", value)
 
     # focus_color
+
     @property
     def focus_color(self):
         return self._get_attr("focusColor")
@@ -310,6 +322,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
         self._set_attr("focusColor", value)
 
     # disabled_color
+
     @property
     def disabled_color(self):
         return self._get_attr("disabledColor")
@@ -319,6 +332,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
         self._set_attr("disabledColor", value)
 
     # padding
+
     @property
     def padding(self) -> PaddingValue:
         return self.__padding
@@ -328,6 +342,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
         self.__padding = value
 
     # selected
+
     @property
     def selected(self) -> Optional[bool]:
         return self._get_attr("selected", data_type="bool", def_value=False)
@@ -337,6 +352,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
         self._set_attr("selected", value)
 
     # enable_feedback
+
     @property
     def enable_feedback(self) -> Optional[bool]:
         return self._get_attr("enableFeedback", data_type="bool", def_value=True)
@@ -346,6 +362,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
         self._set_attr("enableFeedback", value)
 
     # style
+
     @property
     def style(self) -> Optional[ButtonStyle]:
         return self.__style
@@ -355,6 +372,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
         self.__style = value
 
     # url
+
     @property
     def url(self):
         return self._get_attr("url")
@@ -364,6 +382,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
         self._set_attr("url", value)
 
     # url_target
+
     @property
     def url_target(self) -> Optional[UrlTarget]:
         return self.__url_target
@@ -376,6 +395,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
         )
 
     # mouse_cursor
+
     @property
     def mouse_cursor(self) -> Optional[MouseCursor]:
         return self.__mouse_cursor
@@ -388,6 +408,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
         )
 
     # visual_density
+
     @property
     def visual_density(self) -> Optional[ThemeVisualDensity]:
         return self.__visual_density
@@ -401,6 +422,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
         )
 
     # on_click
+
     @property
     def on_click(self):
         return self._get_event_handler("click")
@@ -410,6 +432,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
         self._add_event_handler("click", handler)
 
     # content
+
     @property
     def content(self) -> Optional[Control]:
         return self.__content
@@ -419,6 +442,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
         self.__content = value
 
     # autofocus
+
     @property
     def autofocus(self) -> Optional[bool]:
         return self._get_attr("autofocus", data_type="bool", def_value=False)
@@ -428,6 +452,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
         self._set_attr("autofocus", value)
 
     # on_focus
+
     @property
     def on_focus(self):
         return self._get_event_handler("focus")
@@ -437,6 +462,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
         self._add_event_handler("focus", handler)
 
     # on_blur
+
     @property
     def on_blur(self):
         return self._get_event_handler("blur")
@@ -446,6 +472,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
         self._add_event_handler("blur", handler)
 
     # alignment
+
     @property
     def alignment(self) -> Optional[Alignment]:
         return self.__alignment

--- a/sdk/python/packages/flet-core/src/flet_core/image.py
+++ b/sdk/python/packages/flet-core/src/flet_core/image.py
@@ -1,7 +1,7 @@
 from typing import Any, Optional, Union
 
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
@@ -10,6 +10,7 @@ from flet_core.types import (
     ImageFit,
     ImageRepeat,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -154,6 +155,7 @@ class Image(ConstrainedControl):
         self._set_attr_json("borderRadius", self.__border_radius)
 
     # src
+
     @property
     def src(self):
         return self._get_attr("src")
@@ -163,6 +165,7 @@ class Image(ConstrainedControl):
         self._set_attr("src", value)
 
     # src_base64
+
     @property
     def src_base64(self):
         return self._get_attr("srcBase64")
@@ -172,6 +175,7 @@ class Image(ConstrainedControl):
         self._set_attr("srcBase64", value)
 
     # fit
+
     @property
     def fit(self) -> Optional[ImageFit]:
         return self.__fit
@@ -182,6 +186,7 @@ class Image(ConstrainedControl):
         self._set_attr("fit", value.value if isinstance(value, ImageFit) else value)
 
     # filter_quality
+
     @property
     def filter_quality(self) -> Optional[FilterQuality]:
         return self.__filter_quality
@@ -194,6 +199,7 @@ class Image(ConstrainedControl):
         )
 
     # repeat
+
     @property
     def repeat(self) -> Optional[ImageRepeat]:
         return self.__repeat
@@ -206,6 +212,7 @@ class Image(ConstrainedControl):
         )
 
     # border_radius
+
     @property
     def border_radius(self) -> BorderRadiusValue:
         return self.__border_radius
@@ -215,6 +222,7 @@ class Image(ConstrainedControl):
         self.__border_radius = value
 
     # color
+
     @property
     def color(self):
         return self._get_attr("color")
@@ -224,6 +232,7 @@ class Image(ConstrainedControl):
         self._set_attr("color", value)
 
     # color_blend_mode
+
     @property
     def color_blend_mode(self) -> Optional[BlendMode]:
         return self.__blend_mode
@@ -236,6 +245,7 @@ class Image(ConstrainedControl):
         )
 
     # gapless_playback
+
     @property
     def gapless_playback(self) -> Optional[bool]:
         return self._get_attr("gaplessPlayback", data_type="bool", def_value=False)
@@ -245,6 +255,7 @@ class Image(ConstrainedControl):
         self._set_attr("gaplessPlayback", value)
 
     # exclude_from_semantics
+
     @property
     def exclude_from_semantics(self) -> Optional[bool]:
         return self._get_attr("excludeFromSemantics", data_type="bool", def_value=False)
@@ -254,6 +265,7 @@ class Image(ConstrainedControl):
         self._set_attr("excludeFromSemantics", value)
 
     # semantics_label
+
     @property
     def semantics_label(self):
         return self._get_attr("semanticsLabel")
@@ -263,6 +275,7 @@ class Image(ConstrainedControl):
         self._set_attr("semanticsLabel", value)
 
     # error_content
+
     @property
     def error_content(self) -> Optional[Control]:
         return self.__error_content

--- a/sdk/python/packages/flet-core/src/flet_core/list_tile.py
+++ b/sdk/python/packages/flet-core/src/flet_core/list_tile.py
@@ -4,7 +4,7 @@ from typing import Any, Optional, Union
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.buttons import OutlinedBorder
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.text_style import TextStyle
 from flet_core.theme import ThemeVisualDensity
@@ -12,6 +12,7 @@ from flet_core.types import (
     AnimationValue,
     MouseCursor,
     OffsetValue,
+    OptionalNumber,
     PaddingValue,
     ResponsiveNumber,
     RotateValue,
@@ -242,6 +243,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
         return children
 
     # content_padding
+
     @property
     def content_padding(self) -> PaddingValue:
         return self.__content_padding
@@ -251,6 +253,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
         self.__content_padding = value
 
     # bgcolor
+
     @property
     def bgcolor(self) -> Optional[str]:
         return self._get_attr("bgcolor")
@@ -260,6 +263,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
         self._set_attr("bgcolor", value)
 
     # selected_color
+
     @property
     def selected_color(self) -> Optional[str]:
         return self._get_attr("selectedColor")
@@ -269,6 +273,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
         self._set_attr("selectedColor", value)
 
     # selected_tile_color
+
     @property
     def selected_tile_color(self) -> Optional[str]:
         return self._get_attr("selectedTileColor")
@@ -278,6 +283,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
         self._set_attr("selectedTileColor", value)
 
     # bgcolor_activated
+
     @property
     def bgcolor_activated(self) -> Optional[str]:
         return self._get_attr("bgcolorActivated")
@@ -287,6 +293,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
         self._set_attr("bgcolorActivated", value)
 
     # min_leading_width
+
     @property
     def min_leading_width(self) -> OptionalNumber:
         return self._get_attr("minLeadingWidth", data_type="float", def_value=40)
@@ -296,6 +303,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
         self._set_attr("minLeadingWidth", value)
 
     # horizontal_spacing
+
     @property
     def horizontal_spacing(self) -> OptionalNumber:
         return self._get_attr("horizontalSpacing", data_type="float", def_value=16)
@@ -305,6 +313,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
         self._set_attr("horizontalSpacing", value)
 
     # hover_color
+
     @property
     def hover_color(self) -> Optional[str]:
         return self._get_attr("hoverColor")
@@ -314,6 +323,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
         self._set_attr("hoverColor", value)
 
     # leading
+
     @property
     def leading(self) -> Optional[Control]:
         return self.__leading
@@ -323,6 +333,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
         self.__leading = value
 
     # title
+
     @property
     def title(self) -> Optional[Control]:
         return self.__title
@@ -332,6 +343,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
         self.__title = value
 
     # min_vertical_padding
+
     @property
     def min_vertical_padding(self) -> OptionalNumber:
         return self._get_attr("minVerticalPadding", data_type="float", def_value=4.0)
@@ -341,6 +353,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
         self._set_attr("minVerticalPadding", value)
 
     # subtitle
+
     @property
     def subtitle(self) -> Optional[Control]:
         return self.__subtitle
@@ -350,6 +363,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
         self.__subtitle = value
 
     # trailing
+
     @property
     def trailing(self) -> Optional[Control]:
         return self.__trailing
@@ -359,6 +373,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
         self.__trailing = value
 
     # is_three_line
+
     @property
     def is_three_line(self) -> Optional[bool]:
         return self._get_attr("isThreeLine", data_type="bool", def_value=False)
@@ -368,6 +383,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
         self._set_attr("isThreeLine", value)
 
     # enable_feedback
+
     @property
     def enable_feedback(self) -> Optional[bool]:
         return self._get_attr("enableFeedback", data_type="bool", def_value=True)
@@ -377,6 +393,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
         self._set_attr("enableFeedback", value)
 
     # style
+
     @property
     def style(self) -> Optional[ListTileStyle]:
         return self.__style
@@ -389,6 +406,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
         )
 
     # title_alignment
+
     @property
     def title_alignment(self) -> Optional[ListTileTitleAlignment]:
         return self.__title_alignment
@@ -399,6 +417,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
         self._set_enum_attr("titleAlignment", value, ListTileTitleAlignment)
 
     # selected
+
     @property
     def selected(self) -> Optional[bool]:
         return self._get_attr("selected", data_type="bool", def_value=False)
@@ -408,6 +427,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
         self._set_attr("selected", value)
 
     # dense
+
     @property
     def dense(self) -> Optional[bool]:
         return self._get_attr("dense", data_type="bool", def_value=False)
@@ -417,6 +437,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
         self._set_attr("dense", value)
 
     # autofocus
+
     @property
     def autofocus(self) -> Optional[bool]:
         return self._get_attr("autofocus", data_type="bool", def_value=False)
@@ -426,6 +447,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
         self._set_attr("autofocus", value)
 
     # toggle_inputs
+
     @property
     def toggle_inputs(self) -> Optional[bool]:
         return self._get_attr("toggleInputs", data_type="bool", def_value=False)
@@ -435,6 +457,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
         self._set_attr("toggleInputs", value)
 
     # url
+
     @property
     def url(self) -> Optional[str]:
         return self._get_attr("url")
@@ -444,6 +467,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
         self._set_attr("url", value)
 
     # icon_color
+
     @property
     def icon_color(self) -> Optional[str]:
         return self._get_attr("iconColor")
@@ -453,6 +477,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
         self._set_attr("iconColor", value)
 
     # text_color
+
     @property
     def text_color(self) -> Optional[str]:
         return self._get_attr("textColor")
@@ -462,6 +487,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
         self._set_attr("textColor", value)
 
     # url_target
+
     @property
     def url_target(self) -> Optional[UrlTarget]:
         return self.__url_target
@@ -474,6 +500,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
         )
 
     # mouse_cursor
+
     @property
     def mouse_cursor(self) -> Optional[MouseCursor]:
         return self.__mouse_cursor
@@ -486,6 +513,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
         )
 
     # visual_density
+
     @property
     def visual_density(self) -> Optional[ThemeVisualDensity]:
         return self.__visual_density
@@ -499,6 +527,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
         )
 
     # shape
+
     @property
     def shape(self) -> Optional[OutlinedBorder]:
         return self.__shape
@@ -508,6 +537,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
         self.__shape = value
 
     # title_text_style
+
     @property
     def title_text_style(self) -> Optional[TextStyle]:
         return self.__title_text_style
@@ -517,6 +547,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
         self.__title_text_style = value
 
     # subtitle_text_style
+
     @property
     def subtitle_text_style(self) -> Optional[TextStyle]:
         return self.__subtitle_text_style
@@ -526,6 +557,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
         self.__subtitle_text_style = value
 
     # leading_and_trailing_text_style
+
     @property
     def leading_and_trailing_text_style(self) -> Optional[TextStyle]:
         return self.__leading_and_trailing_text_style
@@ -535,6 +567,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
         self.__leading_and_trailing_text_style = value
 
     # on_click
+
     @property
     def on_click(self):
         return self._get_event_handler("click")
@@ -545,6 +578,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
         self._set_attr("onclick", True if handler is not None else None)
 
     # on_long_press
+
     @property
     def on_long_press(self):
         return self._get_event_handler("long_press")
@@ -555,6 +589,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
         self._set_attr("onLongPress", True if handler is not None else None)
 
     # on_focus
+
     @property
     def on_focus(self):
         return self._get_event_handler("focus")
@@ -564,6 +599,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
         self._add_event_handler("focus", handler)
 
     # on_blur
+
     @property
     def on_blur(self):
         return self._get_event_handler("blur")

--- a/sdk/python/packages/flet-core/src/flet_core/list_view.py
+++ b/sdk/python/packages/flet-core/src/flet_core/list_view.py
@@ -2,17 +2,18 @@ from typing import Any, List, Optional, Union
 
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.scrollable_control import ScrollableControl
 from flet_core.types import (
     AnimationValue,
+    ClipBehavior,
     OffsetValue,
+    OptionalNumber,
     PaddingValue,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
-    ClipBehavior,
 )
 from flet_core.utils import deprecated
 
@@ -184,6 +185,7 @@ class ListView(ConstrainedControl, ScrollableControl, AdaptiveControl):
         self.clean()
 
     # horizontal
+
     @property
     def horizontal(self) -> Optional[bool]:
         return self._get_attr("horizontal")
@@ -193,6 +195,7 @@ class ListView(ConstrainedControl, ScrollableControl, AdaptiveControl):
         self._set_attr("horizontal", value)
 
     # spacing
+
     @property
     def spacing(self) -> OptionalNumber:
         return self._get_attr("spacing")
@@ -202,6 +205,7 @@ class ListView(ConstrainedControl, ScrollableControl, AdaptiveControl):
         self._set_attr("spacing", value)
 
     # divider_thickness
+
     @property
     def divider_thickness(self) -> OptionalNumber:
         return self._get_attr("dividerThickness")
@@ -211,6 +215,7 @@ class ListView(ConstrainedControl, ScrollableControl, AdaptiveControl):
         self._set_attr("dividerThickness", value)
 
     # item_extent
+
     @property
     def item_extent(self) -> OptionalNumber:
         return self._get_attr("itemExtent")
@@ -220,6 +225,7 @@ class ListView(ConstrainedControl, ScrollableControl, AdaptiveControl):
         self._set_attr("itemExtent", value)
 
     # cache_extent
+
     @property
     def cache_extent(self) -> OptionalNumber:
         return self._get_attr("cacheExtent")
@@ -229,6 +235,7 @@ class ListView(ConstrainedControl, ScrollableControl, AdaptiveControl):
         self._set_attr("cacheExtent", value)
 
     # first_item_prototype
+
     @property
     def first_item_prototype(self) -> Optional[bool]:
         return self._get_attr("firstItemPrototype")
@@ -238,6 +245,7 @@ class ListView(ConstrainedControl, ScrollableControl, AdaptiveControl):
         self._set_attr("firstItemPrototype", value)
 
     # padding
+
     @property
     def padding(self) -> PaddingValue:
         return self.__padding
@@ -247,6 +255,7 @@ class ListView(ConstrainedControl, ScrollableControl, AdaptiveControl):
         self.__padding = value
 
     # controls
+
     @property
     def controls(self):
         return self.__controls
@@ -256,6 +265,7 @@ class ListView(ConstrainedControl, ScrollableControl, AdaptiveControl):
         self.__controls = value if value is not None else []
 
     # clip_behavior
+
     @property
     def clip_behavior(self) -> Optional[ClipBehavior]:
         return self._get_attr("clipBehavior")
@@ -267,6 +277,7 @@ class ListView(ConstrainedControl, ScrollableControl, AdaptiveControl):
         )
 
     # semantic_child_count
+
     @property
     def semantic_child_count(self) -> Optional[int]:
         return self._get_attr("semanticChildCount", data_type="int")

--- a/sdk/python/packages/flet-core/src/flet_core/lottie.py
+++ b/sdk/python/packages/flet-core/src/flet_core/lottie.py
@@ -1,15 +1,15 @@
 from typing import Any, Optional, Union
 
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import OptionalNumber
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
+    ImageFit,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
-    ImageFit,
 )
 from flet_core.video import FilterQuality
 
@@ -112,6 +112,7 @@ class Lottie(ConstrainedControl):
         return "lottie"
 
     # src
+
     @property
     def src(self):
         return self._get_attr("src")
@@ -121,6 +122,7 @@ class Lottie(ConstrainedControl):
         self._set_attr("src", value)
 
     # src_base64
+
     @property
     def src_base64(self):
         return self._get_attr("srcBase64")
@@ -130,6 +132,7 @@ class Lottie(ConstrainedControl):
         self._set_attr("srcBase64", value)
 
     # repeat
+
     @property
     def repeat(self):
         return self._get_attr("repeat", def_value=True, data_type="bool")
@@ -139,6 +142,7 @@ class Lottie(ConstrainedControl):
         self._set_attr("repeat", value)
 
     # animate
+
     @property
     def animate(self):
         return self._get_attr("animate", def_value=True, data_type="bool")
@@ -148,6 +152,7 @@ class Lottie(ConstrainedControl):
         self._set_attr("animate", value)
 
     # reverse
+
     @property
     def reverse(self):
         return self._get_attr("reverse", def_value=False, data_type="bool")
@@ -157,6 +162,7 @@ class Lottie(ConstrainedControl):
         self._set_attr("reverse", value)
 
     # filter_quality
+
     @property
     def filter_quality(self) -> Optional[FilterQuality]:
         return self.__filter_quality
@@ -169,6 +175,7 @@ class Lottie(ConstrainedControl):
         )
 
     # fit
+
     @property
     def fit(self) -> Optional[ImageFit]:
         return self.__fit
@@ -179,6 +186,7 @@ class Lottie(ConstrainedControl):
         self._set_attr("fit", value.value if isinstance(value, ImageFit) else value)
 
     # background_loading
+
     @property
     def background_loading(self):
         return self._get_attr("backgroundLoading", data_type="bool")
@@ -188,6 +196,7 @@ class Lottie(ConstrainedControl):
         self._set_attr("backgroundLoading", value)
 
     # on_error
+
     @property
     def on_error(self):
         return self._get_event_handler("error")

--- a/sdk/python/packages/flet-core/src/flet_core/markdown.py
+++ b/sdk/python/packages/flet-core/src/flet_core/markdown.py
@@ -1,13 +1,13 @@
 from enum import Enum
-from typing import Any, Optional, Union, cast
+from typing import Any, cast, Optional, Union
 
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import OptionalNumber
 from flet_core.ref import Ref
 from flet_core.text_style import TextStyle
 from flet_core.types import (
     AnimationValue,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -124,6 +124,7 @@ class Markdown(ConstrainedControl):
         self._set_attr_json("codeStyle", self.__code_style)
 
     # value
+
     @property
     def value(self) -> Optional[str]:
         return self._get_attr("value")
@@ -133,6 +134,7 @@ class Markdown(ConstrainedControl):
         self._set_attr("value", value)
 
     # selectable
+
     @property
     def selectable(self) -> Optional[bool]:
         return self._get_attr("selectable", data_type="bool", def_value=False)
@@ -142,6 +144,7 @@ class Markdown(ConstrainedControl):
         self._set_attr("selectable", value)
 
     # extension_set
+
     @property
     def extension_set(self) -> Optional[MarkdownExtensionSet]:
         return self.__extension_set
@@ -152,6 +155,7 @@ class Markdown(ConstrainedControl):
         self._set_enum_attr("extensionSet", value, MarkdownExtensionSet)
 
     # code_theme
+
     @property
     def code_theme(self):
         return self._get_attr("codeTheme")
@@ -161,6 +165,7 @@ class Markdown(ConstrainedControl):
         self._set_attr("codeTheme", value)
 
     # code_style
+
     @property
     def code_style(self):
         return self.__code_style
@@ -170,6 +175,7 @@ class Markdown(ConstrainedControl):
         self.__code_style = value
 
     # auto_follow_links
+
     @property
     def auto_follow_links(self) -> Optional[bool]:
         return cast(
@@ -182,6 +188,7 @@ class Markdown(ConstrainedControl):
         self._set_attr("autoFollowLinks", value)
 
     # auto_follow_links_target
+
     @property
     def auto_follow_links_target(self) -> Optional[str]:
         return self._get_attr("autoFollowLinksTarget")
@@ -191,6 +198,7 @@ class Markdown(ConstrainedControl):
         self._set_attr("autoFollowLinksTarget", value)
 
     # on_tap_link
+
     @property
     def on_tap_link(self):
         return self._get_event_handler("tap_link")

--- a/sdk/python/packages/flet-core/src/flet_core/matplotlib_chart.py
+++ b/sdk/python/packages/flet-core/src/flet_core/matplotlib_chart.py
@@ -5,16 +5,16 @@ from typing import Any, Optional, Union
 
 from flet_core import alignment
 from flet_core.container import Container
-from flet_core.control import OptionalNumber
 from flet_core.image import Image
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
+    ImageFit,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
-    ImageFit,
 )
 
 try:
@@ -150,6 +150,7 @@ class MatplotlibChart(Container):
             self.__img.src = svg
 
     # original_size
+
     @property
     def original_size(self):
         return self.__original_size
@@ -159,6 +160,7 @@ class MatplotlibChart(Container):
         self.__original_size = value
 
     # isolated
+
     @property
     def isolated(self):
         return self.__isolated
@@ -168,6 +170,7 @@ class MatplotlibChart(Container):
         self.__isolated = value
 
     # figure
+
     @property
     def figure(self):
         return self.__figure
@@ -177,6 +180,7 @@ class MatplotlibChart(Container):
         self.__figure = value
 
     # transparent
+
     @property
     def transparent(self) -> bool:
         return self.__transparent

--- a/sdk/python/packages/flet-core/src/flet_core/menu_bar.py
+++ b/sdk/python/packages/flet-core/src/flet_core/menu_bar.py
@@ -5,12 +5,13 @@ from typing import Any, Dict, List, Optional, Union
 from flet_core.alignment import Alignment
 from flet_core.border import BorderSide
 from flet_core.buttons import OutlinedBorder
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.types import (
     ClipBehavior,
     MaterialState,
     MouseCursor,
+    OptionalNumber,
     PaddingValue,
     ResponsiveNumber,
 )
@@ -111,6 +112,7 @@ class MenuBar(Control):
         return self.__controls
 
     # controls
+
     @property
     def controls(self):
         return self.__controls
@@ -120,6 +122,7 @@ class MenuBar(Control):
         self.__controls = value if value is not None else []
 
     # clip_behavior
+
     @property
     def clip_behavior(self) -> Optional[ClipBehavior]:
         return self.__clip_behavior
@@ -132,6 +135,7 @@ class MenuBar(Control):
         )
 
     # style
+
     @property
     def style(self) -> Optional[MenuStyle]:
         return self.__style

--- a/sdk/python/packages/flet-core/src/flet_core/menu_item_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/menu_item_button.py
@@ -3,12 +3,13 @@ from typing import Any, Optional, Union
 
 from flet_core.buttons import ButtonStyle
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     ClipBehavior,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -149,6 +150,7 @@ class MenuItemButton(ConstrainedControl):
         self.focus()
 
     # focus_on_hover
+
     @property
     def focus_on_hover(self) -> Optional[bool]:
         return self._get_attr("focusOnHover", data_type="bool", def_value=True)
@@ -158,6 +160,7 @@ class MenuItemButton(ConstrainedControl):
         self._set_attr("focusOnHover", value)
 
     # close_on_click
+
     @property
     def close_on_click(self) -> Optional[bool]:
         return self._get_attr("closeOnClick", data_type="bool", def_value=True)
@@ -167,6 +170,7 @@ class MenuItemButton(ConstrainedControl):
         self._set_attr("closeOnClick", value)
 
     # leading
+
     @property
     def leading(self) -> Optional[Control]:
         return self.__leading
@@ -176,6 +180,7 @@ class MenuItemButton(ConstrainedControl):
         self.__leading = value
 
     # trailing
+
     @property
     def trailing(self) -> Optional[Control]:
         return self.__trailing
@@ -185,6 +190,7 @@ class MenuItemButton(ConstrainedControl):
         self.__trailing = value
 
     # content
+
     @property
     def content(self) -> Optional[Control]:
         return self.__content
@@ -194,6 +200,7 @@ class MenuItemButton(ConstrainedControl):
         self.__content = value
 
     # style
+
     @property
     def style(self) -> Optional[ButtonStyle]:
         return self.__style
@@ -203,6 +210,7 @@ class MenuItemButton(ConstrainedControl):
         self.__style = value
 
     # clip_behavior
+
     @property
     def clip_behavior(self) -> Optional[ClipBehavior]:
         return self.__clip_behavior
@@ -215,6 +223,7 @@ class MenuItemButton(ConstrainedControl):
         )
 
     # on_click
+
     @property
     def on_click(self):
         return self._get_event_handler("click")
@@ -225,6 +234,7 @@ class MenuItemButton(ConstrainedControl):
         self._set_attr("onClick", True if handler is not None else None)
 
     # on_hover
+
     @property
     def on_hover(self):
         return self._get_event_handler("hover")
@@ -235,6 +245,7 @@ class MenuItemButton(ConstrainedControl):
         self._set_attr("onHover", True if handler is not None else None)
 
     # on_focus
+
     @property
     def on_focus(self):
         return self._get_event_handler("focus")
@@ -244,6 +255,7 @@ class MenuItemButton(ConstrainedControl):
         self._add_event_handler("focus", handler)
 
     # on_blur
+
     @property
     def on_blur(self):
         return self._get_event_handler("blur")

--- a/sdk/python/packages/flet-core/src/flet_core/navigation_bar.py
+++ b/sdk/python/packages/flet-core/src/flet_core/navigation_bar.py
@@ -9,7 +9,9 @@ from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
+    ColorStr,
     ControlEventFunction,
+    IconStr,
     MaterialState,
     OffsetValue,
     OptionalNumber,
@@ -35,18 +37,18 @@ class NavigationBarDestination(Control):
     def __init__(
         self,
         label: Optional[str] = None,
-        icon: Optional[str] = None,
+        icon: IconStr = None,
         icon_content: Optional[Control] = None,
-        selected_icon: Optional[str] = None,
+        selected_icon: IconStr = None,
         selected_icon_content: Optional[Control] = None,
-        bgcolor: Optional[str] = None,
+        bgcolor: ColorStr = None,
         #
         # Control
         #
         ref: Optional[Ref] = None,
         tooltip: Optional[str] = None,
         disabled: Optional[bool] = None,
-        data: Any = None
+        data: Any = None,
     ) -> None:
         Control.__init__(self, ref=ref, tooltip=tooltip, disabled=disabled, data=data)
         self.label = label
@@ -75,11 +77,11 @@ class NavigationBarDestination(Control):
 
     # icon
     @property
-    def icon(self) -> Optional[str]:
+    def icon(self) -> IconStr:
         return self._get_attr("icon")
 
     @icon.setter
-    def icon(self, value: Optional[str]):
+    def icon(self, value: IconStr):
         self._set_attr("icon", value)
 
     # icon_content
@@ -93,11 +95,11 @@ class NavigationBarDestination(Control):
 
     # selected_icon
     @property
-    def selected_icon(self) -> Optional[str]:
+    def selected_icon(self) -> IconStr:
         return self._get_attr("selectedIcon")
 
     @selected_icon.setter
-    def selected_icon(self, value: Optional[str]):
+    def selected_icon(self, value: IconStr):
         self._set_attr("selectedIcon", value)
 
     # selected_icon_content
@@ -110,7 +112,6 @@ class NavigationBarDestination(Control):
         self.__selected_icon_content = value
 
     # label
-
     @property
     def label(self) -> Optional[str]:
         return self._get_attr("label")
@@ -120,13 +121,12 @@ class NavigationBarDestination(Control):
         self._set_attr("label", value)
 
     # bgcolor
-
     @property
-    def bgcolor(self) -> Optional[str]:
+    def bgcolor(self) -> ColorStr:
         return self._get_attr("bgcolor")
 
     @bgcolor.setter
-    def bgcolor(self, value: Optional[str]):
+    def bgcolor(self, value: ColorStr):
         self._set_attr("bgcolor", value)
 
 
@@ -171,16 +171,16 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
         self,
         destinations: Optional[List[NavigationBarDestination]] = None,
         selected_index: Optional[int] = None,
-        bgcolor: Optional[str] = None,
+        bgcolor: ColorStr = None,
         label_behavior: Optional[NavigationBarLabelBehavior] = None,
         elevation: OptionalNumber = None,
-        shadow_color: Optional[str] = None,
-        indicator_color: Optional[str] = None,
+        shadow_color: ColorStr = None,
+        indicator_color: ColorStr = None,
         indicator_shape: Optional[OutlinedBorder] = None,
-        surface_tint_color: Optional[str] = None,
+        surface_tint_color: ColorStr = None,
         border: Optional[Border] = None,
         animation_duration: Optional[int] = None,
-        overlay_color: Union[None, str, Dict[MaterialState, str]] = None,
+        overlay_color: Optional[Union[ColorStr, Dict[MaterialState, ColorStr]]] = None,
         on_change: Optional[ControlEventFunction] = None,
         #
         # ConstrainedControl and AdaptiveControl
@@ -210,7 +210,7 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
         visible: Optional[bool] = None,
         disabled: Optional[bool] = None,
         data: Any = None,
-        adaptive: Optional[bool] = None
+        adaptive: Optional[bool] = None,
     ) -> None:
         ConstrainedControl.__init__(
             self,
@@ -301,20 +301,20 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
 
     # overlay_color
     @property
-    def overlay_color(self) -> Optional[Union[str, Dict[MaterialState, str]]]:
+    def overlay_color(self) -> Optional[Union[ColorStr, Dict[MaterialState, ColorStr]]]:
         return self.__overlay_color
 
     @overlay_color.setter
-    def overlay_color(self, value: Optional[Union[str, Dict[MaterialState, str]]]):
+    def overlay_color(self, value: Optional[Union[ColorStr, Dict[MaterialState, ColorStr]]]):
         self.__overlay_color = value
 
     # bgcolor
     @property
-    def bgcolor(self) -> Optional[str]:
+    def bgcolor(self) -> ColorStr:
         return self._get_attr("bgcolor")
 
     @bgcolor.setter
-    def bgcolor(self, value: Optional[str]):
+    def bgcolor(self, value: ColorStr):
         self._set_attr("bgcolor", value)
 
     # elevation
@@ -328,20 +328,20 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
 
     # shadow_color
     @property
-    def shadow_color(self) -> Optional[str]:
+    def shadow_color(self) -> ColorStr:
         return self._get_attr("shadowColor")
 
     @shadow_color.setter
-    def shadow_color(self, value: Optional[str]):
+    def shadow_color(self, value: ColorStr):
         self._set_attr("shadowColor", value)
 
     # indicator_color
     @property
-    def indicator_color(self) -> Optional[str]:
+    def indicator_color(self) -> ColorStr:
         return self._get_attr("indicatorColor")
 
     @indicator_color.setter
-    def indicator_color(self, value: Optional[str]):
+    def indicator_color(self, value: ColorStr):
         self._set_attr("indicatorColor", value)
 
     # indicator_shape
@@ -355,11 +355,11 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
 
     # surface_tint_color
     @property
-    def surface_tint_color(self) -> Optional[str]:
+    def surface_tint_color(self) -> ColorStr:
         return self._get_attr("surfaceTintColor")
 
     @surface_tint_color.setter
-    def surface_tint_color(self, value: Optional[str]):
+    def surface_tint_color(self, value: ColorStr):
         self._set_attr("surfaceTintColor", value)
 
     # border

--- a/sdk/python/packages/flet-core/src/flet_core/navigation_bar.py
+++ b/sdk/python/packages/flet-core/src/flet_core/navigation_bar.py
@@ -46,7 +46,7 @@ class NavigationBarDestination(Control):
         ref: Optional[Ref] = None,
         tooltip: Optional[str] = None,
         disabled: Optional[bool] = None,
-        data: Any = None,
+        data: Any = None
     ) -> None:
         Control.__init__(self, ref=ref, tooltip=tooltip, disabled=disabled, data=data)
         self.label = label
@@ -58,10 +58,10 @@ class NavigationBarDestination(Control):
         self.selected_icon_content = selected_icon_content
         self.bgcolor = bgcolor
 
-    def _get_control_name(self) -> str:
+    def _get_control_name(self):
         return "navigationbardestination"
 
-    def _get_children(self) -> Optional[List[Control]]:
+    def _get_children(self):
         children = []
         if self.__icon_content:
             self.__icon_content._set_attr_internal("n", "icon_content")
@@ -74,43 +74,39 @@ class NavigationBarDestination(Control):
         return children
 
     # icon
-
     @property
     def icon(self) -> Optional[str]:
         return self._get_attr("icon")
 
     @icon.setter
-    def icon(self, value: str) -> None:
+    def icon(self, value: Optional[str]):
         self._set_attr("icon", value)
 
     # icon_content
-
     @property
     def icon_content(self) -> Optional[Control]:
         return self.__icon_content
 
     @icon_content.setter
-    def icon_content(self, value: Control) -> None:
+    def icon_content(self, value: Optional[Control]):
         self.__icon_content = value
 
     # selected_icon
-
     @property
     def selected_icon(self) -> Optional[str]:
         return self._get_attr("selectedIcon")
 
     @selected_icon.setter
-    def selected_icon(self, value: str) -> None:
+    def selected_icon(self, value: Optional[str]):
         self._set_attr("selectedIcon", value)
 
     # selected_icon_content
-
     @property
     def selected_icon_content(self) -> Optional[Control]:
         return self.__selected_icon_content
 
     @selected_icon_content.setter
-    def selected_icon_content(self, value: Control) -> None:
+    def selected_icon_content(self, value: Optional[Control]):
         self.__selected_icon_content = value
 
     # label
@@ -120,7 +116,7 @@ class NavigationBarDestination(Control):
         return self._get_attr("label")
 
     @label.setter
-    def label(self, value: str) -> None:
+    def label(self, value: Optional[str]):
         self._set_attr("label", value)
 
     # bgcolor
@@ -130,8 +126,11 @@ class NavigationBarDestination(Control):
         return self._get_attr("bgcolor")
 
     @bgcolor.setter
-    def bgcolor(self, value: str) -> None:
+    def bgcolor(self, value: Optional[str]):
         self._set_attr("bgcolor", value)
+
+
+NavigationDestination = NavigationBarDestination
 
 
 class NavigationBar(ConstrainedControl, AdaptiveControl):
@@ -211,7 +210,7 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
         visible: Optional[bool] = None,
         disabled: Optional[bool] = None,
         data: Any = None,
-        adaptive: Optional[bool] = None,
+        adaptive: Optional[bool] = None
     ) -> None:
         ConstrainedControl.__init__(
             self,
@@ -258,7 +257,7 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
         self.animation_duration = animation_duration
         self.overlay_color = overlay_color
 
-    def _get_control_name(self) -> str:
+    def _get_control_name(self):
         return "navigationbar"
 
     def before_update(self) -> None:
@@ -267,138 +266,125 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
         self._set_attr_json("border", self.__border)
         self._set_attr_json("overlayColor", self.__overlay_color)
 
-    def _get_children(self) -> Optional[List[NavigationBarDestination]]:
+    def _get_children(self):
         children = []
         children.extend(self.__destinations)
         return children
 
     # destinations
-
     @property
     def destinations(self) -> Optional[List[NavigationBarDestination]]:
         return self.__destinations
 
     @destinations.setter
-    def destinations(self, value: List[NavigationBarDestination]) -> None:
+    def destinations(self, value: Optional[List[NavigationBarDestination]]):
         self.__destinations = value if value else []
 
     # selected_index
-
     @property
     def selected_index(self) -> Optional[int]:
         return self._get_attr("selectedIndex", data_type="int", def_value=0)
 
     @selected_index.setter
-    def selected_index(self, value: int) -> None:
+    def selected_index(self, value: Optional[int]):
         self._set_attr("selectedIndex", value)
 
     # label_behavior
-
     @property
     def label_behavior(self) -> Optional[NavigationBarLabelBehavior]:
         return self.__label_behavior
 
     @label_behavior.setter
-    def label_behavior(self, value: NavigationBarLabelBehavior) -> None:
+    def label_behavior(self, value: Optional[NavigationBarLabelBehavior]):
         self.__label_behavior = value
         self._set_enum_attr("labelBehavior", value, NavigationBarLabelBehavior)
 
     # overlay_color
-
     @property
     def overlay_color(self) -> Optional[Union[str, Dict[MaterialState, str]]]:
         return self.__overlay_color
 
     @overlay_color.setter
-    def overlay_color(self, value: Union[str, Dict[MaterialState, str]]) -> None:
+    def overlay_color(self, value: Optional[Union[str, Dict[MaterialState, str]]]):
         self.__overlay_color = value
 
     # bgcolor
-
     @property
     def bgcolor(self) -> Optional[str]:
         return self._get_attr("bgcolor")
 
     @bgcolor.setter
-    def bgcolor(self, value: str) -> None:
+    def bgcolor(self, value: Optional[str]):
         self._set_attr("bgcolor", value)
 
     # elevation
-
     @property
     def elevation(self) -> OptionalNumber:
         return self._get_attr("elevation")
 
     @elevation.setter
-    def elevation(self, value: OptionalNumber) -> None:
+    def elevation(self, value: OptionalNumber):
         self._set_attr("elevation", value)
 
     # shadow_color
-
     @property
     def shadow_color(self) -> Optional[str]:
         return self._get_attr("shadowColor")
 
     @shadow_color.setter
-    def shadow_color(self, value: str) -> None:
+    def shadow_color(self, value: Optional[str]):
         self._set_attr("shadowColor", value)
 
     # indicator_color
-
     @property
     def indicator_color(self) -> Optional[str]:
         return self._get_attr("indicatorColor")
 
     @indicator_color.setter
-    def indicator_color(self, value: str) -> None:
+    def indicator_color(self, value: Optional[str]):
         self._set_attr("indicatorColor", value)
 
     # indicator_shape
-
     @property
     def indicator_shape(self) -> Optional[OutlinedBorder]:
         return self.__indicator_shape
 
     @indicator_shape.setter
-    def indicator_shape(self, value: OutlinedBorder) -> None:
+    def indicator_shape(self, value: Optional[OutlinedBorder]):
         self.__indicator_shape = value
 
     # surface_tint_color
-
     @property
     def surface_tint_color(self) -> Optional[str]:
         return self._get_attr("surfaceTintColor")
 
     @surface_tint_color.setter
-    def surface_tint_color(self, value: str) -> None:
+    def surface_tint_color(self, value: Optional[str]):
         self._set_attr("surfaceTintColor", value)
 
     # border
-
     @property
     def border(self) -> Optional[Border]:
         return self.__border
 
     @border.setter
-    def border(self, value: Border) -> None:
+    def border(self, value: Optional[Border]):
         self.__border = value
 
     # animation_duration
-
     @property
     def animation_duration(self) -> OptionalNumber:
         return self._get_attr("animationDuration", data_type="int")
 
     @animation_duration.setter
-    def animation_duration(self, value: Union[int, float]) -> None:
+    def animation_duration(self, value: OptionalNumber):
         self._set_attr("animationDuration", value)
 
     # on_change
-
     @property
     def on_change(self) -> Optional[ControlEventFunction]:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: ControlEventFunction) -> None:
+    def on_change(self, handler: Optional[ControlEventFunction]):
         self._add_event_handler("change", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/navigation_bar.py
+++ b/sdk/python/packages/flet-core/src/flet_core/navigation_bar.py
@@ -1,11 +1,12 @@
 from enum import Enum
-from typing import Any, List, Optional, Union, Dict
+from typing import Any, Callable, List, Optional, Union, Dict
 
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.border import Border
 from flet_core.buttons import OutlinedBorder
 from flet_core.constrained_control import ConstrainedControl
 from flet_core.control import Control, OptionalNumber
+from flet_core.control_event import ControlEvent
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
@@ -16,12 +17,6 @@ from flet_core.types import (
     MaterialState,
 )
 
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
-
-
 class NavigationBarLabelBehavior(Enum):
     """Defines how the destinations' labels will be laid out and when they'll be displayed."""
 
@@ -30,10 +25,10 @@ class NavigationBarLabelBehavior(Enum):
     ONLY_SHOW_SELECTED = "onlyShowSelected"
 
 
-class NavigationDestination(Control):
+class NavigationBarDestination(Control):
     """Defines the appearance of the button items that are arrayed within the navigation bar.
 
-    The value must be a list of two or more NavigationDestination instances."""
+    The value must be a list of two or more NavigationBarDestination instances."""
 
     def __init__(
         self,
@@ -50,7 +45,7 @@ class NavigationDestination(Control):
         tooltip: Optional[str] = None,
         disabled: Optional[bool] = None,
         data: Any = None,
-    ):
+    ) -> None:
         Control.__init__(self, ref=ref, tooltip=tooltip, disabled=disabled, data=data)
         self.label = label
         self.icon = icon
@@ -61,10 +56,10 @@ class NavigationDestination(Control):
         self.selected_icon_content = selected_icon_content
         self.bgcolor = bgcolor
 
-    def _get_control_name(self):
-        return "navigationdestination"
+    def _get_control_name(self) -> str:
+        return "navigationbardestination"
 
-    def _get_children(self):
+    def _get_children(self) -> Optional[List[Control]]:
         children = []
         if self.__icon_content:
             self.__icon_content._set_attr_internal("n", "icon_content")
@@ -82,7 +77,7 @@ class NavigationDestination(Control):
         return self._get_attr("icon")
 
     @icon.setter
-    def icon(self, value: Optional[str]):
+    def icon(self, value: str) -> None:
         self._set_attr("icon", value)
 
     # icon_content
@@ -91,7 +86,7 @@ class NavigationDestination(Control):
         return self.__icon_content
 
     @icon_content.setter
-    def icon_content(self, value: Optional[Control]):
+    def icon_content(self, value: Control) -> None:
         self.__icon_content = value
 
     # selected_icon
@@ -100,7 +95,7 @@ class NavigationDestination(Control):
         return self._get_attr("selectedIcon")
 
     @selected_icon.setter
-    def selected_icon(self, value: Optional[str]):
+    def selected_icon(self, value: str) -> None:
         self._set_attr("selectedIcon", value)
 
     # selected_icon_content
@@ -109,7 +104,7 @@ class NavigationDestination(Control):
         return self.__selected_icon_content
 
     @selected_icon_content.setter
-    def selected_icon_content(self, value: Optional[Control]):
+    def selected_icon_content(self, value: Control) -> None:
         self.__selected_icon_content = value
 
     # label
@@ -118,7 +113,7 @@ class NavigationDestination(Control):
         return self._get_attr("label")
 
     @label.setter
-    def label(self, value: Optional[str]):
+    def label(self, value: str) -> None:
         self._set_attr("label", value)
 
     # bgcolor
@@ -127,7 +122,7 @@ class NavigationDestination(Control):
         return self._get_attr("bgcolor")
 
     @bgcolor.setter
-    def bgcolor(self, value: Optional[str]):
+    def bgcolor(self, value: str) -> None:
         self._set_attr("bgcolor", value)
 
 
@@ -143,16 +138,15 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
     import flet as ft
 
     def main(page: ft.Page):
-
         page.title = "NavigationBar Example"
         page.navigation_bar = ft.NavigationBar(
             destinations=[
-                ft.NavigationDestination(icon=ft.icons.EXPLORE, label="Explore"),
-                ft.NavigationDestination(icon=ft.icons.COMMUTE, label="Commute"),
-                ft.NavigationDestination(
+                ft.NavigationBarDestination(icon=ft.icons.EXPLORE, label="Explore"),
+                ft.NavigationBarDestination(icon=ft.icons.COMMUTE, label="Commute"),
+                ft.NavigationBarDestination(
                     icon=ft.icons.BOOKMARK_BORDER,
                     selected_icon=ft.icons.BOOKMARK,
-                    label="Explore",
+                    label="Explore"
                 ),
             ]
         )
@@ -168,7 +162,7 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
 
     def __init__(
         self,
-        destinations: Optional[List[NavigationDestination]] = None,
+        destinations: Optional[List[NavigationBarDestination]] = None,
         selected_index: Optional[int] = None,
         bgcolor: Optional[str] = None,
         label_behavior: Optional[NavigationBarLabelBehavior] = None,
@@ -180,7 +174,7 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
         border: Optional[Border] = None,
         animation_duration: Optional[int] = None,
         overlay_color: Union[None, str, Dict[MaterialState, str]] = None,
-        on_change=None,
+        on_change: Optional[Callable[[ControlEvent], None]] = None,
         #
         # ConstrainedControl and AdaptiveControl
         #
@@ -205,12 +199,12 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
         animate_rotation: AnimationValue = None,
         animate_scale: AnimationValue = None,
         animate_offset: AnimationValue = None,
-        on_animation_end=None,
+        on_animation_end: Callable[..., None] = None,
         visible: Optional[bool] = None,
         disabled: Optional[bool] = None,
         data: Any = None,
         adaptive: Optional[bool] = None,
-    ):
+    ) -> None:
         ConstrainedControl.__init__(
             self,
             ref=ref,
@@ -256,28 +250,28 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
         self.animation_duration = animation_duration
         self.overlay_color = overlay_color
 
-    def _get_control_name(self):
+    def _get_control_name(self) -> str:
         return "navigationbar"
 
-    def before_update(self):
+    def before_update(self) -> None:
         super().before_update()
         self._set_attr_json("indicatorShape", self.__indicator_shape)
         self._set_attr_json("border", self.__border)
         self._set_attr_json("overlayColor", self.__overlay_color)
 
-    def _get_children(self):
+    def _get_children(self) -> Optional[List[NavigationBarDestination]]:
         children = []
         children.extend(self.__destinations)
         return children
 
     # destinations
     @property
-    def destinations(self) -> Optional[List[NavigationDestination]]:
+    def destinations(self) -> Optional[List[NavigationBarDestination]]:
         return self.__destinations
 
     @destinations.setter
-    def destinations(self, value: Optional[List[NavigationDestination]]):
-        self.__destinations = value if value is not None else []
+    def destinations(self, value: List[NavigationBarDestination]) -> None:
+        self.__destinations = value if value else []
 
     # selected_index
     @property
@@ -285,7 +279,7 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
         return self._get_attr("selectedIndex", data_type="int", def_value=0)
 
     @selected_index.setter
-    def selected_index(self, value: Optional[int]):
+    def selected_index(self, value: int) -> None:
         self._set_attr("selectedIndex", value)
 
     # label_behavior
@@ -294,26 +288,26 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
         return self.__label_behavior
 
     @label_behavior.setter
-    def label_behavior(self, value: Optional[NavigationBarLabelBehavior]):
+    def label_behavior(self, value: NavigationBarLabelBehavior) -> None:
         self.__label_behavior = value
         self._set_enum_attr("labelBehavior", value, NavigationBarLabelBehavior)
 
     # overlay_color
     @property
-    def overlay_color(self) -> Union[None, str, Dict[MaterialState, str]]:
+    def overlay_color(self) -> Optional[Union[str, Dict[MaterialState, str]]]:
         return self.__overlay_color
 
     @overlay_color.setter
-    def overlay_color(self, value: Union[None, str, Dict[MaterialState, str]]):
+    def overlay_color(self, value: Union[str, Dict[MaterialState, str]]) -> None:
         self.__overlay_color = value
 
     # bgcolor
     @property
-    def bgcolor(self):
+    def bgcolor(self) -> Optional[str]:
         return self._get_attr("bgcolor")
 
     @bgcolor.setter
-    def bgcolor(self, value):
+    def bgcolor(self, value: str) -> None:
         self._set_attr("bgcolor", value)
 
     # elevation
@@ -322,25 +316,25 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
         return self._get_attr("elevation")
 
     @elevation.setter
-    def elevation(self, value: OptionalNumber):
+    def elevation(self, value: OptionalNumber) -> None:
         self._set_attr("elevation", value)
 
     # shadow_color
     @property
-    def shadow_color(self):
+    def shadow_color(self) -> Optional[str]:
         return self._get_attr("shadowColor")
 
     @shadow_color.setter
-    def shadow_color(self, value):
+    def shadow_color(self, value: str) -> None:
         self._set_attr("shadowColor", value)
 
     # indicator_color
     @property
-    def indicator_color(self):
+    def indicator_color(self) -> Optional[str]:
         return self._get_attr("indicatorColor")
 
     @indicator_color.setter
-    def indicator_color(self, value):
+    def indicator_color(self, value: str) -> None:
         self._set_attr("indicatorColor", value)
 
     # indicator_shape
@@ -349,16 +343,16 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
         return self.__indicator_shape
 
     @indicator_shape.setter
-    def indicator_shape(self, value: Optional[OutlinedBorder]):
+    def indicator_shape(self, value: OutlinedBorder) -> None:
         self.__indicator_shape = value
 
     # surface_tint_color
     @property
-    def surface_tint_color(self):
+    def surface_tint_color(self) -> Optional[str]:
         return self._get_attr("surfaceTintColor")
 
     @surface_tint_color.setter
-    def surface_tint_color(self, value):
+    def surface_tint_color(self, value: str) -> None:
         self._set_attr("surfaceTintColor", value)
 
     # border
@@ -367,23 +361,23 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
         return self.__border
 
     @border.setter
-    def border(self, value: Optional[Border]):
+    def border(self, value: Border) -> None:
         self.__border = value
 
     # animation_duration
     @property
-    def animation_duration(self):
+    def animation_duration(self) -> OptionalNumber:
         return self._get_attr("animationDuration", data_type="int")
 
     @animation_duration.setter
-    def animation_duration(self, value: OptionalNumber):
+    def animation_duration(self, value: Union[int, float]) -> None:
         self._set_attr("animationDuration", value)
 
     # on_change
     @property
-    def on_change(self):
+    def on_change(self) -> Optional[Callable[[ControlEvent], None]]:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler):
+    def on_change(self, handler: Callable[[ControlEvent], None]) -> None:
         self._add_event_handler("change", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/navigation_bar.py
+++ b/sdk/python/packages/flet-core/src/flet_core/navigation_bar.py
@@ -1,24 +1,26 @@
 from enum import Enum
-from typing import Any, Callable, List, Optional, Union, Dict
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.border import Border
 from flet_core.buttons import OutlinedBorder
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
-from flet_core.control_event import ControlEvent
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
+    ControlEventFunction,
+    MaterialState,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
-    MaterialState,
 )
 
+
 class NavigationBarLabelBehavior(Enum):
-    """Defines how the destinations' labels will be laid out and when they'll be displayed."""
+    "Defines how the destinations' labels will be laid out and when they'll be displayed."
 
     ALWAYS_SHOW = "alwaysShow"
     ALWAYS_HIDE = "alwaysHide"
@@ -72,6 +74,7 @@ class NavigationBarDestination(Control):
         return children
 
     # icon
+
     @property
     def icon(self) -> Optional[str]:
         return self._get_attr("icon")
@@ -81,6 +84,7 @@ class NavigationBarDestination(Control):
         self._set_attr("icon", value)
 
     # icon_content
+
     @property
     def icon_content(self) -> Optional[Control]:
         return self.__icon_content
@@ -90,6 +94,7 @@ class NavigationBarDestination(Control):
         self.__icon_content = value
 
     # selected_icon
+
     @property
     def selected_icon(self) -> Optional[str]:
         return self._get_attr("selectedIcon")
@@ -99,6 +104,7 @@ class NavigationBarDestination(Control):
         self._set_attr("selectedIcon", value)
 
     # selected_icon_content
+
     @property
     def selected_icon_content(self) -> Optional[Control]:
         return self.__selected_icon_content
@@ -108,6 +114,7 @@ class NavigationBarDestination(Control):
         self.__selected_icon_content = value
 
     # label
+
     @property
     def label(self) -> Optional[str]:
         return self._get_attr("label")
@@ -117,6 +124,7 @@ class NavigationBarDestination(Control):
         self._set_attr("label", value)
 
     # bgcolor
+
     @property
     def bgcolor(self) -> Optional[str]:
         return self._get_attr("bgcolor")
@@ -174,7 +182,7 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
         border: Optional[Border] = None,
         animation_duration: Optional[int] = None,
         overlay_color: Union[None, str, Dict[MaterialState, str]] = None,
-        on_change: Optional[Callable[[ControlEvent], None]] = None,
+        on_change: Optional[ControlEventFunction] = None,
         #
         # ConstrainedControl and AdaptiveControl
         #
@@ -265,6 +273,7 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
         return children
 
     # destinations
+
     @property
     def destinations(self) -> Optional[List[NavigationBarDestination]]:
         return self.__destinations
@@ -274,6 +283,7 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
         self.__destinations = value if value else []
 
     # selected_index
+
     @property
     def selected_index(self) -> Optional[int]:
         return self._get_attr("selectedIndex", data_type="int", def_value=0)
@@ -283,6 +293,7 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
         self._set_attr("selectedIndex", value)
 
     # label_behavior
+
     @property
     def label_behavior(self) -> Optional[NavigationBarLabelBehavior]:
         return self.__label_behavior
@@ -293,6 +304,7 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
         self._set_enum_attr("labelBehavior", value, NavigationBarLabelBehavior)
 
     # overlay_color
+
     @property
     def overlay_color(self) -> Optional[Union[str, Dict[MaterialState, str]]]:
         return self.__overlay_color
@@ -302,6 +314,7 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
         self.__overlay_color = value
 
     # bgcolor
+
     @property
     def bgcolor(self) -> Optional[str]:
         return self._get_attr("bgcolor")
@@ -311,6 +324,7 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
         self._set_attr("bgcolor", value)
 
     # elevation
+
     @property
     def elevation(self) -> OptionalNumber:
         return self._get_attr("elevation")
@@ -320,6 +334,7 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
         self._set_attr("elevation", value)
 
     # shadow_color
+
     @property
     def shadow_color(self) -> Optional[str]:
         return self._get_attr("shadowColor")
@@ -329,6 +344,7 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
         self._set_attr("shadowColor", value)
 
     # indicator_color
+
     @property
     def indicator_color(self) -> Optional[str]:
         return self._get_attr("indicatorColor")
@@ -338,6 +354,7 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
         self._set_attr("indicatorColor", value)
 
     # indicator_shape
+
     @property
     def indicator_shape(self) -> Optional[OutlinedBorder]:
         return self.__indicator_shape
@@ -347,6 +364,7 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
         self.__indicator_shape = value
 
     # surface_tint_color
+
     @property
     def surface_tint_color(self) -> Optional[str]:
         return self._get_attr("surfaceTintColor")
@@ -356,6 +374,7 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
         self._set_attr("surfaceTintColor", value)
 
     # border
+
     @property
     def border(self) -> Optional[Border]:
         return self.__border
@@ -365,6 +384,7 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
         self.__border = value
 
     # animation_duration
+
     @property
     def animation_duration(self) -> OptionalNumber:
         return self._get_attr("animationDuration", data_type="int")
@@ -374,10 +394,11 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
         self._set_attr("animationDuration", value)
 
     # on_change
+
     @property
-    def on_change(self) -> Optional[Callable[[ControlEvent], None]]:
+    def on_change(self) -> Optional[ControlEventFunction]:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: Callable[[ControlEvent], None]) -> None:
+    def on_change(self, handler: ControlEventFunction) -> None:
         self._add_event_handler("change", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/navigation_drawer.py
+++ b/sdk/python/packages/flet-core/src/flet_core/navigation_drawer.py
@@ -1,17 +1,13 @@
-from typing import Any, Callable, List, Optional
+from typing import Any, List, Optional
 
 from flet_core.buttons import OutlinedBorder
-from flet_core.control import Control, OptionalNumber
-from flet_core.control_event import ControlEvent
+from flet_core.control import Control
 from flet_core.ref import Ref
-from flet_core.types import PaddingValue
+from flet_core.types import ControlEventFunction, OptionalNumber, PaddingValue
 
 
 class NavigationDrawerDestination(Control):
-    """
-    Displays an icon with a label, for use in NavigationDrawer destinations.
-
-    """
+    "Displays an icon with a label, for use in NavigationDrawer destinations."
 
     def __init__(
         self,
@@ -52,6 +48,7 @@ class NavigationDrawerDestination(Control):
         return children
 
     # bgcolor
+
     @property
     def bgcolor(self) -> Optional[str]:
         return self._get_attr("bgColor")
@@ -61,6 +58,7 @@ class NavigationDrawerDestination(Control):
         self._set_attr("bgColor", value)
 
     # icon
+
     @property
     def icon(self) -> Optional[str]:
         return self._get_attr("icon")
@@ -70,6 +68,7 @@ class NavigationDrawerDestination(Control):
         self._set_attr("icon", value)
 
     # icon_content
+
     @property
     def icon_content(self) -> Optional[Control]:
         return self.__icon_content
@@ -79,6 +78,7 @@ class NavigationDrawerDestination(Control):
         self.__icon_content = value
 
     # selected_icon
+
     @property
     def selected_icon(self) -> Optional[str]:
         return self._get_attr("selectedIcon")
@@ -88,6 +88,7 @@ class NavigationDrawerDestination(Control):
         self._set_attr("selectedIcon", value)
 
     # selected_icon_content
+
     @property
     def selected_icon_content(self) -> Optional[Control]:
         return self.__selected_icon_content
@@ -97,6 +98,7 @@ class NavigationDrawerDestination(Control):
         self.__selected_icon_content = value
 
     # label
+
     @property
     def label(self) -> Optional[str]:
         return self._get_attr("label")
@@ -192,8 +194,8 @@ class NavigationDrawer(Control):
         shadow_color: Optional[str] = None,
         surface_tint_color: Optional[str] = None,
         tile_padding: PaddingValue = None,
-        on_change: Optional[Callable[[ControlEvent], None]] = None,
-        on_dismiss: Optional[Callable[[ControlEvent], None]] = None,
+        on_change: Optional[ControlEventFunction] = None,
+        on_dismiss: Optional[ControlEventFunction] = None,
         #
         # Control
         #
@@ -238,6 +240,7 @@ class NavigationDrawer(Control):
         return children
 
     # open
+
     @property
     def open(self) -> Optional[bool]:
         return self._get_attr("open", data_type="bool", def_value=False)
@@ -247,6 +250,7 @@ class NavigationDrawer(Control):
         self._set_attr("open", value)
 
     # controls
+
     @property
     def controls(self) -> Optional[List[Control]]:
         return self.__controls
@@ -256,6 +260,7 @@ class NavigationDrawer(Control):
         self.__controls = value if value else []
 
     # selected_index
+
     @property
     def selected_index(self) -> Optional[int]:
         return self._get_attr("selectedIndex", data_type="int", def_value=0)
@@ -265,6 +270,7 @@ class NavigationDrawer(Control):
         self._set_attr("selectedIndex", value)
 
     # bgcolor
+
     @property
     def bgcolor(self) -> Optional[str]:
         return self._get_attr("bgcolor")
@@ -274,6 +280,7 @@ class NavigationDrawer(Control):
         self._set_attr("bgcolor", value)
 
     # elevation
+
     @property
     def elevation(self) -> OptionalNumber:
         return self._get_attr("elevation")
@@ -283,6 +290,7 @@ class NavigationDrawer(Control):
         self._set_attr("elevation", value)
 
     # indicator_color
+
     @property
     def indicator_color(self) -> Optional[str]:
         return self._get_attr("indicatorColor")
@@ -292,6 +300,7 @@ class NavigationDrawer(Control):
         self._set_attr("indicatorColor", value)
 
     # indicator_shape
+
     @property
     def indicator_shape(self) -> Optional[OutlinedBorder]:
         return self.__indicator_shape
@@ -301,6 +310,7 @@ class NavigationDrawer(Control):
         self.__indicator_shape = value
 
     # shadow_color
+
     @property
     def shadow_color(self) -> Optional[str]:
         return self._get_attr("shadowColor")
@@ -310,6 +320,7 @@ class NavigationDrawer(Control):
         self._set_attr("shadowColor", value)
 
     # surface_tint_color
+
     @property
     def surface_tint_color(self) -> Optional[str]:
         return self._get_attr("surfaceTintColor")
@@ -319,6 +330,7 @@ class NavigationDrawer(Control):
         self._set_attr("surfaceTintColor", value)
 
     # tile_padding
+
     @property
     def tile_padding(self) -> PaddingValue:
         return self.__tile_padding
@@ -328,19 +340,21 @@ class NavigationDrawer(Control):
         self.__tile_padding = value
 
     # on_change
+
     @property
-    def on_change(self) -> Optional[Callable[[ControlEvent], None]]:
+    def on_change(self) -> Optional[ControlEventFunction]:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: Callable[[ControlEvent], None]) -> None:
+    def on_change(self, handler: ControlEventFunction) -> None:
         self._add_event_handler("change", handler)
 
     # on_dismiss
+
     @property
-    def on_dismiss(self) -> Optional[Callable[[ControlEvent], None]]:
+    def on_dismiss(self) -> Optional[ControlEventFunction]:
         return self._get_event_handler("dismiss")
 
     @on_dismiss.setter
-    def on_dismiss(self, handler: Callable[[ControlEvent], None]) -> None:
+    def on_dismiss(self, handler: ControlEventFunction) -> None:
         self._add_event_handler("dismiss", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/navigation_drawer.py
+++ b/sdk/python/packages/flet-core/src/flet_core/navigation_drawer.py
@@ -20,7 +20,7 @@ class NavigationDrawerDestination(Control):
         #
         # Control
         #
-        ref: Optional[Ref] = None,
+        ref: Optional[Ref] = None
     ) -> None:
         Control.__init__(self, ref=ref)
         self.label = label
@@ -32,10 +32,10 @@ class NavigationDrawerDestination(Control):
         self.__selected_icon_content: Optional[Control] = None
         self.selected_icon_content = selected_icon_content
 
-    def _get_control_name(self) -> str:
+    def _get_control_name(self):
         return "navigationdrawerdestination"
 
-    def _get_children(self) -> Optional[List[Control]]:
+    def _get_children(self):
         children = []
         if self.__icon_content:
             self.__icon_content._set_attr_internal("n", "icon_content")
@@ -48,63 +48,57 @@ class NavigationDrawerDestination(Control):
         return children
 
     # bgcolor
-
     @property
     def bgcolor(self) -> Optional[str]:
         return self._get_attr("bgColor")
 
     @bgcolor.setter
-    def bgcolor(self, value: Optional[str]) -> None:
+    def bgcolor(self, value: Optional[str]):
         self._set_attr("bgColor", value)
 
     # icon
-
     @property
     def icon(self) -> Optional[str]:
         return self._get_attr("icon")
 
     @icon.setter
-    def icon(self, value: Optional[str]) -> None:
+    def icon(self, value: Optional[str]):
         self._set_attr("icon", value)
 
     # icon_content
-
     @property
     def icon_content(self) -> Optional[Control]:
         return self.__icon_content
 
     @icon_content.setter
-    def icon_content(self, value: Optional[Control]) -> None:
+    def icon_content(self, value: Optional[Control]):
         self.__icon_content = value
 
     # selected_icon
-
     @property
     def selected_icon(self) -> Optional[str]:
         return self._get_attr("selectedIcon")
 
     @selected_icon.setter
-    def selected_icon(self, value: Optional[str]) -> None:
+    def selected_icon(self, value: Optional[str]):
         self._set_attr("selectedIcon", value)
 
     # selected_icon_content
-
     @property
     def selected_icon_content(self) -> Optional[Control]:
         return self.__selected_icon_content
 
     @selected_icon_content.setter
-    def selected_icon_content(self, value: Optional[Control]) -> None:
+    def selected_icon_content(self, value: Optional[Control]):
         self.__selected_icon_content = value
 
     # label
-
     @property
     def label(self) -> Optional[str]:
         return self._get_attr("label")
 
     @label.setter
-    def label(self, value: Optional[str]) -> None:
+    def label(self, value: Optional[str]):
         self._set_attr("label", value)
 
 
@@ -202,7 +196,7 @@ class NavigationDrawer(Control):
         ref: Optional[Ref] = None,
         disabled: Optional[bool] = None,
         visible: Optional[bool] = None,
-        data: Any = None,
+        data: Any = None
     ) -> None:
         Control.__init__(
             self,
@@ -226,7 +220,7 @@ class NavigationDrawer(Control):
         self.on_change = on_change
         self.on_dismiss = on_dismiss
 
-    def _get_control_name(self) -> str:
+    def _get_control_name(self):
         return "navigationdrawer"
 
     def before_update(self) -> None:
@@ -234,127 +228,115 @@ class NavigationDrawer(Control):
         self._set_attr_json("indicatorShape", self.__indicator_shape)
         self._set_attr_json("tilePadding", self.__tile_padding)
 
-    def _get_children(self) -> Optional[List[Control]]:
+    def _get_children(self):
         children = []
         children.extend(self.__controls)
         return children
 
     # open
-
     @property
     def open(self) -> Optional[bool]:
         return self._get_attr("open", data_type="bool", def_value=False)
 
     @open.setter
-    def open(self, value: Optional[bool]) -> None:
+    def open(self, value: Optional[bool]):
         self._set_attr("open", value)
 
     # controls
-
     @property
     def controls(self) -> Optional[List[Control]]:
         return self.__controls
 
     @controls.setter
-    def controls(self, value: Optional[List[Control]]) -> None:
+    def controls(self, value: Optional[List[Control]]):
         self.__controls = value if value else []
 
     # selected_index
-
     @property
     def selected_index(self) -> Optional[int]:
         return self._get_attr("selectedIndex", data_type="int", def_value=0)
 
     @selected_index.setter
-    def selected_index(self, value: Optional[int]) -> None:
+    def selected_index(self, value: Optional[int]):
         self._set_attr("selectedIndex", value)
 
     # bgcolor
-
     @property
     def bgcolor(self) -> Optional[str]:
         return self._get_attr("bgcolor")
 
     @bgcolor.setter
-    def bgcolor(self, value) -> None:
+    def bgcolor(self, value: Optional[str]):
         self._set_attr("bgcolor", value)
 
     # elevation
-
     @property
     def elevation(self) -> OptionalNumber:
         return self._get_attr("elevation")
 
     @elevation.setter
-    def elevation(self, value: OptionalNumber) -> None:
+    def elevation(self, value: OptionalNumber):
         self._set_attr("elevation", value)
 
     # indicator_color
-
     @property
     def indicator_color(self) -> Optional[str]:
         return self._get_attr("indicatorColor")
 
     @indicator_color.setter
-    def indicator_color(self, value) -> None:
+    def indicator_color(self, value: Optional[str]):
         self._set_attr("indicatorColor", value)
 
     # indicator_shape
-
     @property
     def indicator_shape(self) -> Optional[OutlinedBorder]:
         return self.__indicator_shape
 
     @indicator_shape.setter
-    def indicator_shape(self, value: Optional[OutlinedBorder]) -> None:
+    def indicator_shape(self, value: Optional[OutlinedBorder]):
         self.__indicator_shape = value
 
     # shadow_color
-
     @property
     def shadow_color(self) -> Optional[str]:
         return self._get_attr("shadowColor")
 
     @shadow_color.setter
-    def shadow_color(self, value) -> None:
+    def shadow_color(self, value: Optional[str]):
         self._set_attr("shadowColor", value)
 
     # surface_tint_color
-
     @property
     def surface_tint_color(self) -> Optional[str]:
         return self._get_attr("surfaceTintColor")
 
     @surface_tint_color.setter
-    def surface_tint_color(self, value) -> None:
+    def surface_tint_color(self, value: Optional[str]):
         self._set_attr("surfaceTintColor", value)
 
     # tile_padding
-
     @property
     def tile_padding(self) -> PaddingValue:
         return self.__tile_padding
 
     @tile_padding.setter
-    def tile_padding(self, value: PaddingValue) -> None:
+    def tile_padding(self, value: PaddingValue):
         self.__tile_padding = value
 
     # on_change
-
     @property
     def on_change(self) -> Optional[ControlEventFunction]:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: ControlEventFunction) -> None:
+    def on_change(self, handler: Optional[ControlEventFunction]):
         self._add_event_handler("change", handler)
 
     # on_dismiss
-
     @property
     def on_dismiss(self) -> Optional[ControlEventFunction]:
         return self._get_event_handler("dismiss")
 
     @on_dismiss.setter
-    def on_dismiss(self, handler: ControlEventFunction) -> None:
+    def on_dismiss(self, handler: Optional[ControlEventFunction]):
         self._add_event_handler("dismiss", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/navigation_drawer.py
+++ b/sdk/python/packages/flet-core/src/flet_core/navigation_drawer.py
@@ -1,7 +1,8 @@
-from typing import Any, List, Optional
+from typing import Any, Callable, List, Optional
 
 from flet_core.buttons import OutlinedBorder
 from flet_core.control import Control, OptionalNumber
+from flet_core.control_event import ControlEvent
 from flet_core.ref import Ref
 from flet_core.types import PaddingValue
 
@@ -24,7 +25,7 @@ class NavigationDrawerDestination(Control):
         # Control
         #
         ref: Optional[Ref] = None,
-    ):
+    ) -> None:
         Control.__init__(self, ref=ref)
         self.label = label
         self.bgcolor = bgcolor
@@ -35,10 +36,10 @@ class NavigationDrawerDestination(Control):
         self.__selected_icon_content: Optional[Control] = None
         self.selected_icon_content = selected_icon_content
 
-    def _get_control_name(self):
+    def _get_control_name(self) -> str:
         return "navigationdrawerdestination"
 
-    def _get_children(self):
+    def _get_children(self) -> Optional[List[Control]]:
         children = []
         if self.__icon_content:
             self.__icon_content._set_attr_internal("n", "icon_content")
@@ -56,7 +57,7 @@ class NavigationDrawerDestination(Control):
         return self._get_attr("bgColor")
 
     @bgcolor.setter
-    def bgcolor(self, value: Optional[str]):
+    def bgcolor(self, value: Optional[str]) -> None:
         self._set_attr("bgColor", value)
 
     # icon
@@ -65,7 +66,7 @@ class NavigationDrawerDestination(Control):
         return self._get_attr("icon")
 
     @icon.setter
-    def icon(self, value: Optional[str]):
+    def icon(self, value: Optional[str]) -> None:
         self._set_attr("icon", value)
 
     # icon_content
@@ -74,7 +75,7 @@ class NavigationDrawerDestination(Control):
         return self.__icon_content
 
     @icon_content.setter
-    def icon_content(self, value: Optional[Control]):
+    def icon_content(self, value: Optional[Control]) -> None:
         self.__icon_content = value
 
     # selected_icon
@@ -83,7 +84,7 @@ class NavigationDrawerDestination(Control):
         return self._get_attr("selectedIcon")
 
     @selected_icon.setter
-    def selected_icon(self, value: Optional[str]):
+    def selected_icon(self, value: Optional[str]) -> None:
         self._set_attr("selectedIcon", value)
 
     # selected_icon_content
@@ -92,7 +93,7 @@ class NavigationDrawerDestination(Control):
         return self.__selected_icon_content
 
     @selected_icon_content.setter
-    def selected_icon_content(self, value: Optional[Control]):
+    def selected_icon_content(self, value: Optional[Control]) -> None:
         self.__selected_icon_content = value
 
     # label
@@ -101,7 +102,7 @@ class NavigationDrawerDestination(Control):
         return self._get_attr("label")
 
     @label.setter
-    def label(self, value: Optional[str]):
+    def label(self, value: Optional[str]) -> None:
         self._set_attr("label", value)
 
 
@@ -121,7 +122,7 @@ class NavigationDrawer(Control):
         def item_selected_left(e):
             print(e.control.selected_index)
 
-        page.drawer = ft.NavigationDrawer(
+        drawer = ft.NavigationDrawer(
             elevation=40,
             indicator_color=ft.colors.GREEN_200,
             indicator_shape=ft.StadiumBorder(),
@@ -159,19 +160,12 @@ class NavigationDrawer(Control):
             ],
         )
 
-        def show_drawer(e):
-            page.drawer.open = True
-            page.drawer.update()
-
-        def show_end_drawer(e):
-            page.show_end_drawer(end_drawer)
-
         page.add(
             ft.Row(
                 alignment=ft.MainAxisAlignment.SPACE_BETWEEN,
                 controls=[
-                    ft.ElevatedButton("Show drawer", on_click=show_drawer),
-                    ft.ElevatedButton("Show end drawer", on_click=show_end_drawer),
+                    ft.ElevatedButton("Show drawer", on_click=lambda _: page.show_drawer(drawer)),
+                    ft.ElevatedButton("Show end drawer", on_click=lambda _: page.show_end_drawer(end_drawer)),
                 ],
             )
         )
@@ -198,8 +192,8 @@ class NavigationDrawer(Control):
         shadow_color: Optional[str] = None,
         surface_tint_color: Optional[str] = None,
         tile_padding: PaddingValue = None,
-        on_change=None,
-        on_dismiss=None,
+        on_change: Optional[Callable[[ControlEvent], None]] = None,
+        on_dismiss: Optional[Callable[[ControlEvent], None]] = None,
         #
         # Control
         #
@@ -207,7 +201,7 @@ class NavigationDrawer(Control):
         disabled: Optional[bool] = None,
         visible: Optional[bool] = None,
         data: Any = None,
-    ):
+    ) -> None:
         Control.__init__(
             self,
             ref=ref,
@@ -230,15 +224,15 @@ class NavigationDrawer(Control):
         self.on_change = on_change
         self.on_dismiss = on_dismiss
 
-    def _get_control_name(self):
+    def _get_control_name(self) -> str:
         return "navigationdrawer"
 
-    def before_update(self):
+    def before_update(self) -> None:
         super().before_update()
         self._set_attr_json("indicatorShape", self.__indicator_shape)
         self._set_attr_json("tilePadding", self.__tile_padding)
 
-    def _get_children(self):
+    def _get_children(self) -> Optional[List[Control]]:
         children = []
         children.extend(self.__controls)
         return children
@@ -249,7 +243,7 @@ class NavigationDrawer(Control):
         return self._get_attr("open", data_type="bool", def_value=False)
 
     @open.setter
-    def open(self, value: Optional[bool]):
+    def open(self, value: Optional[bool]) -> None:
         self._set_attr("open", value)
 
     # controls
@@ -258,8 +252,8 @@ class NavigationDrawer(Control):
         return self.__controls
 
     @controls.setter
-    def controls(self, value: Optional[List[Control]]):
-        self.__controls = value if value is not None else []
+    def controls(self, value: Optional[List[Control]]) -> None:
+        self.__controls = value if value else []
 
     # selected_index
     @property
@@ -267,16 +261,16 @@ class NavigationDrawer(Control):
         return self._get_attr("selectedIndex", data_type="int", def_value=0)
 
     @selected_index.setter
-    def selected_index(self, value: Optional[int]):
+    def selected_index(self, value: Optional[int]) -> None:
         self._set_attr("selectedIndex", value)
 
     # bgcolor
     @property
-    def bgcolor(self):
+    def bgcolor(self) -> Optional[str]:
         return self._get_attr("bgcolor")
 
     @bgcolor.setter
-    def bgcolor(self, value):
+    def bgcolor(self, value) -> None:
         self._set_attr("bgcolor", value)
 
     # elevation
@@ -285,16 +279,16 @@ class NavigationDrawer(Control):
         return self._get_attr("elevation")
 
     @elevation.setter
-    def elevation(self, value: OptionalNumber):
+    def elevation(self, value: OptionalNumber) -> None:
         self._set_attr("elevation", value)
 
     # indicator_color
     @property
-    def indicator_color(self):
+    def indicator_color(self) -> Optional[str]:
         return self._get_attr("indicatorColor")
 
     @indicator_color.setter
-    def indicator_color(self, value):
+    def indicator_color(self, value) -> None:
         self._set_attr("indicatorColor", value)
 
     # indicator_shape
@@ -303,25 +297,25 @@ class NavigationDrawer(Control):
         return self.__indicator_shape
 
     @indicator_shape.setter
-    def indicator_shape(self, value: Optional[OutlinedBorder]):
+    def indicator_shape(self, value: Optional[OutlinedBorder]) -> None:
         self.__indicator_shape = value
 
     # shadow_color
     @property
-    def shadow_color(self):
+    def shadow_color(self) -> Optional[str]:
         return self._get_attr("shadowColor")
 
     @shadow_color.setter
-    def shadow_color(self, value):
+    def shadow_color(self, value) -> None:
         self._set_attr("shadowColor", value)
 
     # surface_tint_color
     @property
-    def surface_tint_color(self):
+    def surface_tint_color(self) -> Optional[str]:
         return self._get_attr("surfaceTintColor")
 
     @surface_tint_color.setter
-    def surface_tint_color(self, value):
+    def surface_tint_color(self, value) -> None:
         self._set_attr("surfaceTintColor", value)
 
     # tile_padding
@@ -330,23 +324,23 @@ class NavigationDrawer(Control):
         return self.__tile_padding
 
     @tile_padding.setter
-    def tile_padding(self, value: PaddingValue):
+    def tile_padding(self, value: PaddingValue) -> None:
         self.__tile_padding = value
 
     # on_change
     @property
-    def on_change(self):
+    def on_change(self) -> Optional[Callable[[ControlEvent], None]]:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler):
+    def on_change(self, handler: Callable[[ControlEvent], None]) -> None:
         self._add_event_handler("change", handler)
 
     # on_dismiss
     @property
-    def on_dismiss(self):
+    def on_dismiss(self) -> Optional[Callable[[ControlEvent], None]]:
         return self._get_event_handler("dismiss")
 
     @on_dismiss.setter
-    def on_dismiss(self, handler):
+    def on_dismiss(self, handler: Callable[[ControlEvent], None]) -> None:
         self._add_event_handler("dismiss", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/navigation_drawer.py
+++ b/sdk/python/packages/flet-core/src/flet_core/navigation_drawer.py
@@ -3,7 +3,13 @@ from typing import Any, List, Optional
 from flet_core.buttons import OutlinedBorder
 from flet_core.control import Control
 from flet_core.ref import Ref
-from flet_core.types import ControlEventFunction, OptionalNumber, PaddingValue
+from flet_core.types import (
+    ColorStr,
+    ControlEventFunction,
+    IconStr,
+    OptionalNumber,
+    PaddingValue,
+)
 
 
 class NavigationDrawerDestination(Control):
@@ -12,15 +18,15 @@ class NavigationDrawerDestination(Control):
     def __init__(
         self,
         label: Optional[str] = None,
-        icon: Optional[str] = None,
+        icon: IconStr = None,
         icon_content: Optional[Control] = None,
-        selected_icon: Optional[str] = None,
+        selected_icon: IconStr = None,
         selected_icon_content: Optional[Control] = None,
-        bgcolor: Optional[str] = None,
+        bgcolor: ColorStr = None,
         #
         # Control
         #
-        ref: Optional[Ref] = None
+        ref: Optional[Ref] = None,
     ) -> None:
         Control.__init__(self, ref=ref)
         self.label = label
@@ -49,20 +55,20 @@ class NavigationDrawerDestination(Control):
 
     # bgcolor
     @property
-    def bgcolor(self) -> Optional[str]:
+    def bgcolor(self) -> ColorStr:
         return self._get_attr("bgColor")
 
     @bgcolor.setter
-    def bgcolor(self, value: Optional[str]):
+    def bgcolor(self, value: ColorStr):
         self._set_attr("bgColor", value)
 
     # icon
     @property
-    def icon(self) -> Optional[str]:
+    def icon(self) -> IconStr:
         return self._get_attr("icon")
 
     @icon.setter
-    def icon(self, value: Optional[str]):
+    def icon(self, value: IconStr):
         self._set_attr("icon", value)
 
     # icon_content
@@ -76,11 +82,11 @@ class NavigationDrawerDestination(Control):
 
     # selected_icon
     @property
-    def selected_icon(self) -> Optional[str]:
+    def selected_icon(self) -> IconStr:
         return self._get_attr("selectedIcon")
 
     @selected_icon.setter
-    def selected_icon(self, value: Optional[str]):
+    def selected_icon(self, value: IconStr):
         self._set_attr("selectedIcon", value)
 
     # selected_icon_content
@@ -181,12 +187,12 @@ class NavigationDrawer(Control):
         controls: Optional[List[Control]] = None,
         open: bool = False,
         selected_index: Optional[int] = None,
-        bgcolor: Optional[str] = None,
+        bgcolor: ColorStr = None,
         elevation: OptionalNumber = None,
-        indicator_color: Optional[str] = None,
+        indicator_color: ColorStr = None,
         indicator_shape: Optional[OutlinedBorder] = None,
-        shadow_color: Optional[str] = None,
-        surface_tint_color: Optional[str] = None,
+        shadow_color: ColorStr = None,
+        surface_tint_color: ColorStr = None,
         tile_padding: PaddingValue = None,
         on_change: Optional[ControlEventFunction] = None,
         on_dismiss: Optional[ControlEventFunction] = None,
@@ -196,7 +202,7 @@ class NavigationDrawer(Control):
         ref: Optional[Ref] = None,
         disabled: Optional[bool] = None,
         visible: Optional[bool] = None,
-        data: Any = None
+        data: Any = None,
     ) -> None:
         Control.__init__(
             self,
@@ -262,11 +268,11 @@ class NavigationDrawer(Control):
 
     # bgcolor
     @property
-    def bgcolor(self) -> Optional[str]:
+    def bgcolor(self) -> ColorStr:
         return self._get_attr("bgcolor")
 
     @bgcolor.setter
-    def bgcolor(self, value: Optional[str]):
+    def bgcolor(self, value: ColorStr):
         self._set_attr("bgcolor", value)
 
     # elevation
@@ -280,11 +286,11 @@ class NavigationDrawer(Control):
 
     # indicator_color
     @property
-    def indicator_color(self) -> Optional[str]:
+    def indicator_color(self) -> ColorStr:
         return self._get_attr("indicatorColor")
 
     @indicator_color.setter
-    def indicator_color(self, value: Optional[str]):
+    def indicator_color(self, value: ColorStr):
         self._set_attr("indicatorColor", value)
 
     # indicator_shape
@@ -298,20 +304,20 @@ class NavigationDrawer(Control):
 
     # shadow_color
     @property
-    def shadow_color(self) -> Optional[str]:
+    def shadow_color(self) -> ColorStr:
         return self._get_attr("shadowColor")
 
     @shadow_color.setter
-    def shadow_color(self, value: Optional[str]):
+    def shadow_color(self, value: ColorStr):
         self._set_attr("shadowColor", value)
 
     # surface_tint_color
     @property
-    def surface_tint_color(self) -> Optional[str]:
+    def surface_tint_color(self) -> ColorStr:
         return self._get_attr("surfaceTintColor")
 
     @surface_tint_color.setter
-    def surface_tint_color(self, value: Optional[str]):
+    def surface_tint_color(self, value: ColorStr):
         self._set_attr("surfaceTintColor", value)
 
     # tile_padding

--- a/sdk/python/packages/flet-core/src/flet_core/navigation_rail.py
+++ b/sdk/python/packages/flet-core/src/flet_core/navigation_rail.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, List, Optional, Union
+from typing import Any, Callable, List, Optional, Union
 
 from flet_core.buttons import OutlinedBorder
 from flet_core.constrained_control import ConstrainedControl
@@ -8,6 +8,8 @@ from flet_core.ref import Ref
 from flet_core.text_style import TextStyle
 from flet_core.types import (
     AnimationValue,
+    ColorStr,
+    ControlEventFunction,
     IconStr,
     OffsetValue,
     OptionalNumber,
@@ -34,7 +36,7 @@ class NavigationRailDestination(Control):
         label: Optional[str] = None,
         label_content: Optional[Control] = None,
         padding: PaddingValue = None,
-        indicator_color: Optional[str] = None,
+        indicator_color: ColorStr = None,
         indicator_shape: Optional[OutlinedBorder] = None,
         #
         # Control
@@ -137,11 +139,11 @@ class NavigationRailDestination(Control):
 
     # indicator_color
     @property
-    def indicator_color(self) -> Optional[str]:
+    def indicator_color(self) -> ColorStr:
         return self._get_attr("indicatorColor")
 
     @indicator_color.setter
-    def indicator_color(self, value: Optional[str]):
+    def indicator_color(self, value: ColorStr):
         self._set_attr("indicatorColor", value)
 
     # indicator_shape
@@ -226,8 +228,8 @@ class NavigationRail(ConstrainedControl):
         selected_index: Optional[int] = None,
         extended: Optional[bool] = None,
         label_type: Optional[NavigationRailLabelType] = None,
-        bgcolor: Optional[str] = None,
-        indicator_color: Optional[str] = None,
+        bgcolor: ColorStr = None,
+        indicator_color: ColorStr = None,
         indicator_shape: Optional[OutlinedBorder] = None,
         leading: Optional[Control] = None,
         trailing: Optional[Control] = None,
@@ -236,7 +238,7 @@ class NavigationRail(ConstrainedControl):
         group_alignment: OptionalNumber = None,
         selected_label_text_style: Optional[TextStyle] = None,
         unselected_label_text_style: Optional[TextStyle] = None,
-        on_change=None,
+        on_change: ControlEventFunction = None,
         #
         # ConstrainedControl
         #
@@ -261,7 +263,7 @@ class NavigationRail(ConstrainedControl):
         animate_rotation: AnimationValue = None,
         animate_scale: AnimationValue = None,
         animate_offset: AnimationValue = None,
-        on_animation_end=None,
+        on_animation_end: Callable[..., None] = None,
         visible: Optional[bool] = None,
         disabled: Optional[bool] = None,
         data: Any = None,
@@ -348,7 +350,7 @@ class NavigationRail(ConstrainedControl):
 
     @destinations.setter
     def destinations(self, value: Optional[List[NavigationRailDestination]]):
-        self.__destinations = value if value is not None else []
+        self.__destinations = value if value else []
 
     # on_change
     @property
@@ -389,20 +391,20 @@ class NavigationRail(ConstrainedControl):
 
     # indicator_color
     @property
-    def indicator_color(self) -> Optional[str]:
+    def indicator_color(self) -> ColorStr:
         return self._get_attr("indicatorColor")
 
     @indicator_color.setter
-    def indicator_color(self, value: Optional[str]):
+    def indicator_color(self, value: ColorStr):
         self._set_attr("indicatorColor", value)
 
     # bgcolor
     @property
-    def bgcolor(self) -> Optional[str]:
+    def bgcolor(self) -> ColorStr:
         return self._get_attr("bgcolor")
 
     @bgcolor.setter
-    def bgcolor(self, value: Optional[str]):
+    def bgcolor(self, value: ColorStr):
         self._set_attr("bgcolor", value)
 
     # elevation

--- a/sdk/python/packages/flet-core/src/flet_core/navigation_rail.py
+++ b/sdk/python/packages/flet-core/src/flet_core/navigation_rail.py
@@ -8,6 +8,7 @@ from flet_core.ref import Ref
 from flet_core.text_style import TextStyle
 from flet_core.types import (
     AnimationValue,
+    IconStr,
     OffsetValue,
     OptionalNumber,
     PaddingValue,
@@ -15,11 +16,6 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
 )
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
 
 
 class NavigationRailLabelType(Enum):
@@ -31,9 +27,9 @@ class NavigationRailLabelType(Enum):
 class NavigationRailDestination(Control):
     def __init__(
         self,
-        icon: Optional[str] = None,
+        icon: IconStr = None,
         icon_content: Optional[Control] = None,
-        selected_icon: Optional[str] = None,
+        selected_icon: IconStr = None,
         selected_icon_content: Optional[Control] = None,
         label: Optional[str] = None,
         label_content: Optional[Control] = None,
@@ -46,7 +42,7 @@ class NavigationRailDestination(Control):
         ref: Optional[Ref] = None,
         disabled: Optional[bool] = None,
         data: Any = None,
-    ):
+    ) -> None:
         Control.__init__(self, ref=ref, disabled=disabled, data=data)
         self.label = label
         self.icon = icon
@@ -64,7 +60,7 @@ class NavigationRailDestination(Control):
     def _get_control_name(self):
         return "navigationraildestination"
 
-    def before_update(self):
+    def before_update(self) -> None:
         super().before_update()
         self._set_attr_json("padding", self.__padding)
         if isinstance(self.__indicator_shape, OutlinedBorder):
@@ -86,37 +82,15 @@ class NavigationRailDestination(Control):
         return children
 
     # icon
-
     @property
-    def icon(self) -> Optional[str]:
+    def icon(self) -> IconStr:
         return self._get_attr("icon")
 
     @icon.setter
-    def icon(self, value: Optional[str]):
+    def icon(self, value: IconStr):
         self._set_attr("icon", value)
-
-    # indicator_color
-
-    @property
-    def indicator_color(self) -> Optional[str]:
-        return self._get_attr("indicatorColor")
-
-    @indicator_color.setter
-    def indicator_color(self, value: Optional[str]):
-        self._set_attr("indicatorColor", value)
-
-    # indicator_shape
-
-    @property
-    def indicator_shape(self) -> Optional[OutlinedBorder]:
-        return self.__indicator_shape
-
-    @indicator_shape.setter
-    def indicator_shape(self, value: Optional[OutlinedBorder]):
-        self.__indicator_shape = value
-
+    
     # icon_content
-
     @property
     def icon_content(self) -> Optional[Control]:
         return self.__icon_content
@@ -126,17 +100,15 @@ class NavigationRailDestination(Control):
         self.__icon_content = value
 
     # selected_icon
-
     @property
-    def selected_icon(self):
+    def selected_icon(self) -> IconStr:
         return self._get_attr("selectedIcon")
 
     @selected_icon.setter
-    def selected_icon(self, value):
+    def selected_icon(self, value: IconStr):
         self._set_attr("selectedIcon", value)
 
     # selected_icon_content
-
     @property
     def selected_icon_content(self) -> Optional[Control]:
         return self.__selected_icon_content
@@ -146,17 +118,15 @@ class NavigationRailDestination(Control):
         self.__selected_icon_content = value
 
     # label
-
     @property
-    def label(self):
+    def label(self) -> Optional[str]:
         return self._get_attr("label")
 
     @label.setter
-    def label(self, value):
+    def label(self, value: Optional[str]):
         self._set_attr("label", value)
 
     # label_content
-
     @property
     def label_content(self) -> Optional[Control]:
         return self.__label_content
@@ -165,8 +135,25 @@ class NavigationRailDestination(Control):
     def label_content(self, value: Optional[Control]):
         self.__label_content = value
 
-    # padding
+    # indicator_color
+    @property
+    def indicator_color(self) -> Optional[str]:
+        return self._get_attr("indicatorColor")
 
+    @indicator_color.setter
+    def indicator_color(self, value: Optional[str]):
+        self._set_attr("indicatorColor", value)
+
+    # indicator_shape
+    @property
+    def indicator_shape(self) -> Optional[OutlinedBorder]:
+        return self.__indicator_shape
+
+    @indicator_shape.setter
+    def indicator_shape(self, value: Optional[OutlinedBorder]):
+        self.__indicator_shape = value
+
+    # padding
     @property
     def padding(self) -> PaddingValue:
         return self.__padding
@@ -355,7 +342,6 @@ class NavigationRail(ConstrainedControl):
         return children
 
     # destinations
-
     @property
     def destinations(self) -> Optional[List[NavigationRailDestination]]:
         return self.__destinations
@@ -365,7 +351,6 @@ class NavigationRail(ConstrainedControl):
         self.__destinations = value if value is not None else []
 
     # on_change
-
     @property
     def on_change(self):
         return self._get_event_handler("change")
@@ -375,7 +360,6 @@ class NavigationRail(ConstrainedControl):
         self._add_event_handler("change", handler)
 
     # selected_index
-
     @property
     def selected_index(self) -> Optional[int]:
         return self._get_attr("selectedIndex", data_type="int", def_value=0)
@@ -385,7 +369,6 @@ class NavigationRail(ConstrainedControl):
         self._set_attr("selectedIndex", value)
 
     # label_type
-
     @property
     def label_type(self) -> Optional[NavigationRailLabelType]:
         return self.__label_type
@@ -396,7 +379,6 @@ class NavigationRail(ConstrainedControl):
         self._set_enum_attr("labelType", value, NavigationRailLabelType)
 
     # indicator_shape
-
     @property
     def indicator_shape(self) -> Optional[OutlinedBorder]:
         return self.__indicator_shape
@@ -406,7 +388,6 @@ class NavigationRail(ConstrainedControl):
         self.__indicator_shape = value
 
     # indicator_color
-
     @property
     def indicator_color(self) -> Optional[str]:
         return self._get_attr("indicatorColor")
@@ -416,7 +397,6 @@ class NavigationRail(ConstrainedControl):
         self._set_attr("indicatorColor", value)
 
     # bgcolor
-
     @property
     def bgcolor(self) -> Optional[str]:
         return self._get_attr("bgcolor")
@@ -426,7 +406,6 @@ class NavigationRail(ConstrainedControl):
         self._set_attr("bgcolor", value)
 
     # elevation
-
     @property
     def elevation(self) -> OptionalNumber:
         return self._get_attr("elevation")
@@ -436,7 +415,6 @@ class NavigationRail(ConstrainedControl):
         self._set_attr("elevation", value)
 
     # extended
-
     @property
     def extended(self) -> Optional[bool]:
         return self._get_attr("extended", data_type="bool", def_value=False)
@@ -446,7 +424,6 @@ class NavigationRail(ConstrainedControl):
         self._set_attr("extended", value)
 
     # leading
-
     @property
     def leading(self) -> Optional[Control]:
         return self.__leading
@@ -456,7 +433,6 @@ class NavigationRail(ConstrainedControl):
         self.__leading = value
 
     # trailing
-
     @property
     def trailing(self) -> Optional[Control]:
         return self.__trailing
@@ -466,7 +442,6 @@ class NavigationRail(ConstrainedControl):
         self.__trailing = value
 
     # selected_label_text_style
-
     @property
     def selected_label_text_style(self) -> Optional[TextStyle]:
         return self.__selected_label_text_style
@@ -476,7 +451,6 @@ class NavigationRail(ConstrainedControl):
         self.__selected_label_text_style = value
 
     # unselected_label_text_style
-
     @property
     def unselected_label_text_style(self) -> Optional[TextStyle]:
         return self.__unselected_label_text_style
@@ -486,7 +460,6 @@ class NavigationRail(ConstrainedControl):
         self.__unselected_label_text_style = value
 
     # min_width
-
     @property
     def min_width(self) -> OptionalNumber:
         return self._get_attr("minWidth")
@@ -496,7 +469,6 @@ class NavigationRail(ConstrainedControl):
         self._set_attr("minWidth", value)
 
     # min_extended_width
-
     @property
     def min_extended_width(self) -> OptionalNumber:
         return self._get_attr("minExtendedWidth")
@@ -506,7 +478,6 @@ class NavigationRail(ConstrainedControl):
         self._set_attr("minExtendedWidth", value)
 
     # group_alignment
-
     @property
     def group_alignment(self) -> OptionalNumber:
         return self._get_attr("groupAlignment")

--- a/sdk/python/packages/flet-core/src/flet_core/navigation_rail.py
+++ b/sdk/python/packages/flet-core/src/flet_core/navigation_rail.py
@@ -3,12 +3,13 @@ from typing import Any, List, Optional, Union
 
 from flet_core.buttons import OutlinedBorder
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.text_style import TextStyle
 from flet_core.types import (
     AnimationValue,
     OffsetValue,
+    OptionalNumber,
     PaddingValue,
     ResponsiveNumber,
     RotateValue,
@@ -85,6 +86,7 @@ class NavigationRailDestination(Control):
         return children
 
     # icon
+
     @property
     def icon(self) -> Optional[str]:
         return self._get_attr("icon")
@@ -94,6 +96,7 @@ class NavigationRailDestination(Control):
         self._set_attr("icon", value)
 
     # indicator_color
+
     @property
     def indicator_color(self) -> Optional[str]:
         return self._get_attr("indicatorColor")
@@ -103,6 +106,7 @@ class NavigationRailDestination(Control):
         self._set_attr("indicatorColor", value)
 
     # indicator_shape
+
     @property
     def indicator_shape(self) -> Optional[OutlinedBorder]:
         return self.__indicator_shape
@@ -112,6 +116,7 @@ class NavigationRailDestination(Control):
         self.__indicator_shape = value
 
     # icon_content
+
     @property
     def icon_content(self) -> Optional[Control]:
         return self.__icon_content
@@ -121,6 +126,7 @@ class NavigationRailDestination(Control):
         self.__icon_content = value
 
     # selected_icon
+
     @property
     def selected_icon(self):
         return self._get_attr("selectedIcon")
@@ -130,6 +136,7 @@ class NavigationRailDestination(Control):
         self._set_attr("selectedIcon", value)
 
     # selected_icon_content
+
     @property
     def selected_icon_content(self) -> Optional[Control]:
         return self.__selected_icon_content
@@ -139,6 +146,7 @@ class NavigationRailDestination(Control):
         self.__selected_icon_content = value
 
     # label
+
     @property
     def label(self):
         return self._get_attr("label")
@@ -148,6 +156,7 @@ class NavigationRailDestination(Control):
         self._set_attr("label", value)
 
     # label_content
+
     @property
     def label_content(self) -> Optional[Control]:
         return self.__label_content
@@ -157,6 +166,7 @@ class NavigationRailDestination(Control):
         self.__label_content = value
 
     # padding
+
     @property
     def padding(self) -> PaddingValue:
         return self.__padding
@@ -345,6 +355,7 @@ class NavigationRail(ConstrainedControl):
         return children
 
     # destinations
+
     @property
     def destinations(self) -> Optional[List[NavigationRailDestination]]:
         return self.__destinations
@@ -354,6 +365,7 @@ class NavigationRail(ConstrainedControl):
         self.__destinations = value if value is not None else []
 
     # on_change
+
     @property
     def on_change(self):
         return self._get_event_handler("change")
@@ -363,6 +375,7 @@ class NavigationRail(ConstrainedControl):
         self._add_event_handler("change", handler)
 
     # selected_index
+
     @property
     def selected_index(self) -> Optional[int]:
         return self._get_attr("selectedIndex", data_type="int", def_value=0)
@@ -372,6 +385,7 @@ class NavigationRail(ConstrainedControl):
         self._set_attr("selectedIndex", value)
 
     # label_type
+
     @property
     def label_type(self) -> Optional[NavigationRailLabelType]:
         return self.__label_type
@@ -382,6 +396,7 @@ class NavigationRail(ConstrainedControl):
         self._set_enum_attr("labelType", value, NavigationRailLabelType)
 
     # indicator_shape
+
     @property
     def indicator_shape(self) -> Optional[OutlinedBorder]:
         return self.__indicator_shape
@@ -391,6 +406,7 @@ class NavigationRail(ConstrainedControl):
         self.__indicator_shape = value
 
     # indicator_color
+
     @property
     def indicator_color(self) -> Optional[str]:
         return self._get_attr("indicatorColor")
@@ -400,6 +416,7 @@ class NavigationRail(ConstrainedControl):
         self._set_attr("indicatorColor", value)
 
     # bgcolor
+
     @property
     def bgcolor(self) -> Optional[str]:
         return self._get_attr("bgcolor")
@@ -409,6 +426,7 @@ class NavigationRail(ConstrainedControl):
         self._set_attr("bgcolor", value)
 
     # elevation
+
     @property
     def elevation(self) -> OptionalNumber:
         return self._get_attr("elevation")
@@ -418,6 +436,7 @@ class NavigationRail(ConstrainedControl):
         self._set_attr("elevation", value)
 
     # extended
+
     @property
     def extended(self) -> Optional[bool]:
         return self._get_attr("extended", data_type="bool", def_value=False)
@@ -427,6 +446,7 @@ class NavigationRail(ConstrainedControl):
         self._set_attr("extended", value)
 
     # leading
+
     @property
     def leading(self) -> Optional[Control]:
         return self.__leading
@@ -436,6 +456,7 @@ class NavigationRail(ConstrainedControl):
         self.__leading = value
 
     # trailing
+
     @property
     def trailing(self) -> Optional[Control]:
         return self.__trailing
@@ -445,6 +466,7 @@ class NavigationRail(ConstrainedControl):
         self.__trailing = value
 
     # selected_label_text_style
+
     @property
     def selected_label_text_style(self) -> Optional[TextStyle]:
         return self.__selected_label_text_style
@@ -454,6 +476,7 @@ class NavigationRail(ConstrainedControl):
         self.__selected_label_text_style = value
 
     # unselected_label_text_style
+
     @property
     def unselected_label_text_style(self) -> Optional[TextStyle]:
         return self.__unselected_label_text_style
@@ -463,6 +486,7 @@ class NavigationRail(ConstrainedControl):
         self.__unselected_label_text_style = value
 
     # min_width
+
     @property
     def min_width(self) -> OptionalNumber:
         return self._get_attr("minWidth")
@@ -472,6 +496,7 @@ class NavigationRail(ConstrainedControl):
         self._set_attr("minWidth", value)
 
     # min_extended_width
+
     @property
     def min_extended_width(self) -> OptionalNumber:
         return self._get_attr("minExtendedWidth")
@@ -481,6 +506,7 @@ class NavigationRail(ConstrainedControl):
         self._set_attr("minExtendedWidth", value)
 
     # group_alignment
+
     @property
     def group_alignment(self) -> OptionalNumber:
         return self._get_attr("groupAlignment")

--- a/sdk/python/packages/flet-core/src/flet_core/outlined_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/outlined_button.py
@@ -4,12 +4,13 @@ from typing import Any, Optional, Union
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.buttons import ButtonStyle
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     ClipBehavior,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -166,6 +167,7 @@ class OutlinedButton(ConstrainedControl, AdaptiveControl):
         self.focus()
 
     # text
+
     @property
     def text(self):
         return self._get_attr("text")
@@ -175,6 +177,7 @@ class OutlinedButton(ConstrainedControl, AdaptiveControl):
         self._set_attr("text", value)
 
     # icon
+
     @property
     def icon(self):
         return self._get_attr("icon")
@@ -184,6 +187,7 @@ class OutlinedButton(ConstrainedControl, AdaptiveControl):
         self._set_attr("icon", value)
 
     # icon_color
+
     @property
     def icon_color(self):
         return self._get_attr("iconColor")
@@ -193,6 +197,7 @@ class OutlinedButton(ConstrainedControl, AdaptiveControl):
         self._set_attr("iconColor", value)
 
     # style
+
     @property
     def style(self) -> Optional[ButtonStyle]:
         return self.__style
@@ -202,6 +207,7 @@ class OutlinedButton(ConstrainedControl, AdaptiveControl):
         self.__style = value
 
     # url
+
     @property
     def url(self):
         return self._get_attr("url")
@@ -211,6 +217,7 @@ class OutlinedButton(ConstrainedControl, AdaptiveControl):
         self._set_attr("url", value)
 
     # url_target
+
     @property
     def url_target(self) -> Optional[UrlTarget]:
         return self.__url_target
@@ -223,6 +230,7 @@ class OutlinedButton(ConstrainedControl, AdaptiveControl):
         )
 
     # on_click
+
     @property
     def on_click(self):
         return self._get_event_handler("click")
@@ -232,6 +240,7 @@ class OutlinedButton(ConstrainedControl, AdaptiveControl):
         self._add_event_handler("click", handler)
 
     # on_long_press
+
     @property
     def on_long_press(self):
         return self._get_event_handler("long_press")
@@ -242,6 +251,7 @@ class OutlinedButton(ConstrainedControl, AdaptiveControl):
         self._set_attr("onLongPress", True if handler is not None else None)
 
     # content
+
     @property
     def content(self) -> Optional[Control]:
         return self.__content
@@ -251,6 +261,7 @@ class OutlinedButton(ConstrainedControl, AdaptiveControl):
         self.__content = value
 
     # autofocus
+
     @property
     def autofocus(self) -> Optional[bool]:
         return self._get_attr("autofocus", data_type="bool", def_value=False)
@@ -260,6 +271,7 @@ class OutlinedButton(ConstrainedControl, AdaptiveControl):
         self._set_attr("autofocus", value)
 
     # clip_behavior
+
     @property
     def clip_behavior(self) -> Optional[ClipBehavior]:
         return self._get_attr("clipBehavior")
@@ -271,6 +283,7 @@ class OutlinedButton(ConstrainedControl, AdaptiveControl):
         )
 
     # on_hover
+
     @property
     def on_hover(self):
         return self._get_event_handler("hover")
@@ -284,6 +297,7 @@ class OutlinedButton(ConstrainedControl, AdaptiveControl):
             self._set_attr("onHover", None)
 
     # on_focus
+
     @property
     def on_focus(self):
         return self._get_event_handler("focus")
@@ -293,6 +307,7 @@ class OutlinedButton(ConstrainedControl, AdaptiveControl):
         self._add_event_handler("focus", handler)
 
     # on_blur
+
     @property
     def on_blur(self):
         return self._get_event_handler("blur")

--- a/sdk/python/packages/flet-core/src/flet_core/pagelet.py
+++ b/sdk/python/packages/flet-core/src/flet_core/pagelet.py
@@ -4,7 +4,7 @@ from flet_core.adaptive_control import AdaptiveControl
 from flet_core.app_bar import AppBar
 from flet_core.bottom_app_bar import BottomAppBar
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.cupertino_app_bar import CupertinoAppBar
 from flet_core.cupertino_navigation_bar import CupertinoNavigationBar
 from flet_core.floating_action_button import FloatingActionButton
@@ -15,6 +15,7 @@ from flet_core.types import (
     AnimationValue,
     FloatingActionButtonLocation,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -178,6 +179,7 @@ class Pagelet(ConstrainedControl, AdaptiveControl):
 
     # Drawer
     #
+
     def show_drawer(self, drawer: NavigationDrawer):
         self.drawer = drawer
         self.drawer.open = True
@@ -206,6 +208,7 @@ class Pagelet(ConstrainedControl, AdaptiveControl):
 
     # End_drawer
     #
+
     def show_end_drawer(self, end_drawer: NavigationDrawer):
         self.end_drawer = end_drawer
         self.end_drawer.open = True
@@ -233,6 +236,7 @@ class Pagelet(ConstrainedControl, AdaptiveControl):
         self.close_end_drawer()
 
     # appbar
+
     @property
     def appbar(self) -> Union[AppBar, CupertinoAppBar, None]:
         return self.__appbar
@@ -242,6 +246,7 @@ class Pagelet(ConstrainedControl, AdaptiveControl):
         self.__appbar = value
 
     # content
+
     @property
     def content(self) -> Optional[Control]:
         return self.__content
@@ -251,6 +256,7 @@ class Pagelet(ConstrainedControl, AdaptiveControl):
         self.__content = value
 
     # bgcolor
+
     @property
     def bgcolor(self):
         return self._get_attr("bgcolor")
@@ -260,6 +266,7 @@ class Pagelet(ConstrainedControl, AdaptiveControl):
         self._set_attr("bgcolor", value)
 
     # bottom_appbar
+
     @property
     def bottom_appbar(self) -> Optional[BottomAppBar]:
         return self.__bottom_appbar
@@ -269,6 +276,7 @@ class Pagelet(ConstrainedControl, AdaptiveControl):
         self.__bottom_appbar = value
 
     # navigation_bar
+
     @property
     def navigation_bar(self) -> Union[NavigationBar, CupertinoNavigationBar, None]:
         return self.__navigation_bar
@@ -281,6 +289,7 @@ class Pagelet(ConstrainedControl, AdaptiveControl):
         self.__navigation_bar = value
 
     # bottom_sheet
+
     @property
     def bottom_sheet(self) -> Optional[Control]:
         return self.__bottom_sheet
@@ -293,6 +302,7 @@ class Pagelet(ConstrainedControl, AdaptiveControl):
         self.__bottom_sheet = value
 
     # drawer
+
     @property
     def drawer(self) -> Optional[NavigationDrawer]:
         return self.__drawer
@@ -302,6 +312,7 @@ class Pagelet(ConstrainedControl, AdaptiveControl):
         self.__drawer = value
 
     # end_drawer
+
     @property
     def end_drawer(self) -> Optional[NavigationDrawer]:
         return self.__end_drawer
@@ -311,6 +322,7 @@ class Pagelet(ConstrainedControl, AdaptiveControl):
         self.__end_drawer = value
 
     # floating_action_button
+
     @property
     def floating_action_button(self) -> Optional[FloatingActionButton]:
         return self.__floating_action_button
@@ -320,6 +332,7 @@ class Pagelet(ConstrainedControl, AdaptiveControl):
         self.__floating_action_button = value
 
     # floating_action_button_location
+
     @property
     def floating_action_button_location(
         self,

--- a/sdk/python/packages/flet-core/src/flet_core/plotly_chart.py
+++ b/sdk/python/packages/flet-core/src/flet_core/plotly_chart.py
@@ -4,16 +4,16 @@ from typing import Any, Optional, Union
 
 from flet_core import alignment
 from flet_core.container import Container
-from flet_core.control import OptionalNumber
 from flet_core.image import Image
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
+    ImageFit,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
-    ImageFit,
 )
 
 try:
@@ -128,6 +128,7 @@ class PlotlyChart(Container):
             self.__img.src = svg
 
     # original_size
+
     @property
     def original_size(self):
         return self.__original_size
@@ -137,6 +138,7 @@ class PlotlyChart(Container):
         self.__original_size = value
 
     # isolated
+
     @property
     def isolated(self):
         return self.__isolated
@@ -146,6 +148,7 @@ class PlotlyChart(Container):
         self.__isolated = value
 
     # figure
+
     @property
     def figure(self):
         return self.__figure

--- a/sdk/python/packages/flet-core/src/flet_core/popup_menu_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/popup_menu_button.py
@@ -4,13 +4,14 @@ from typing import Any, List, Optional, Union
 
 from flet_core.buttons import OutlinedBorder
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     ClipBehavior,
     MouseCursor,
     OffsetValue,
+    OptionalNumber,
     PaddingValue,
     ResponsiveNumber,
     RotateValue,
@@ -64,6 +65,7 @@ class PopupMenuItem(Control):
         return children
 
     # checked
+
     @property
     def checked(self) -> Optional[bool]:
         return self._get_attr("checked", data_type="bool")
@@ -73,6 +75,7 @@ class PopupMenuItem(Control):
         self._set_attr("checked", value)
 
     # mouse_cursor
+
     @property
     def mouse_cursor(self) -> Optional[MouseCursor]:
         return self._get_attr("mouseCursor")
@@ -84,6 +87,7 @@ class PopupMenuItem(Control):
         )
 
     # icon
+
     @property
     def icon(self) -> Optional[str]:
         return self._get_attr("icon")
@@ -93,6 +97,7 @@ class PopupMenuItem(Control):
         self._set_attr("icon", value)
 
     # text
+
     @property
     def text(self) -> Optional[str]:
         return self._get_attr("text")
@@ -102,6 +107,7 @@ class PopupMenuItem(Control):
         self._set_attr("text", value)
 
     # height
+
     @property
     def height(self) -> OptionalNumber:
         return self._get_attr("height", data_type="float", def_value=48)
@@ -111,6 +117,7 @@ class PopupMenuItem(Control):
         self._set_attr("height", value)
 
     # padding
+
     @property
     def padding(self) -> PaddingValue:
         return self.__padding
@@ -120,6 +127,7 @@ class PopupMenuItem(Control):
         self.__padding = value
 
     # content
+
     @property
     def content(self) -> Optional[Control]:
         return self.__content
@@ -129,6 +137,7 @@ class PopupMenuItem(Control):
         self.__content = value
 
     # on_click
+
     @property
     def on_click(self):
         return self._get_event_handler("click")
@@ -299,6 +308,7 @@ class PopupMenuButton(ConstrainedControl):
         self._set_attr_json("padding", self.__padding)
 
     # items
+
     @property
     def items(self) -> Optional[List[PopupMenuItem]]:
         return self.__items
@@ -308,6 +318,7 @@ class PopupMenuButton(ConstrainedControl):
         self.__items = value if value is not None else []
 
     # shape
+
     @property
     def shape(self) -> Optional[OutlinedBorder]:
         return self.__shape
@@ -317,6 +328,7 @@ class PopupMenuButton(ConstrainedControl):
         self.__shape = value
 
     # padding
+
     @property
     def padding(self) -> PaddingValue:
         return self.__padding
@@ -326,6 +338,7 @@ class PopupMenuButton(ConstrainedControl):
         self.__padding = value
 
     # icon
+
     @property
     def icon(self) -> Optional[str]:
         return self._get_attr("icon")
@@ -335,6 +348,7 @@ class PopupMenuButton(ConstrainedControl):
         self._set_attr("icon", value)
 
     # icon_color
+
     @property
     def icon_color(self) -> Optional[str]:
         return self._get_attr("iconColor")
@@ -344,6 +358,7 @@ class PopupMenuButton(ConstrainedControl):
         self._set_attr("iconColor", value)
 
     # bgcolor
+
     @property
     def bgcolor(self) -> Optional[str]:
         return self._get_attr("bgcolor")
@@ -353,6 +368,7 @@ class PopupMenuButton(ConstrainedControl):
         self._set_attr("bgcolor", value)
 
     # shadow_color
+
     @property
     def shadow_color(self) -> Optional[str]:
         return self._get_attr("shadowColor")
@@ -362,6 +378,7 @@ class PopupMenuButton(ConstrainedControl):
         self._set_attr("shadowColor", value)
 
     # surface_tint_color
+
     @property
     def surface_tint_color(self) -> Optional[str]:
         return self._get_attr("surfaceTintColor")
@@ -371,6 +388,7 @@ class PopupMenuButton(ConstrainedControl):
         self._set_attr("surfaceTintColor", value)
 
     # icon_size
+
     @property
     def icon_size(self) -> OptionalNumber:
         return self._get_attr("iconSize", data_type="float")
@@ -380,6 +398,7 @@ class PopupMenuButton(ConstrainedControl):
         self._set_attr("iconSize", value)
 
     # enable_feedback
+
     @property
     def enable_feedback(self) -> Optional[bool]:
         return self._get_attr("enableFeedback", data_type="bool", def_value=True)
@@ -389,6 +408,7 @@ class PopupMenuButton(ConstrainedControl):
         self._set_attr("enableFeedback", value)
 
     # elevation
+
     @property
     def elevation(self) -> OptionalNumber:
         return self._get_attr("elevation", data_type="float", def_value=8)
@@ -398,6 +418,7 @@ class PopupMenuButton(ConstrainedControl):
         self._set_attr("elevation", value)
 
     # splash_radius
+
     @property
     def splash_radius(self) -> OptionalNumber:
         return self._get_attr("splashRadius", data_type="float")
@@ -407,6 +428,7 @@ class PopupMenuButton(ConstrainedControl):
         self._set_attr("splashRadius", value)
 
     # content
+
     @property
     def content(self) -> Optional[Control]:
         return self.__content
@@ -416,6 +438,7 @@ class PopupMenuButton(ConstrainedControl):
         self.__content = value
 
     # menu_position
+
     @property
     def menu_position(self) -> PopupMenuPosition:
         return self.__menu_position
@@ -429,6 +452,7 @@ class PopupMenuButton(ConstrainedControl):
         )
 
     # clip_behavior
+
     @property
     def clip_behavior(self) -> ClipBehavior:
         return self.__clip_behavior
@@ -442,6 +466,7 @@ class PopupMenuButton(ConstrainedControl):
         )
 
     # on_cancel
+
     @property
     def on_cancel(self):
         return self._get_event_handler("cancel")
@@ -451,6 +476,7 @@ class PopupMenuButton(ConstrainedControl):
         self._add_event_handler("cancel", handler)
 
     # on_cancelled
+
     @property
     def on_cancelled(self):
         warnings.warn(
@@ -473,6 +499,7 @@ class PopupMenuButton(ConstrainedControl):
             )
 
     # on_open
+
     @property
     def on_open(self):
         return self._get_event_handler("open")

--- a/sdk/python/packages/flet-core/src/flet_core/progress_bar.py
+++ b/sdk/python/packages/flet-core/src/flet_core/progress_bar.py
@@ -1,12 +1,12 @@
 from typing import Any, Optional, Union
 
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import OptionalNumber
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     BorderRadiusValue,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -135,6 +135,7 @@ class ProgressBar(ConstrainedControl):
         self._set_attr_json("borderRadius", self.__border_radius)
 
     # value
+
     @property
     def value(self) -> OptionalNumber:
         return self._get_attr("value")
@@ -144,6 +145,7 @@ class ProgressBar(ConstrainedControl):
         self._set_attr("value", value)
 
     # bar_height
+
     @property
     def bar_height(self) -> OptionalNumber:
         return self._get_attr("barHeight")
@@ -153,6 +155,7 @@ class ProgressBar(ConstrainedControl):
         self._set_attr("barHeight", value)
 
     # semantics_value
+
     @property
     def semantics_value(self) -> OptionalNumber:
         return self._get_attr("semanticsValue")
@@ -162,6 +165,7 @@ class ProgressBar(ConstrainedControl):
         self._set_attr("semanticsValue", value)
 
     # color
+
     @property
     def color(self):
         return self._get_attr("color")
@@ -171,6 +175,7 @@ class ProgressBar(ConstrainedControl):
         self._set_attr("color", value)
 
     # semantics_label
+
     @property
     def semantics_label(self):
         return self._get_attr("semanticsLabel")
@@ -180,6 +185,7 @@ class ProgressBar(ConstrainedControl):
         self._set_attr("semanticsLabel", value)
 
     # bgcolor
+
     @property
     def bgcolor(self):
         return self._get_attr("bgcolor")
@@ -189,6 +195,7 @@ class ProgressBar(ConstrainedControl):
         self._set_attr("bgcolor", value)
 
     # border_radius
+
     @property
     def border_radius(self) -> BorderRadiusValue:
         return self.__border_radius

--- a/sdk/python/packages/flet-core/src/flet_core/progress_ring.py
+++ b/sdk/python/packages/flet-core/src/flet_core/progress_ring.py
@@ -2,11 +2,11 @@ from enum import Enum
 from typing import Any, Optional, Union
 
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import OptionalNumber
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -141,6 +141,7 @@ class ProgressRing(ConstrainedControl):
         return "progressring"
 
     # value
+
     @property
     def value(self) -> OptionalNumber:
         return self._get_attr("value")
@@ -150,6 +151,7 @@ class ProgressRing(ConstrainedControl):
         self._set_attr("value", value)
 
     # stroke_width
+
     @property
     def stroke_width(self) -> OptionalNumber:
         return self._get_attr("strokeWidth")
@@ -159,6 +161,7 @@ class ProgressRing(ConstrainedControl):
         self._set_attr("strokeWidth", value)
 
     # stroke_align
+
     @property
     def stroke_align(self) -> OptionalNumber:
         return self._get_attr("strokeAlign", data_type="float", def_value=0.0)
@@ -168,6 +171,7 @@ class ProgressRing(ConstrainedControl):
         self._set_attr("strokeAlign", value)
 
     # stroke_cap
+
     @property
     def stroke_cap(self) -> OptionalNumber:
         return self.__stroke_cap
@@ -180,6 +184,7 @@ class ProgressRing(ConstrainedControl):
         )
 
     # color
+
     @property
     def color(self):
         return self._get_attr("color")
@@ -189,6 +194,7 @@ class ProgressRing(ConstrainedControl):
         self._set_attr("color", value)
 
     # bgcolor
+
     @property
     def bgcolor(self):
         return self._get_attr("bgcolor")

--- a/sdk/python/packages/flet-core/src/flet_core/radio.py
+++ b/sdk/python/packages/flet-core/src/flet_core/radio.py
@@ -2,7 +2,6 @@ from typing import Any, Dict, Optional, Union
 
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import OptionalNumber
 from flet_core.ref import Ref
 from flet_core.text_style import TextStyle
 from flet_core.theme import ThemeVisualDensity
@@ -12,6 +11,7 @@ from flet_core.types import (
     MaterialState,
     MouseCursor,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -164,6 +164,7 @@ class Radio(ConstrainedControl, AdaptiveControl):
             self._set_attr_json("labelStyle", self.__label_style)
 
     # value
+
     @property
     def value(self) -> Optional[str]:
         return self._get_attr("value", def_value="")
@@ -173,6 +174,7 @@ class Radio(ConstrainedControl, AdaptiveControl):
         self._set_attr("value", value)
 
     # active_color
+
     @property
     def active_color(self) -> Optional[str]:
         return self._get_attr("activeColor")
@@ -182,6 +184,7 @@ class Radio(ConstrainedControl, AdaptiveControl):
         self._set_attr("activeColor", value)
 
     # focus_color
+
     @property
     def focus_color(self) -> Optional[str]:
         return self._get_attr("focusColor")
@@ -191,6 +194,7 @@ class Radio(ConstrainedControl, AdaptiveControl):
         self._set_attr("focusColor", value)
 
     # splash_radius
+
     @property
     def splash_radius(self) -> OptionalNumber:
         return self._get_attr("splashRadius", data_type="float")
@@ -200,6 +204,7 @@ class Radio(ConstrainedControl, AdaptiveControl):
         self._set_attr("splashRadius", value)
 
     # toggleable
+
     @property
     def toggleable(self) -> Optional[bool]:
         return self._get_attr("toggleable", data_type="bool", def_value=False)
@@ -209,6 +214,7 @@ class Radio(ConstrainedControl, AdaptiveControl):
         self._set_attr("toggleable", value)
 
     # visual_density
+
     @property
     def visual_density(self) -> Optional[ThemeVisualDensity]:
         return self.__visual_density
@@ -222,6 +228,7 @@ class Radio(ConstrainedControl, AdaptiveControl):
         )
 
     # label
+
     @property
     def label(self):
         return self._get_attr("label")
@@ -231,6 +238,7 @@ class Radio(ConstrainedControl, AdaptiveControl):
         self._set_attr("label", value)
 
     # label_position
+
     @property
     def label_position(self) -> Optional[LabelPosition]:
         return self.__label_position
@@ -243,6 +251,7 @@ class Radio(ConstrainedControl, AdaptiveControl):
         )
 
     # mouse_cursor
+
     @property
     def mouse_cursor(self) -> Optional[MouseCursor]:
         return self.__mouse_cursor
@@ -255,6 +264,7 @@ class Radio(ConstrainedControl, AdaptiveControl):
         )
 
     # label_style
+
     @property
     def label_style(self) -> Optional[TextStyle]:
         return self.__label_style
@@ -264,6 +274,7 @@ class Radio(ConstrainedControl, AdaptiveControl):
         self.__label_style = value
 
     # fill_color
+
     @property
     def fill_color(self) -> Union[None, str, Dict[MaterialState, str]]:
         return self.__fill_color
@@ -273,6 +284,7 @@ class Radio(ConstrainedControl, AdaptiveControl):
         self.__fill_color = value
 
     # overlay_color
+
     @property
     def overlay_color(self) -> Union[None, str, Dict[MaterialState, str]]:
         return self.__overlay_color
@@ -282,6 +294,7 @@ class Radio(ConstrainedControl, AdaptiveControl):
         self.__overlay_color = value
 
     # on_focus
+
     @property
     def on_focus(self):
         return self._get_event_handler("focus")
@@ -291,6 +304,7 @@ class Radio(ConstrainedControl, AdaptiveControl):
         self._add_event_handler("focus", handler)
 
     # on_blur
+
     @property
     def on_blur(self):
         return self._get_event_handler("blur")
@@ -300,6 +314,7 @@ class Radio(ConstrainedControl, AdaptiveControl):
         self._add_event_handler("blur", handler)
 
     # autofocus
+
     @property
     def autofocus(self) -> Optional[bool]:
         return self._get_attr("autofocus", data_type="bool", def_value=False)

--- a/sdk/python/packages/flet-core/src/flet_core/radio_group.py
+++ b/sdk/python/packages/flet-core/src/flet_core/radio_group.py
@@ -1,7 +1,8 @@
 from typing import Any, Optional
 
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
+from flet_core.types import OptionalNumber
 
 
 class RadioGroup(Control):
@@ -72,6 +73,7 @@ class RadioGroup(Control):
         return [self.__content]
 
     # value
+
     @property
     def value(self) -> Optional[str]:
         return self._get_attr("value")
@@ -81,6 +83,7 @@ class RadioGroup(Control):
         self._set_attr("value", value)
 
     # content
+
     @property
     def content(self) -> Optional[Control]:
         return self.__content
@@ -90,6 +93,7 @@ class RadioGroup(Control):
         self.__content = value
 
     # on_change
+
     @property
     def on_change(self):
         return self._get_event_handler("change")

--- a/sdk/python/packages/flet-core/src/flet_core/range_slider.py
+++ b/sdk/python/packages/flet-core/src/flet_core/range_slider.py
@@ -1,12 +1,12 @@
 from typing import Any, Dict, Optional, Union
 
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import OptionalNumber
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     MaterialState,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -172,6 +172,7 @@ class RangeSlider(ConstrainedControl):
         self._set_attr_json("overlayColor", self.__overlay_color)
 
     # start_value
+
     @property
     def start_value(self) -> float:
         return self._get_attr("startvalue")
@@ -181,6 +182,7 @@ class RangeSlider(ConstrainedControl):
         self._set_attr("startvalue", value)
 
     # end_value
+
     @property
     def end_value(self) -> float:
         return self._get_attr("endvalue")
@@ -190,6 +192,7 @@ class RangeSlider(ConstrainedControl):
         self._set_attr("endvalue", value)
 
     # label
+
     @property
     def label(self) -> str:
         return self._get_attr("label")
@@ -199,6 +202,7 @@ class RangeSlider(ConstrainedControl):
         self._set_attr("label", value)
 
     # min
+
     @property
     def min(self) -> OptionalNumber:
         return self._get_attr("min")
@@ -208,6 +212,7 @@ class RangeSlider(ConstrainedControl):
         self._set_attr("min", value)
 
     # max
+
     @property
     def max(self) -> OptionalNumber:
         return self._get_attr("max")
@@ -217,6 +222,7 @@ class RangeSlider(ConstrainedControl):
         self._set_attr("max", value)
 
     # divisions
+
     @property
     def divisions(self) -> Optional[int]:
         return self._get_attr("divisions")
@@ -226,6 +232,7 @@ class RangeSlider(ConstrainedControl):
         self._set_attr("divisions", value)
 
     # round
+
     @property
     def round(self) -> Optional[int]:
         return self._get_attr("round")
@@ -235,6 +242,7 @@ class RangeSlider(ConstrainedControl):
         self._set_attr("round", value)
 
     # active_color
+
     @property
     def active_color(self):
         return self._get_attr("activeColor")
@@ -244,6 +252,7 @@ class RangeSlider(ConstrainedControl):
         self._set_attr("activeColor", value)
 
     # inactive_color
+
     @property
     def inactive_color(self):
         return self._get_attr("inactiveColor")
@@ -253,6 +262,7 @@ class RangeSlider(ConstrainedControl):
         self._set_attr("inactiveColor", value)
 
     # overlay_color
+
     @property
     def overlay_color(self) -> Union[None, str, Dict[MaterialState, str]]:
         return self.__overlay_color
@@ -262,6 +272,7 @@ class RangeSlider(ConstrainedControl):
         self.__overlay_color = value
 
     # on_change
+
     @property
     def on_change(self):
         return self._get_event_handler("change")
@@ -271,6 +282,7 @@ class RangeSlider(ConstrainedControl):
         self._add_event_handler("change", handler)
 
     # on_change_start
+
     @property
     def on_change_start(self):
         return self._get_event_handler("change_start")
@@ -280,6 +292,7 @@ class RangeSlider(ConstrainedControl):
         self._add_event_handler("change_start", handler)
 
     # on_change_end
+
     @property
     def on_change_end(self):
         return self._get_event_handler("change_end")

--- a/sdk/python/packages/flet-core/src/flet_core/responsive_row.py
+++ b/sdk/python/packages/flet-core/src/flet_core/responsive_row.py
@@ -2,13 +2,14 @@ from typing import Any, List, Optional, Union
 
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     CrossAxisAlignment,
     MainAxisAlignment,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -156,6 +157,7 @@ class ResponsiveRow(ConstrainedControl, AdaptiveControl):
         self.clean()
 
     # horizontal_alignment
+
     @property
     def alignment(self) -> MainAxisAlignment:
         return self.__alignment
@@ -168,6 +170,7 @@ class ResponsiveRow(ConstrainedControl, AdaptiveControl):
         )
 
     # vertical_alignment
+
     @property
     def vertical_alignment(self) -> CrossAxisAlignment:
         return self.__vertical_alignment
@@ -181,6 +184,7 @@ class ResponsiveRow(ConstrainedControl, AdaptiveControl):
         )
 
     # columns
+
     @property
     def columns(self) -> Optional[ResponsiveNumber]:
         return self.__columns
@@ -190,6 +194,7 @@ class ResponsiveRow(ConstrainedControl, AdaptiveControl):
         self.__columns = value
 
     # spacing
+
     @property
     def spacing(self) -> Optional[ResponsiveNumber]:
         return self.__spacing
@@ -199,6 +204,7 @@ class ResponsiveRow(ConstrainedControl, AdaptiveControl):
         self.__spacing = value
 
     # run_spacing
+
     @property
     def run_spacing(self) -> Optional[ResponsiveNumber]:
         return self.__run_spacing
@@ -208,6 +214,7 @@ class ResponsiveRow(ConstrainedControl, AdaptiveControl):
         self.__run_spacing = value
 
     # controls
+
     @property
     def controls(self):
         return self.__controls

--- a/sdk/python/packages/flet-core/src/flet_core/rive.py
+++ b/sdk/python/packages/flet-core/src/flet_core/rive.py
@@ -2,15 +2,16 @@ from typing import Any, Optional, Union
 
 from flet_core.alignment import Alignment
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import OptionalNumber, Control
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
+    ImageFit,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
-    ImageFit,
 )
 
 
@@ -117,6 +118,7 @@ class Rive(ConstrainedControl):
         return []
 
     # src
+
     @property
     def src(self) -> Optional[str]:
         return self._get_attr("src")
@@ -128,6 +130,7 @@ class Rive(ConstrainedControl):
         self._set_attr("src", value)
 
     # alignment
+
     @property
     def alignment(self) -> Optional[Alignment]:
         return self.__alignment
@@ -137,6 +140,7 @@ class Rive(ConstrainedControl):
         self.__alignment = value
 
     # artboard
+
     @property
     def artboard(self):
         return self._get_attr("artBoard")
@@ -146,6 +150,7 @@ class Rive(ConstrainedControl):
         self._set_attr("artBoard", value)
 
     # enable_antialiasing
+
     @property
     def enable_antialiasing(self) -> Optional[bool]:
         return self._get_attr("enableAntiAliasing", def_value=True, data_type="bool")
@@ -155,6 +160,7 @@ class Rive(ConstrainedControl):
         self._set_attr("enableAntiAliasing", value)
 
     # placeholder
+
     @property
     def placeholder(self) -> Optional[Control]:
         return self.__placeholder
@@ -164,6 +170,7 @@ class Rive(ConstrainedControl):
         self.__placeholder = value
 
     # use_artboard_size
+
     @property
     def use_artboard_size(self) -> Optional[bool]:
         return self._get_attr("useArtBoardSize", def_value=False, data_type="bool")
@@ -173,6 +180,7 @@ class Rive(ConstrainedControl):
         self._set_attr("useArtBoardSize", value)
 
     # fit
+
     @property
     def fit(self) -> Optional[ImageFit]:
         return self.__fit

--- a/sdk/python/packages/flet-core/src/flet_core/row.py
+++ b/sdk/python/packages/flet-core/src/flet_core/row.py
@@ -2,7 +2,7 @@ from typing import Any, List, Optional, Union
 
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.scrollable_control import ScrollableControl
 from flet_core.types import (
@@ -10,6 +10,7 @@ from flet_core.types import (
     CrossAxisAlignment,
     MainAxisAlignment,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -176,6 +177,7 @@ class Row(ConstrainedControl, ScrollableControl, AdaptiveControl):
         self.clean()
 
     # tight
+
     @property
     def tight(self) -> Optional[bool]:
         return self._get_attr("tight", data_type="bool", def_value=False)
@@ -185,6 +187,7 @@ class Row(ConstrainedControl, ScrollableControl, AdaptiveControl):
         self._set_attr("tight", value)
 
     # horizontal_alignment
+
     @property
     def alignment(self) -> MainAxisAlignment:
         return self.__alignment
@@ -197,6 +200,7 @@ class Row(ConstrainedControl, ScrollableControl, AdaptiveControl):
         )
 
     # vertical_alignment
+
     @property
     def vertical_alignment(self) -> CrossAxisAlignment:
         return self.__vertical_alignment
@@ -210,6 +214,7 @@ class Row(ConstrainedControl, ScrollableControl, AdaptiveControl):
         )
 
     # spacing
+
     @property
     def spacing(self) -> OptionalNumber:
         return self._get_attr("spacing")
@@ -219,6 +224,7 @@ class Row(ConstrainedControl, ScrollableControl, AdaptiveControl):
         self._set_attr("spacing", value)
 
     # wrap
+
     @property
     def wrap(self) -> Optional[bool]:
         return self._get_attr("wrap", data_type="bool", def_value=False)
@@ -228,6 +234,7 @@ class Row(ConstrainedControl, ScrollableControl, AdaptiveControl):
         self._set_attr("wrap", value)
 
     # run_spacing
+
     @property
     def run_spacing(self) -> OptionalNumber:
         return self._get_attr("runSpacing")
@@ -237,6 +244,7 @@ class Row(ConstrainedControl, ScrollableControl, AdaptiveControl):
         self._set_attr("runSpacing", value)
 
     # controls
+
     @property
     def controls(self):
         return self.__controls

--- a/sdk/python/packages/flet-core/src/flet_core/safe_area.py
+++ b/sdk/python/packages/flet-core/src/flet_core/safe_area.py
@@ -2,11 +2,12 @@ from typing import Any, Optional, Union
 
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     OffsetValue,
+    OptionalNumber,
     PaddingValue,
     ResponsiveNumber,
     RotateValue,
@@ -109,6 +110,7 @@ class SafeArea(ConstrainedControl, AdaptiveControl):
         return children
 
     # left
+
     @property
     def left(self) -> Optional[bool]:
         return self._get_attr("left", data_type="bool", def_value=True)
@@ -118,6 +120,7 @@ class SafeArea(ConstrainedControl, AdaptiveControl):
         self._set_attr("left", value)
 
     # top
+
     @property
     def top(self) -> Optional[bool]:
         return self._get_attr("top", data_type="bool", def_value=True)
@@ -127,6 +130,7 @@ class SafeArea(ConstrainedControl, AdaptiveControl):
         self._set_attr("top", value)
 
     # right
+
     @property
     def right(self) -> Optional[bool]:
         return self._get_attr("right", data_type="bool", def_value=True)
@@ -136,6 +140,7 @@ class SafeArea(ConstrainedControl, AdaptiveControl):
         self._set_attr("right", value)
 
     # bottom
+
     @property
     def bottom(self) -> Optional[bool]:
         return self._get_attr("bottom", data_type="bool", def_value=True)
@@ -145,6 +150,7 @@ class SafeArea(ConstrainedControl, AdaptiveControl):
         self._set_attr("bottom", value)
 
     # maintain_bottom_view_padding
+
     @property
     def maintain_bottom_view_padding(self) -> Optional[bool]:
         return self._get_attr(
@@ -156,6 +162,7 @@ class SafeArea(ConstrainedControl, AdaptiveControl):
         self._set_attr("maintainBottomViewPadding", value)
 
     # content
+
     @property
     def content(self) -> Optional[Control]:
         return self.__content
@@ -165,6 +172,7 @@ class SafeArea(ConstrainedControl, AdaptiveControl):
         self.__content = value
 
     # minimum
+
     @property
     def minimum(self) -> PaddingValue:
         return self.__minimum

--- a/sdk/python/packages/flet-core/src/flet_core/scrollable_control.py
+++ b/sdk/python/packages/flet-core/src/flet_core/scrollable_control.py
@@ -3,10 +3,10 @@ import time
 from typing import Any, Optional
 
 from flet_core.animation import AnimationCurve
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.control_event import ControlEvent
 from flet_core.event_handler import EventHandler
-from flet_core.types import ScrollMode
+from flet_core.types import OptionalNumber, ScrollMode
 from flet_core.utils import deprecated
 
 
@@ -70,6 +70,7 @@ class ScrollableControl(Control):
         self.scroll_to(offset, delta, key, duration, curve)
 
     # scroll
+
     @property
     def scroll(self) -> Optional[ScrollMode]:
         return self.__scroll
@@ -79,14 +80,15 @@ class ScrollableControl(Control):
         self.__scroll = value
         self._set_attr(
             "scroll",
-            value.value
-            if isinstance(value, ScrollMode)
-            else "auto" if value is True
-            else None if value is False
-            else value,
+            (
+                value.value
+                if isinstance(value, ScrollMode)
+                else "auto" if value is True else None if value is False else value
+            ),
         )
 
     # auto_scroll
+
     @property
     def auto_scroll(self) -> Optional[str]:
         return self._get_attr("autoScroll", data_type="bool", def_value=False)
@@ -96,6 +98,7 @@ class ScrollableControl(Control):
         self._set_attr("autoScroll", value)
 
     # reverse
+
     @property
     def reverse(self) -> Optional[bool]:
         return self._get_attr("reverse", data_type="bool", def_value=False)
@@ -105,6 +108,7 @@ class ScrollableControl(Control):
         self._set_attr("reverse", value)
 
     # on_scroll_interval
+
     @property
     def on_scroll_interval(self) -> OptionalNumber:
         return self._get_attr("onScrollInterval")
@@ -114,6 +118,7 @@ class ScrollableControl(Control):
         self._set_attr("onScrollInterval", value)
 
     # on_scroll
+
     @property
     def on_scroll(self):
         return self.__on_scroll

--- a/sdk/python/packages/flet-core/src/flet_core/search_bar.py
+++ b/sdk/python/packages/flet-core/src/flet_core/search_bar.py
@@ -4,14 +4,15 @@ from typing import Any, Dict, List, Optional, Union
 from flet_core.border import BorderSide
 from flet_core.buttons import OutlinedBorder
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.text_style import TextStyle
-from flet_core.textfield import TextCapitalization, KeyboardType
+from flet_core.textfield import KeyboardType, TextCapitalization
 from flet_core.types import (
     AnimationValue,
     MaterialState,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -208,6 +209,7 @@ class SearchBar(ConstrainedControl):
         self.close_view(text=text)
 
     # bar_leading
+
     @property
     def bar_leading(self) -> Optional[Control]:
         return self.__bar_leading
@@ -217,6 +219,7 @@ class SearchBar(ConstrainedControl):
         self.__bar_leading = value
 
     # bar_trailing
+
     @property
     def bar_trailing(self) -> Optional[List[Control]]:
         return self.__bar_trailing
@@ -226,6 +229,7 @@ class SearchBar(ConstrainedControl):
         self.__bar_trailing = value
 
     # bar_bgcolor
+
     @property
     def bar_bgcolor(self) -> Union[None, str, Dict[MaterialState, str]]:
         return self.__bar_bgcolor
@@ -235,6 +239,7 @@ class SearchBar(ConstrainedControl):
         self.__bar_bgcolor = value
 
     # bar_overlay_color
+
     @property
     def bar_overlay_color(self) -> Union[None, str, Dict[MaterialState, str]]:
         return self.__bar_overlay_color
@@ -244,6 +249,7 @@ class SearchBar(ConstrainedControl):
         self.__bar_overlay_color = value
 
     # view_leading
+
     @property
     def view_leading(self) -> Optional[Control]:
         return self.__view_leading
@@ -253,6 +259,7 @@ class SearchBar(ConstrainedControl):
         self.__view_leading = value
 
     # view_surface_tint_color
+
     @property
     def view_surface_tint_color(self) -> Optional[str]:
         return self._get_attr("viewSurfaceTintColor")
@@ -262,6 +269,7 @@ class SearchBar(ConstrainedControl):
         self._set_attr("viewSurfaceTintColor", value)
 
     # autofocus
+
     @property
     def autofocus(self) -> Optional[bool]:
         return self._get_attr("autofocus", data_type="bool", def_value=False)
@@ -271,6 +279,7 @@ class SearchBar(ConstrainedControl):
         self._set_attr("autofocus", value)
 
     # view_trailing
+
     @property
     def view_trailing(self) -> Optional[List[Control]]:
         return self.__view_trailing
@@ -280,6 +289,7 @@ class SearchBar(ConstrainedControl):
         self.__view_trailing = value
 
     # view_elevation
+
     @property
     def view_elevation(self) -> OptionalNumber:
         return self._get_attr("viewElevation")
@@ -289,6 +299,7 @@ class SearchBar(ConstrainedControl):
         self._set_attr("viewElevation", value)
 
     # view_bgcolor
+
     @property
     def view_bgcolor(self) -> Optional[str]:
         return self._get_attr("viewBgcolor")
@@ -298,6 +309,7 @@ class SearchBar(ConstrainedControl):
         self._set_attr("viewBgcolor", value)
 
     # divider_color
+
     @property
     def divider_color(self) -> Optional[str]:
         return self._get_attr("dividerColor")
@@ -307,6 +319,7 @@ class SearchBar(ConstrainedControl):
         self._set_attr("dividerColor", value)
 
     # bar_hint_text
+
     @property
     def bar_hint_text(self) -> Optional[str]:
         return self._get_attr("barHintText")
@@ -316,6 +329,7 @@ class SearchBar(ConstrainedControl):
         self._set_attr("barHintText", value)
 
     # view_hint_text
+
     @property
     def view_hint_text(self) -> Optional[str]:
         return self._get_attr("viewHintText")
@@ -325,6 +339,7 @@ class SearchBar(ConstrainedControl):
         self._set_attr("viewHintText", value)
 
     # view_shape
+
     @property
     def view_shape(self) -> Optional[OutlinedBorder]:
         return self.__view_shape
@@ -334,6 +349,7 @@ class SearchBar(ConstrainedControl):
         self.__view_shape = value
 
     # view_side
+
     @property
     def view_side(self) -> Optional[BorderSide]:
         return self.__view_side
@@ -343,6 +359,7 @@ class SearchBar(ConstrainedControl):
         self.__view_side = value
 
     # full_screen
+
     @property
     def full_screen(self) -> Optional[bool]:
         return self._get_attr("fullScreen", data_type="bool", def_value=False)
@@ -352,6 +369,7 @@ class SearchBar(ConstrainedControl):
         self._set_attr("fullScreen", value)
 
     # capitalization
+
     @property
     def capitalization(self) -> TextCapitalization:
         return self.__capitalization
@@ -365,6 +383,7 @@ class SearchBar(ConstrainedControl):
         )
 
     # keyboard_type
+
     @property
     def keyboard_type(self) -> KeyboardType:
         return self.__keyboard_type
@@ -378,6 +397,7 @@ class SearchBar(ConstrainedControl):
         )
 
     # view_header_text_style
+
     @property
     def view_header_text_style(self):
         return self.__view_header_text_style
@@ -387,6 +407,7 @@ class SearchBar(ConstrainedControl):
         self.__view_header_text_style = value
 
     # view_hint_text_style
+
     @property
     def view_hint_text_style(self):
         return self.__view_hint_text_style
@@ -396,6 +417,7 @@ class SearchBar(ConstrainedControl):
         self.__view_hint_text_style = value
 
     # controls
+
     @property
     def controls(self):
         return self.__controls
@@ -405,6 +427,7 @@ class SearchBar(ConstrainedControl):
         self.__controls = value if value is not None else []
 
     # value
+
     @property
     def value(self) -> Optional[str]:
         return self._get_attr("value", def_value="")
@@ -414,6 +437,7 @@ class SearchBar(ConstrainedControl):
         self._set_attr("value", value)
 
     # on_change
+
     @property
     def on_change(self):
         return self._get_event_handler("change")
@@ -424,6 +448,7 @@ class SearchBar(ConstrainedControl):
         self._set_attr("onchange", True if handler is not None else None)
 
     # on_tap
+
     @property
     def on_tap(self):
         return self._get_event_handler("tap")
@@ -434,6 +459,7 @@ class SearchBar(ConstrainedControl):
         self._set_attr("ontap", True if handler is not None else None)
 
     # on_submit
+
     @property
     def on_submit(self):
         return self._get_event_handler("submit")

--- a/sdk/python/packages/flet-core/src/flet_core/segmented_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/segmented_button.py
@@ -3,11 +3,12 @@ from typing import Any, List, Optional, Set, Union
 
 from flet_core.buttons import ButtonStyle
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -67,6 +68,7 @@ class Segment(Control):
         return children
 
     # label
+
     @property
     def label(self) -> Optional[Control]:
         return self.__label
@@ -76,6 +78,7 @@ class Segment(Control):
         self.__label = value
 
     # icon
+
     @property
     def icon(self) -> Optional[Control]:
         return self.__icon
@@ -85,6 +88,7 @@ class Segment(Control):
         self.__icon = value
 
     # value
+
     @property
     def value(self) -> str:
         return self._get_attr("value")
@@ -207,6 +211,7 @@ class SegmentedButton(ConstrainedControl):
         return children
 
     # style
+
     @property
     def style(self) -> Optional[ButtonStyle]:
         return self.__style
@@ -216,6 +221,7 @@ class SegmentedButton(ConstrainedControl):
         self.__style = value
 
     # on_change
+
     @property
     def on_change(self):
         return self._get_event_handler("change")
@@ -225,6 +231,7 @@ class SegmentedButton(ConstrainedControl):
         self._add_event_handler("change", handler)
 
     # segments
+
     @property
     def segments(self):
         return self.__segments
@@ -234,6 +241,7 @@ class SegmentedButton(ConstrainedControl):
         self.__segments = value if value is not None else []
 
     # allow_empty_selection
+
     @property
     def allow_empty_selection(self) -> Optional[bool]:
         return self._get_attr("allowEmptySelection", data_type="bool", def_value=False)
@@ -243,6 +251,7 @@ class SegmentedButton(ConstrainedControl):
         self._set_attr("allowEmptySelection", value)
 
     # allow_multiple_selection
+
     @property
     def allow_multiple_selection(self) -> Optional[bool]:
         return self._get_attr(
@@ -254,6 +263,7 @@ class SegmentedButton(ConstrainedControl):
         self._set_attr("allowMultipleSelection", value)
 
     # selected
+
     @property
     def selected(self) -> Optional[Set]:
         s = self._get_attr("selected")
@@ -271,6 +281,7 @@ class SegmentedButton(ConstrainedControl):
         )
 
     # show_selected_icon
+
     @property
     def show_selected_icon(self) -> Optional[bool]:
         return self._get_attr("showSelectedIcon", data_type="bool", def_value=True)
@@ -280,6 +291,7 @@ class SegmentedButton(ConstrainedControl):
         self._set_attr("showSelectedIcon", value)
 
     # selected_icon
+
     @property
     def selected_icon(self) -> Optional[Control]:
         return self.__selected_icon

--- a/sdk/python/packages/flet-core/src/flet_core/semantics.py
+++ b/sdk/python/packages/flet-core/src/flet_core/semantics.py
@@ -1,7 +1,8 @@
 from typing import Any, Optional
 
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
+from flet_core.types import OptionalNumber
 
 
 class Semantics(Control):
@@ -135,6 +136,7 @@ class Semantics(Control):
         return children
 
     # label
+
     @property
     def label(self):
         return self._get_attr("label")
@@ -144,6 +146,7 @@ class Semantics(Control):
         self._set_attr("label", value)
 
     # content
+
     @property
     def content(self) -> Optional[Control]:
         return self.__content
@@ -153,6 +156,7 @@ class Semantics(Control):
         self.__content = value
 
     # expanded
+
     @property
     def expanded(self):
         return self._get_attr("expanded")
@@ -162,6 +166,7 @@ class Semantics(Control):
         self._set_attr("expanded", value)
 
     # hidden
+
     @property
     def hidden(self):
         return self._get_attr("hidden")
@@ -171,6 +176,7 @@ class Semantics(Control):
         self._set_attr("hidden", value)
 
     # textfield
+
     @property
     def textfield(self):
         return self._get_attr("textfield")
@@ -180,6 +186,7 @@ class Semantics(Control):
         self._set_attr("textfield", value)
 
     # link
+
     @property
     def link(self):
         return self._get_attr("link")
@@ -189,6 +196,7 @@ class Semantics(Control):
         self._set_attr("link", value)
 
     # image
+
     @property
     def image(self):
         return self._get_attr("image")
@@ -198,6 +206,7 @@ class Semantics(Control):
         self._set_attr("image", value)
 
     # header
+
     @property
     def header(self):
         return self._get_attr("header")
@@ -207,6 +216,7 @@ class Semantics(Control):
         self._set_attr("header", value)
 
     # selected
+
     @property
     def selected(self):
         return self._get_attr("selected")
@@ -216,6 +226,7 @@ class Semantics(Control):
         self._set_attr("selected", value)
 
     # button
+
     @property
     def button(self):
         return self._get_attr("button")
@@ -225,6 +236,7 @@ class Semantics(Control):
         self._set_attr("button", value)
 
     # obscured
+
     @property
     def obscured(self):
         return self._get_attr("obscured")
@@ -234,6 +246,7 @@ class Semantics(Control):
         self._set_attr("obscured", value)
 
     # multiline
+
     @property
     def multiline(self):
         return self._get_attr("multiline")
@@ -243,6 +256,7 @@ class Semantics(Control):
         self._set_attr("multiline", value)
 
     # focusable
+
     @property
     def focusable(self):
         return self._get_attr("focusable")
@@ -252,6 +266,7 @@ class Semantics(Control):
         self._set_attr("focusable", value)
 
     # read_only
+
     @property
     def read_only(self):
         return self._get_attr("readOnly")
@@ -261,6 +276,7 @@ class Semantics(Control):
         self._set_attr("readOnly", value)
 
     # focused
+
     @property
     def focused(self):
         return self._get_attr("focus")
@@ -270,6 +286,7 @@ class Semantics(Control):
         self._set_attr("focused", value)
 
     # slider
+
     @property
     def slider(self):
         return self._get_attr("slider")
@@ -279,6 +296,7 @@ class Semantics(Control):
         self._set_attr("slider", value)
 
     # tooltip
+
     @property
     def tooltip(self):
         return self._get_attr("tooltip")
@@ -288,6 +306,7 @@ class Semantics(Control):
         self._set_attr("tooltip", value)
 
     # toggled
+
     @property
     def toggled(self):
         return self._get_attr("toggled")
@@ -297,6 +316,7 @@ class Semantics(Control):
         self._set_attr("toggled", value)
 
     # max_value_length
+
     @property
     def max_value_length(self):
         return self._get_attr("maxValueLength")
@@ -306,6 +326,7 @@ class Semantics(Control):
         self._set_attr("maxValueLength", value)
 
     # checked
+
     @property
     def checked(self):
         return self._get_attr("checked")
@@ -315,6 +336,7 @@ class Semantics(Control):
         self._set_attr("checked", value)
 
     # value
+
     @property
     def value(self):
         return self._get_attr("value")
@@ -324,6 +346,7 @@ class Semantics(Control):
         self._set_attr("value", value)
 
     # increased_value
+
     @property
     def increased_value(self):
         return self._get_attr("increasedValue")
@@ -333,6 +356,7 @@ class Semantics(Control):
         self._set_attr("increasedValue", value)
 
     # decreased_value
+
     @property
     def decreased_value(self):
         return self._get_attr("decreasedValue")
@@ -342,6 +366,7 @@ class Semantics(Control):
         self._set_attr("decreasedValue", value)
 
     # hint_text
+
     @property
     def hint_text(self):
         return self._get_attr("hintText")
@@ -351,6 +376,7 @@ class Semantics(Control):
         self._set_attr("hintText", value)
 
     # on_long_press_hint_text
+
     @property
     def on_long_press_hint_text(self):
         return self._get_attr("onLongPressHintText")
@@ -360,6 +386,7 @@ class Semantics(Control):
         self._set_attr("onLongPressHintText", value)
 
     # on_tap_hint_text
+
     @property
     def on_tap_hint_text(self):
         return self._get_attr("onTapHintText")
@@ -369,6 +396,7 @@ class Semantics(Control):
         self._set_attr("onTapHintText", value)
 
     # container
+
     @property
     def container(self):
         return self._get_attr("container")
@@ -378,6 +406,7 @@ class Semantics(Control):
         self._set_attr("container", value)
 
     # live_region
+
     @property
     def live_region(self):
         return self._get_attr("liveRegion")
@@ -387,6 +416,7 @@ class Semantics(Control):
         self._set_attr("liveRegion", value)
 
     # on_tap
+
     @property
     def on_tap(self):
         return self._get_event_handler("tap")
@@ -397,6 +427,7 @@ class Semantics(Control):
         self._set_attr("onTap", True if handler is not None else None)
 
     # on_double_tap
+
     @property
     def on_double_tap(self):
         return self._get_event_handler("double_tap")
@@ -407,6 +438,7 @@ class Semantics(Control):
         self._set_attr("onDoubleTap", True if handler is not None else None)
 
     # on_increase
+
     @property
     def on_increase(self):
         return self._get_event_handler("increase")
@@ -417,6 +449,7 @@ class Semantics(Control):
         self._set_attr("onIncrease", True if handler is not None else None)
 
     # on_decrease
+
     @property
     def on_decrease(self):
         return self._get_event_handler("decrease")
@@ -427,6 +460,7 @@ class Semantics(Control):
         self._set_attr("onDecrease", True if handler is not None else None)
 
     # on_dismiss
+
     @property
     def on_dismiss(self):
         return self._get_event_handler("dismiss")
@@ -437,6 +471,7 @@ class Semantics(Control):
         self._set_attr("onDismiss", True if handler is not None else None)
 
     # on_scroll_left
+
     @property
     def on_scroll_left(self):
         return self._get_event_handler("scroll_left")
@@ -447,6 +482,7 @@ class Semantics(Control):
         self._set_attr("onScrollLeft", True if handler is not None else None)
 
     # on_scroll_right
+
     @property
     def on_scroll_right(self):
         return self._get_event_handler("scroll_right")
@@ -457,6 +493,7 @@ class Semantics(Control):
         self._set_attr("onScrollRight", True if handler is not None else None)
 
     # on_scroll_up
+
     @property
     def on_scroll_up(self):
         return self._get_event_handler("scroll_up")
@@ -467,6 +504,7 @@ class Semantics(Control):
         self._set_attr("onScrollUp", True if handler is not None else None)
 
     # on_scroll_down
+
     @property
     def on_scroll_down(self):
         return self._get_event_handler("scroll_down")
@@ -477,6 +515,7 @@ class Semantics(Control):
         self._set_attr("onScrollDown", True if handler is not None else None)
 
     # on_copy
+
     @property
     def on_copy(self):
         return self._get_event_handler("copy")
@@ -487,6 +526,7 @@ class Semantics(Control):
         self._set_attr("onCopy", True if handler is not None else None)
 
     # on_cut
+
     @property
     def on_cut(self):
         return self._get_event_handler("cut")
@@ -497,6 +537,7 @@ class Semantics(Control):
         self._set_attr("onCut", True if handler is not None else None)
 
     # on_paste
+
     @property
     def on_paste(self):
         return self._get_event_handler("paste")
@@ -507,6 +548,7 @@ class Semantics(Control):
         self._set_attr("onPaste", True if handler is not None else None)
 
     # on_long_press
+
     @property
     def on_long_press(self):
         return self._get_event_handler("long_press")
@@ -517,6 +559,7 @@ class Semantics(Control):
         self._set_attr("onLongPress", True if handler is not None else None)
 
     # on_move_cursor_forward_by_character
+
     @property
     def on_move_cursor_forward_by_character(self):
         return self._get_event_handler("move_cursor_forward_by_character")
@@ -529,6 +572,7 @@ class Semantics(Control):
         )
 
     # on_move_cursor_backward_by_character
+
     @property
     def on_move_cursor_backward_by_character(self):
         return self._get_event_handler("move_cursor_backward_by_character")
@@ -541,6 +585,7 @@ class Semantics(Control):
         )
 
     # on_did_gain_accessibility_focus
+
     @property
     def on_did_gain_accessibility_focus(self):
         return self._get_event_handler("did_gain_accessibility_focus")
@@ -553,6 +598,7 @@ class Semantics(Control):
         )
 
     # on_did_lose_accessibility_focus
+
     @property
     def on_did_lose_accessibility_focus(self):
         return self._get_event_handler("did_lose_accessibility_focus")

--- a/sdk/python/packages/flet-core/src/flet_core/shader_mask.py
+++ b/sdk/python/packages/flet-core/src/flet_core/shader_mask.py
@@ -1,7 +1,7 @@
 from typing import Any, Optional, Union
 
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.gradients import Gradient
 from flet_core.ref import Ref
 from flet_core.types import (
@@ -9,6 +9,7 @@ from flet_core.types import (
     BlendMode,
     BorderRadiusValue,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -139,6 +140,7 @@ class ShaderMask(ConstrainedControl):
         return children
 
     # content
+
     @property
     def content(self) -> Optional[Control]:
         return self.__content
@@ -148,6 +150,7 @@ class ShaderMask(ConstrainedControl):
         self.__content = value
 
     # blend_mode
+
     @property
     def blend_mode(self) -> Optional[BlendMode]:
         return self.__blend_mode
@@ -160,6 +163,7 @@ class ShaderMask(ConstrainedControl):
         )
 
     # shader
+
     @property
     def shader(self) -> Optional[Gradient]:
         return self.__shader
@@ -169,6 +173,7 @@ class ShaderMask(ConstrainedControl):
         self.__shader = value
 
     # border_radius
+
     @property
     def border_radius(self) -> BorderRadiusValue:
         return self.__border_radius

--- a/sdk/python/packages/flet-core/src/flet_core/shake_detector.py
+++ b/sdk/python/packages/flet-core/src/flet_core/shake_detector.py
@@ -1,7 +1,8 @@
 from typing import Any, Optional
 
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
+from flet_core.types import OptionalNumber
 
 
 class ShakeDetector(Control):
@@ -63,6 +64,7 @@ class ShakeDetector(Control):
         return "shakedetector"
 
     # minimum_shake_count
+
     @property
     def minimum_shake_count(self) -> Optional[int]:
         return self._get_attr("minimumShakeCount")
@@ -72,6 +74,7 @@ class ShakeDetector(Control):
         self._set_attr("minimumShakeCount", value)
 
     # shake_slop_time_ms
+
     @property
     def shake_slop_time_ms(self) -> Optional[int]:
         return self._get_attr("shakeSlopTimeMS")
@@ -81,6 +84,7 @@ class ShakeDetector(Control):
         self._set_attr("shakeSlopTimeMS", value)
 
     # shake_count_reset_time_ms
+
     @property
     def shake_count_reset_time_ms(self) -> Optional[int]:
         return self._get_attr("shakeCountResetTimeMs")
@@ -90,6 +94,7 @@ class ShakeDetector(Control):
         self._set_attr("shakeCountResetTimeMs", value)
 
     # shake_threshold_gravity
+
     @property
     def shake_threshold_gravity(self) -> OptionalNumber:
         return self._get_attr("shakeThresholdGravity")
@@ -99,6 +104,7 @@ class ShakeDetector(Control):
         self._set_attr("shakeThresholdGravity", value)
 
     # on_shake
+
     @property
     def on_shake(self):
         return self._get_event_handler("shake")

--- a/sdk/python/packages/flet-core/src/flet_core/slider.py
+++ b/sdk/python/packages/flet-core/src/flet_core/slider.py
@@ -3,13 +3,13 @@ from typing import Any, Dict, Optional, Union
 
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import OptionalNumber
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     MaterialState,
     MouseCursor,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -164,10 +164,12 @@ class Slider(ConstrainedControl, AdaptiveControl):
         self._set_attr_json("overlayColor", self.__overlay_color)
 
     # value
+
     @property
     def value(self) -> OptionalNumber:
         v = self._get_attr("value", data_type="float")
         # verify limits
+
         if self.min and v < self.min:
             v = self.min
         elif self.max and v > self.max:
@@ -179,6 +181,7 @@ class Slider(ConstrainedControl, AdaptiveControl):
         self._set_attr("value", value)
 
     # label
+
     @property
     def label(self) -> Optional[str]:
         return self._get_attr("label")
@@ -188,6 +191,7 @@ class Slider(ConstrainedControl, AdaptiveControl):
         self._set_attr("label", value)
 
     # interaction
+
     @property
     def interaction(self) -> Optional[SliderInteraction]:
         return self.__interaction
@@ -198,6 +202,7 @@ class Slider(ConstrainedControl, AdaptiveControl):
         self._set_enum_attr("interaction", value, SliderInteraction)
 
     # min
+
     @property
     def min(self) -> OptionalNumber:
         return self._get_attr("min")
@@ -207,6 +212,7 @@ class Slider(ConstrainedControl, AdaptiveControl):
         self._set_attr("min", value)
 
     # secondary_track_value
+
     @property
     def secondary_track_value(self) -> OptionalNumber:
         return self._get_attr("secondaryTrackValue", data_type="float")
@@ -216,6 +222,7 @@ class Slider(ConstrainedControl, AdaptiveControl):
         self._set_attr("secondaryTrackValue", value)
 
     # secondary_active_color
+
     @property
     def secondary_active_color(self) -> Optional[str]:
         return self._get_attr("secondaryActiveColor")
@@ -225,6 +232,7 @@ class Slider(ConstrainedControl, AdaptiveControl):
         self._set_attr("secondaryActiveColor", value)
 
     # mouse_cursor
+
     @property
     def mouse_cursor(self) -> Optional[MouseCursor]:
         return self._get_attr("mouseCursor")
@@ -236,6 +244,7 @@ class Slider(ConstrainedControl, AdaptiveControl):
         )
 
     # max
+
     @property
     def max(self) -> OptionalNumber:
         return self._get_attr("max")
@@ -245,6 +254,7 @@ class Slider(ConstrainedControl, AdaptiveControl):
         self._set_attr("max", value)
 
     # divisions
+
     @property
     def divisions(self) -> Optional[int]:
         return self._get_attr("divisions")
@@ -254,6 +264,7 @@ class Slider(ConstrainedControl, AdaptiveControl):
         self._set_attr("divisions", value)
 
     # round
+
     @property
     def round(self) -> Optional[int]:
         return self._get_attr("round")
@@ -263,6 +274,7 @@ class Slider(ConstrainedControl, AdaptiveControl):
         self._set_attr("round", value)
 
     # overlay_color
+
     @property
     def overlay_color(self) -> Union[None, str, Dict[MaterialState, str]]:
         return self.__overlay_color
@@ -272,6 +284,7 @@ class Slider(ConstrainedControl, AdaptiveControl):
         self.__overlay_color = value
 
     # autofocus
+
     @property
     def autofocus(self) -> Optional[bool]:
         return self._get_attr("autofocus", data_type="bool", def_value=False)
@@ -281,6 +294,7 @@ class Slider(ConstrainedControl, AdaptiveControl):
         self._set_attr("autofocus", value)
 
     # active_color
+
     @property
     def active_color(self) -> Optional[str]:
         return self._get_attr("activeColor")
@@ -290,6 +304,7 @@ class Slider(ConstrainedControl, AdaptiveControl):
         self._set_attr("activeColor", value)
 
     # inactive_color
+
     @property
     def inactive_color(self) -> Optional[str]:
         return self._get_attr("inactiveColor")
@@ -299,6 +314,7 @@ class Slider(ConstrainedControl, AdaptiveControl):
         self._set_attr("inactiveColor", value)
 
     # thumb_color
+
     @property
     def thumb_color(self) -> Optional[str]:
         return self._get_attr("thumbColor")
@@ -308,6 +324,7 @@ class Slider(ConstrainedControl, AdaptiveControl):
         self._set_attr("thumbColor", value)
 
     # on_change
+
     @property
     def on_change(self):
         return self._get_event_handler("change")
@@ -317,6 +334,7 @@ class Slider(ConstrainedControl, AdaptiveControl):
         self._add_event_handler("change", handler)
 
     # on_change_start
+
     @property
     def on_change_start(self):
         return self._get_event_handler("change_start")
@@ -326,6 +344,7 @@ class Slider(ConstrainedControl, AdaptiveControl):
         self._add_event_handler("change_start", handler)
 
     # on_change_end
+
     @property
     def on_change_end(self):
         return self._get_event_handler("change_end")
@@ -335,6 +354,7 @@ class Slider(ConstrainedControl, AdaptiveControl):
         self._add_event_handler("change_end", handler)
 
     # on_focus
+
     @property
     def on_focus(self):
         return self._get_event_handler("focus")
@@ -344,6 +364,7 @@ class Slider(ConstrainedControl, AdaptiveControl):
         self._add_event_handler("focus", handler)
 
     # on_blur
+
     @property
     def on_blur(self):
         return self._get_event_handler("blur")

--- a/sdk/python/packages/flet-core/src/flet_core/snack_bar.py
+++ b/sdk/python/packages/flet-core/src/flet_core/snack_bar.py
@@ -2,9 +2,9 @@ from enum import Enum
 from typing import Any, Optional
 
 from flet_core.buttons import OutlinedBorder
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
-from flet_core.types import MarginValue, PaddingValue, ClipBehavior
+from flet_core.types import ClipBehavior, MarginValue, OptionalNumber, PaddingValue
 
 
 class SnackBarBehavior(Enum):
@@ -134,6 +134,7 @@ class SnackBar(Control):
         self._set_attr_json("padding", self.__padding)
 
     # open
+
     @property
     def open(self) -> Optional[bool]:
         return self._get_attr("open", data_type="bool", def_value=False)
@@ -143,6 +144,7 @@ class SnackBar(Control):
         self._set_attr("open", value)
 
     # show_close_icon
+
     @property
     def show_close_icon(self) -> Optional[bool]:
         return self._get_attr("showCloseIcon", data_type="bool", def_value=False)
@@ -152,6 +154,7 @@ class SnackBar(Control):
         self._set_attr("showCloseIcon", value)
 
     # content
+
     @property
     def content(self) -> Control:
         return self.__content
@@ -161,6 +164,7 @@ class SnackBar(Control):
         self.__content = value
 
     # action
+
     @property
     def action(self) -> Optional[str]:
         return self._get_attr("action")
@@ -170,6 +174,7 @@ class SnackBar(Control):
         self._set_attr("action", value)
 
     # action_color
+
     @property
     def action_color(self) -> Optional[str]:
         return self._get_attr("actionColor")
@@ -179,6 +184,7 @@ class SnackBar(Control):
         self._set_attr("actionColor", value)
 
     # bgcolor
+
     @property
     def bgcolor(self) -> Optional[str]:
         return self._get_attr("bgColor")
@@ -188,6 +194,7 @@ class SnackBar(Control):
         self._set_attr("bgColor", value)
 
     # close_icon_color
+
     @property
     def close_icon_color(self) -> Optional[str]:
         return self._get_attr("closeIconColor")
@@ -197,6 +204,7 @@ class SnackBar(Control):
         self._set_attr("closeIconColor", value)
 
     # duration
+
     @property
     def duration(self) -> Optional[int]:
         return self._get_attr("duration", data_type="int")
@@ -206,6 +214,7 @@ class SnackBar(Control):
         self._set_attr("duration", value)
 
     # action_overflow_threshold
+
     @property
     def action_overflow_threshold(self) -> OptionalNumber:
         return self._get_attr("actionOverflowThreshold", data_type="float")
@@ -215,6 +224,7 @@ class SnackBar(Control):
         self._set_attr("actionOverflowThreshold", value)
 
     # behavior
+
     @property
     def behavior(self) -> Optional[SnackBarBehavior]:
         return self.__behavior
@@ -225,6 +235,7 @@ class SnackBar(Control):
         self._set_attr("behavior", value, SnackBarBehavior)
 
     # dismissDirection
+
     @property
     def dismiss_direction(self) -> Optional[DismissDirection]:
         return self.__dismiss_direction
@@ -235,6 +246,7 @@ class SnackBar(Control):
         self._set_enum_attr("dismissDirection", value, DismissDirection)
 
     # padding
+
     @property
     def padding(self) -> PaddingValue:
         return self.__padding
@@ -244,6 +256,7 @@ class SnackBar(Control):
         self.__padding = value
 
     # margin
+
     @property
     def margin(self) -> MarginValue:
         return self.__margin
@@ -253,6 +266,7 @@ class SnackBar(Control):
         self.__margin = value
 
     # width
+
     @property
     def width(self) -> OptionalNumber:
         return self._get_attr("width", data_type="float")
@@ -262,6 +276,7 @@ class SnackBar(Control):
         self._set_attr("width", value)
 
     # elevation
+
     @property
     def elevation(self) -> OptionalNumber:
         return self._get_attr("elevation", data_type="float")
@@ -271,6 +286,7 @@ class SnackBar(Control):
         self._set_attr("elevation", value)
 
     # clip_behavior
+
     @property
     def clip_behavior(self) -> Optional[ClipBehavior]:
         return self.__clip_behavior
@@ -283,6 +299,7 @@ class SnackBar(Control):
         )
 
     # shape
+
     @property
     def shape(self) -> Optional[OutlinedBorder]:
         return self.__shape
@@ -292,6 +309,7 @@ class SnackBar(Control):
         self.__shape = value
 
     # on_action
+
     @property
     def on_action(self):
         return self._get_event_handler("action")
@@ -301,6 +319,7 @@ class SnackBar(Control):
         self._add_event_handler("action", handler)
 
     # on_visible
+
     @property
     def on_visible(self):
         return self._get_event_handler("visible")

--- a/sdk/python/packages/flet-core/src/flet_core/stack.py
+++ b/sdk/python/packages/flet-core/src/flet_core/stack.py
@@ -4,12 +4,13 @@ from typing import Any, List, Optional, Union
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.alignment import Alignment
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     ClipBehavior,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -153,6 +154,7 @@ class Stack(ConstrainedControl, AdaptiveControl):
         return self.__controls
 
     # controls
+
     @property
     def controls(self):
         return self.__controls
@@ -162,6 +164,7 @@ class Stack(ConstrainedControl, AdaptiveControl):
         self.__controls = value if value is not None else []
 
     # clip_behavior
+
     @property
     def clip_behavior(self) -> Optional[ClipBehavior]:
         return self.__clip_behavior
@@ -174,6 +177,7 @@ class Stack(ConstrainedControl, AdaptiveControl):
         )
 
     # alignment
+
     @property
     def alignment(self) -> Optional[Alignment]:
         return self.__alignment
@@ -183,6 +187,7 @@ class Stack(ConstrainedControl, AdaptiveControl):
         self.__alignment = value
 
     # fit
+
     @property
     def fit(self) -> Optional[StackFit]:
         return self.__fit

--- a/sdk/python/packages/flet-core/src/flet_core/submenu_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/submenu_button.py
@@ -3,13 +3,14 @@ from typing import Any, List, Optional, Union
 
 from flet_core.buttons import ButtonStyle
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.menu_bar import MenuStyle
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     ClipBehavior,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -161,6 +162,7 @@ class SubmenuButton(ConstrainedControl):
         self.focus()
 
     # controls
+
     @property
     def controls(self):
         return self.__controls
@@ -170,6 +172,7 @@ class SubmenuButton(ConstrainedControl):
         self.__controls = value if value is not None else []
 
     # leading
+
     @property
     def leading(self) -> Optional[Control]:
         return self.__leading
@@ -179,6 +182,7 @@ class SubmenuButton(ConstrainedControl):
         self.__leading = value
 
     # trailing
+
     @property
     def trailing(self) -> Optional[Control]:
         return self.__trailing
@@ -188,6 +192,7 @@ class SubmenuButton(ConstrainedControl):
         self.__trailing = value
 
     # content
+
     @property
     def content(self) -> Optional[Control]:
         return self.__content
@@ -197,6 +202,7 @@ class SubmenuButton(ConstrainedControl):
         self.__content = value
 
     # style
+
     @property
     def style(self) -> Optional[ButtonStyle]:
         return self.__style
@@ -206,6 +212,7 @@ class SubmenuButton(ConstrainedControl):
         self.__style = value
 
     # menu_style
+
     @property
     def menu_style(self) -> Optional[MenuStyle]:
         return self.__menu_style
@@ -215,6 +222,7 @@ class SubmenuButton(ConstrainedControl):
         self.__menu_style = value
 
     # clip_behavior
+
     @property
     def clip_behavior(self) -> Optional[ClipBehavior]:
         return self.__clip_behavior
@@ -227,6 +235,7 @@ class SubmenuButton(ConstrainedControl):
         )
 
     # alignment_offset
+
     @property
     def alignment_offset(self) -> OffsetValue:
         return self.__alignment_offset
@@ -236,6 +245,7 @@ class SubmenuButton(ConstrainedControl):
         self.__alignment_offset = value
 
     # on_open
+
     @property
     def on_open(self):
         return self._get_event_handler("open")
@@ -246,6 +256,7 @@ class SubmenuButton(ConstrainedControl):
         self._set_attr("onOpen", True if handler is not None else None)
 
     # on_close
+
     @property
     def on_close(self):
         return self._get_event_handler("close")
@@ -256,6 +267,7 @@ class SubmenuButton(ConstrainedControl):
         self._set_attr("onClose", True if handler is not None else None)
 
     # on_hover
+
     @property
     def on_hover(self):
         return self._get_event_handler("hover")
@@ -266,6 +278,7 @@ class SubmenuButton(ConstrainedControl):
         self._set_attr("onHover", True if handler is not None else None)
 
     # on_focus
+
     @property
     def on_focus(self):
         return self._get_event_handler("focus")
@@ -275,6 +288,7 @@ class SubmenuButton(ConstrainedControl):
         self._add_event_handler("focus", handler)
 
     # on_blur
+
     @property
     def on_blur(self):
         return self._get_event_handler("blur")

--- a/sdk/python/packages/flet-core/src/flet_core/switch.py
+++ b/sdk/python/packages/flet-core/src/flet_core/switch.py
@@ -2,7 +2,6 @@ from typing import Any, Dict, Optional, Union
 
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import OptionalNumber
 from flet_core.ref import Ref
 from flet_core.text_style import TextStyle
 from flet_core.types import (
@@ -11,6 +10,7 @@ from flet_core.types import (
     MaterialState,
     MouseCursor,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -175,6 +175,7 @@ class Switch(ConstrainedControl, AdaptiveControl):
             self._set_attr_json("labelStyle", self.__label_style)
 
     # value
+
     @property
     def value(self) -> Optional[bool]:
         return self._get_attr("value", data_type="bool", def_value=False)
@@ -184,6 +185,7 @@ class Switch(ConstrainedControl, AdaptiveControl):
         self._set_attr("value", value)
 
     # label
+
     @property
     def label(self) -> Optional[str]:
         return self._get_attr("label")
@@ -193,6 +195,7 @@ class Switch(ConstrainedControl, AdaptiveControl):
         self._set_attr("label", value)
 
     # hover_color
+
     @property
     def hover_color(self) -> Optional[str]:
         return self._get_attr("hoverColor")
@@ -202,6 +205,7 @@ class Switch(ConstrainedControl, AdaptiveControl):
         self._set_attr("hoverColor", value)
 
     # track_outline_color
+
     @property
     def track_outline_color(self) -> Union[None, str, Dict[MaterialState, str]]:
         return self.__track_outline_color
@@ -211,6 +215,7 @@ class Switch(ConstrainedControl, AdaptiveControl):
         self.__track_outline_color = value
 
     # overlay_color
+
     @property
     def overlay_color(self) -> Union[None, str, Dict[MaterialState, str]]:
         return self.__overlay_color
@@ -220,6 +225,7 @@ class Switch(ConstrainedControl, AdaptiveControl):
         self.__overlay_color = value
 
     # splash_radius
+
     @property
     def splash_radius(self) -> OptionalNumber:
         return self._get_attr("splashRadius", data_type="float")
@@ -229,6 +235,7 @@ class Switch(ConstrainedControl, AdaptiveControl):
         self._set_attr("splashRadius", value)
 
     # label_style
+
     @property
     def label_style(self) -> Optional[TextStyle]:
         return self.__label_style
@@ -238,6 +245,7 @@ class Switch(ConstrainedControl, AdaptiveControl):
         self.__label_style = value
 
     # label_position
+
     @property
     def label_position(self) -> Optional[LabelPosition]:
         return self.__label_position
@@ -250,6 +258,7 @@ class Switch(ConstrainedControl, AdaptiveControl):
         )
 
     # mouse_cursor
+
     @property
     def mouse_cursor(self) -> Optional[MouseCursor]:
         return self.__mouse_cursor
@@ -263,6 +272,7 @@ class Switch(ConstrainedControl, AdaptiveControl):
         )
 
     # autofocus
+
     @property
     def autofocus(self) -> Optional[bool]:
         return self._get_attr("autofocus", data_type="bool", def_value=False)
@@ -272,6 +282,7 @@ class Switch(ConstrainedControl, AdaptiveControl):
         self._set_attr("autofocus", value)
 
     # active_color
+
     @property
     def active_color(self):
         return self._get_attr("activeColor")
@@ -281,6 +292,7 @@ class Switch(ConstrainedControl, AdaptiveControl):
         self._set_attr("activeColor", value)
 
     # active_track_color
+
     @property
     def active_track_color(self):
         return self._get_attr("activeTrackColor")
@@ -290,6 +302,7 @@ class Switch(ConstrainedControl, AdaptiveControl):
         self._set_attr("activeTrackColor", value)
 
     # focus_color
+
     @property
     def focus_color(self):
         return self._get_attr("focusColor")
@@ -299,6 +312,7 @@ class Switch(ConstrainedControl, AdaptiveControl):
         self._set_attr("focusColor", value)
 
     # inactive_thumb_color
+
     @property
     def inactive_thumb_color(self):
         return self._get_attr("inactiveThumbColor")
@@ -308,6 +322,7 @@ class Switch(ConstrainedControl, AdaptiveControl):
         self._set_attr("inactiveThumbColor", value)
 
     # inactive_track_color
+
     @property
     def inactive_track_color(self):
         return self._get_attr("inactiveTrackColor")
@@ -317,6 +332,7 @@ class Switch(ConstrainedControl, AdaptiveControl):
         self._set_attr("inactiveTrackColor", value)
 
     # thumb_color
+
     @property
     def thumb_color(self) -> Union[None, str, Dict[MaterialState, str]]:
         return self.__thumb_color
@@ -326,6 +342,7 @@ class Switch(ConstrainedControl, AdaptiveControl):
         self.__thumb_color = value
 
     # thumb_icon
+
     @property
     def thumb_icon(self) -> Union[None, str, Dict[MaterialState, str]]:
         return self.__thumb_icon
@@ -335,6 +352,7 @@ class Switch(ConstrainedControl, AdaptiveControl):
         self.__thumb_icon = value
 
     # track_color
+
     @property
     def track_color(self) -> Union[None, str, Dict[MaterialState, str]]:
         return self.__track_color
@@ -344,6 +362,7 @@ class Switch(ConstrainedControl, AdaptiveControl):
         self.__track_color = value
 
     # on_change
+
     @property
     def on_change(self):
         return self._get_event_handler("change")
@@ -353,6 +372,7 @@ class Switch(ConstrainedControl, AdaptiveControl):
         self._add_event_handler("change", handler)
 
     # on_focus
+
     @property
     def on_focus(self):
         return self._get_event_handler("focus")
@@ -362,6 +382,7 @@ class Switch(ConstrainedControl, AdaptiveControl):
         self._add_event_handler("focus", handler)
 
     # on_blur
+
     @property
     def on_blur(self):
         return self._get_event_handler("blur")

--- a/sdk/python/packages/flet-core/src/flet_core/tabs.py
+++ b/sdk/python/packages/flet-core/src/flet_core/tabs.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional, Union
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.border import BorderSide
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
@@ -12,6 +12,7 @@ from flet_core.types import (
     MaterialState,
     MouseCursor,
     OffsetValue,
+    OptionalNumber,
     PaddingValue,
     ResponsiveNumber,
     RotateValue,
@@ -58,6 +59,7 @@ class Tab(AdaptiveControl):
         return children
 
     # text
+
     @property
     def text(self):
         return self._get_attr("text")
@@ -67,6 +69,7 @@ class Tab(AdaptiveControl):
         self._set_attr("text", value)
 
     # icon
+
     @property
     def icon(self):
         return self._get_attr("icon")
@@ -76,6 +79,7 @@ class Tab(AdaptiveControl):
         self._set_attr("icon", value)
 
     # tab_content
+
     @property
     def tab_content(self):
         return self.__tab_content
@@ -85,6 +89,7 @@ class Tab(AdaptiveControl):
         self.__tab_content = value
 
     # content
+
     @property
     def content(self):
         return self.__content
@@ -262,6 +267,7 @@ class Tabs(ConstrainedControl, AdaptiveControl):
         return self.__tabs
 
     # tabs
+
     @property
     def tabs(self) -> Optional[List[Tab]]:
         return self.__tabs
@@ -271,6 +277,7 @@ class Tabs(ConstrainedControl, AdaptiveControl):
         self.__tabs = value if value is not None else []
 
     # on_change
+
     @property
     def on_change(self):
         return self._get_event_handler("change")
@@ -280,6 +287,7 @@ class Tabs(ConstrainedControl, AdaptiveControl):
         self._add_event_handler("change", handler)
 
     # selected_index
+
     @property
     def selected_index(self) -> Optional[int]:
         return self._get_attr("selectedIndex", data_type="int", def_value=0)
@@ -289,6 +297,7 @@ class Tabs(ConstrainedControl, AdaptiveControl):
         self._set_attr("selectedIndex", value)
 
     # scrollable
+
     @property
     def scrollable(self) -> Optional[bool]:
         return self._get_attr("scrollable", data_type="bool", def_value=True)
@@ -298,6 +307,7 @@ class Tabs(ConstrainedControl, AdaptiveControl):
         self._set_attr("scrollable", value)
 
     # mouse_cursor
+
     @property
     def mouse_cursor(self) -> Optional[MouseCursor]:
         return self.__mouse_cursor
@@ -311,6 +321,7 @@ class Tabs(ConstrainedControl, AdaptiveControl):
         )
 
     # clip_behavior
+
     @property
     def clip_behavior(self) -> Optional[ClipBehavior]:
         return self.__clip_behavior
@@ -324,6 +335,7 @@ class Tabs(ConstrainedControl, AdaptiveControl):
         )
 
     # is_secondary
+
     @property
     def is_secondary(self) -> Optional[bool]:
         return self._get_attr("isSecondary", data_type="bool", def_value=False)
@@ -333,6 +345,7 @@ class Tabs(ConstrainedControl, AdaptiveControl):
         self._set_attr("isSecondary", value)
 
     # tab_alignment
+
     @property
     def tab_alignment(self) -> Optional[TabAlignment]:
         return self.__tab_alignment
@@ -345,6 +358,7 @@ class Tabs(ConstrainedControl, AdaptiveControl):
         )
 
     # animation_duration
+
     @property
     def animation_duration(self) -> Optional[int]:
         return self._get_attr("animationDuration", data_type="int")
@@ -354,6 +368,7 @@ class Tabs(ConstrainedControl, AdaptiveControl):
         self._set_attr("animationDuration", value)
 
     # divider_height
+
     @property
     def divider_height(self):
         return self._get_attr("dividerHeight", data_type="float", def_value=1.0)
@@ -363,6 +378,7 @@ class Tabs(ConstrainedControl, AdaptiveControl):
         self._set_attr("dividerHeight", value)
 
     # enable_feedback
+
     @property
     def enable_feedback(self):
         return self._get_attr("enableFeedback")
@@ -372,6 +388,7 @@ class Tabs(ConstrainedControl, AdaptiveControl):
         self._set_attr("enableFeedback", value)
 
     # indicator_thickness
+
     @property
     def indicator_thickness(self):
         return self._get_attr("indicatorThickness", data_type="float", def_value=3.0)
@@ -381,6 +398,7 @@ class Tabs(ConstrainedControl, AdaptiveControl):
         self._set_attr("indicatorThickness", value)
 
     # divider_color
+
     @property
     def divider_color(self) -> Optional[str]:
         return self._get_attr("dividerColor")
@@ -390,6 +408,7 @@ class Tabs(ConstrainedControl, AdaptiveControl):
         self._set_attr("dividerColor", value)
 
     # indicator_color
+
     @property
     def indicator_color(self) -> Optional[str]:
         return self._get_attr("indicatorColor")
@@ -399,6 +418,7 @@ class Tabs(ConstrainedControl, AdaptiveControl):
         self._set_attr("indicatorColor", value)
 
     # indicator_border_radius
+
     @property
     def indicator_border_radius(self) -> BorderRadiusValue:
         return self.__indicator_border_radius
@@ -408,6 +428,7 @@ class Tabs(ConstrainedControl, AdaptiveControl):
         self.__indicator_border_radius = value
 
     # indicator_border_side
+
     @property
     def indicator_border_side(self) -> Optional[BorderSide]:
         return self.__indicator_border_side
@@ -417,6 +438,7 @@ class Tabs(ConstrainedControl, AdaptiveControl):
         self.__indicator_border_side = value
 
     # indicator_padding
+
     @property
     def indicator_padding(self) -> PaddingValue:
         return self.__indicator_padding
@@ -426,6 +448,7 @@ class Tabs(ConstrainedControl, AdaptiveControl):
         self.__indicator_padding = value
 
     # indicator_tab_size
+
     @property
     def indicator_tab_size(self) -> Optional[bool]:
         return self._get_attr("indicatorTabSize", data_type="bool", def_value=False)
@@ -435,6 +458,7 @@ class Tabs(ConstrainedControl, AdaptiveControl):
         self._set_attr("indicatorTabSize", value)
 
     # label_color
+
     @property
     def label_color(self) -> Optional[str]:
         return self._get_attr("labelColor")
@@ -444,6 +468,7 @@ class Tabs(ConstrainedControl, AdaptiveControl):
         self._set_attr("labelColor", value)
 
     # unselected_label_color
+
     @property
     def unselected_label_color(self) -> Optional[str]:
         return self._get_attr("unselectedLabelColor")
@@ -453,6 +478,7 @@ class Tabs(ConstrainedControl, AdaptiveControl):
         self._set_attr("unselectedLabelColor", value)
 
     # overlay_color
+
     @property
     def overlay_color(self) -> Union[None, str, Dict[MaterialState, str]]:
         return self.__overlay_color

--- a/sdk/python/packages/flet-core/src/flet_core/text.py
+++ b/sdk/python/packages/flet-core/src/flet_core/text.py
@@ -3,7 +3,6 @@ from typing import Any, List, Optional, Union
 from warnings import warn
 
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import OptionalNumber
 from flet_core.ref import Ref
 from flet_core.text_span import TextSpan
 from flet_core.text_style import TextStyle
@@ -11,16 +10,12 @@ from flet_core.types import (
     AnimationValue,
     FontWeight,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
     TextAlign,
 )
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
 
 
 class TextOverflow(Enum):
@@ -191,6 +186,7 @@ class Text(ConstrainedControl):
             self._set_attr_json("style", self.__style)
 
     # value
+
     @property
     def value(self) -> Optional[str]:
         return self._get_attr("value")
@@ -200,6 +196,7 @@ class Text(ConstrainedControl):
         self._set_attr("value", value)
 
     # spans
+
     @property
     def spans(self) -> Optional[List[TextSpan]]:
         return self.__spans
@@ -209,6 +206,7 @@ class Text(ConstrainedControl):
         self.__spans = value if value is not None else []
 
     # text_align
+
     @property
     def text_align(self) -> Optional[TextAlign]:
         return self.__text_align
@@ -221,6 +219,7 @@ class Text(ConstrainedControl):
         )
 
     # font_family
+
     @property
     def font_family(self):
         return self._get_attr("fontFamily")
@@ -230,6 +229,7 @@ class Text(ConstrainedControl):
         self._set_attr("fontFamily", value)
 
     # size
+
     @property
     def size(self) -> OptionalNumber:
         return self._get_attr("size")
@@ -239,6 +239,7 @@ class Text(ConstrainedControl):
         self._set_attr("size", value)
 
     # weight
+
     @property
     def weight(self) -> Optional[FontWeight]:
         return self.__weight
@@ -251,6 +252,7 @@ class Text(ConstrainedControl):
         )
 
     # style
+
     @property
     def style(self) -> Union[TextThemeStyle, TextStyle, None]:
         return self.__style
@@ -271,6 +273,7 @@ class Text(ConstrainedControl):
                 )
 
     # theme_style
+
     @property
     def theme_style(self):
         return self._get_attr("theme_style")
@@ -282,6 +285,7 @@ class Text(ConstrainedControl):
         )
 
     # italic
+
     @property
     def italic(self) -> Optional[bool]:
         return self._get_attr("italic", data_type="bool", def_value=False)
@@ -291,6 +295,7 @@ class Text(ConstrainedControl):
         self._set_attr("italic", value)
 
     # no_wrap
+
     @property
     def no_wrap(self) -> Optional[bool]:
         return self._get_attr("italic", data_type="noWrap", def_value=False)
@@ -300,6 +305,7 @@ class Text(ConstrainedControl):
         self._set_attr("noWrap", value)
 
     # selectable
+
     @property
     def selectable(self) -> Optional[bool]:
         return self._get_attr("selectable", data_type="bool", def_value=False)
@@ -309,6 +315,7 @@ class Text(ConstrainedControl):
         self._set_attr("selectable", value)
 
     # max_lines
+
     @property
     def max_lines(self) -> Optional[int]:
         return self._get_attr("maxLines")
@@ -318,6 +325,7 @@ class Text(ConstrainedControl):
         self._set_attr("maxLines", value)
 
     # overflow
+
     @property
     def overflow(self) -> TextOverflow:
         return self.__overflow
@@ -330,6 +338,7 @@ class Text(ConstrainedControl):
         )
 
     # color
+
     @property
     def color(self):
         return self._get_attr("color")
@@ -339,6 +348,7 @@ class Text(ConstrainedControl):
         self._set_attr("color", value)
 
     # bgcolor
+
     @property
     def bgcolor(self):
         return self._get_attr("bgcolor")
@@ -348,6 +358,7 @@ class Text(ConstrainedControl):
         self._set_attr("bgcolor", value)
 
     # semantics_label
+
     @property
     def semantics_label(self) -> Optional[str]:
         return self._get_attr("semanticsLabel")

--- a/sdk/python/packages/flet-core/src/flet_core/text_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/text_button.py
@@ -4,11 +4,12 @@ from typing import Any, Optional, Union
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.buttons import ButtonStyle
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -163,6 +164,7 @@ class TextButton(ConstrainedControl, AdaptiveControl):
         self.focus()
 
     # text
+
     @property
     def text(self):
         return self._get_attr("text")
@@ -172,6 +174,7 @@ class TextButton(ConstrainedControl, AdaptiveControl):
         self._set_attr("text", value)
 
     # icon
+
     @property
     def icon(self):
         return self._get_attr("icon")
@@ -181,6 +184,7 @@ class TextButton(ConstrainedControl, AdaptiveControl):
         self._set_attr("icon", value)
 
     # icon_color
+
     @property
     def icon_color(self):
         return self._get_attr("iconColor")
@@ -190,6 +194,7 @@ class TextButton(ConstrainedControl, AdaptiveControl):
         self._set_attr("iconColor", value)
 
     # style
+
     @property
     def style(self) -> Optional[ButtonStyle]:
         return self.__style
@@ -199,6 +204,7 @@ class TextButton(ConstrainedControl, AdaptiveControl):
         self.__style = value
 
     # url
+
     @property
     def url(self):
         return self._get_attr("url")
@@ -208,6 +214,7 @@ class TextButton(ConstrainedControl, AdaptiveControl):
         self._set_attr("url", value)
 
     # url_target
+
     @property
     def url_target(self) -> Optional[UrlTarget]:
         return self.__url_target
@@ -220,6 +227,7 @@ class TextButton(ConstrainedControl, AdaptiveControl):
         )
 
     # on_click
+
     @property
     def on_click(self):
         return self._get_event_handler("click")
@@ -229,6 +237,7 @@ class TextButton(ConstrainedControl, AdaptiveControl):
         self._add_event_handler("click", handler)
 
     # on_long_press
+
     @property
     def on_long_press(self):
         return self._get_event_handler("long_press")
@@ -239,6 +248,7 @@ class TextButton(ConstrainedControl, AdaptiveControl):
         self._set_attr("onLongPress", True if handler is not None else None)
 
     # content
+
     @property
     def content(self) -> Optional[Control]:
         return self.__content
@@ -248,6 +258,7 @@ class TextButton(ConstrainedControl, AdaptiveControl):
         self.__content = value
 
     # autofocus
+
     @property
     def autofocus(self) -> Optional[bool]:
         return self._get_attr("autofocus", data_type="bool", def_value=False)
@@ -257,6 +268,7 @@ class TextButton(ConstrainedControl, AdaptiveControl):
         self._set_attr("autofocus", value)
 
     # on_hover
+
     @property
     def on_hover(self):
         return self._get_event_handler("hover")
@@ -270,6 +282,7 @@ class TextButton(ConstrainedControl, AdaptiveControl):
             self._set_attr("onHover", None)
 
     # on_focus
+
     @property
     def on_focus(self):
         return self._get_event_handler("focus")
@@ -279,6 +292,7 @@ class TextButton(ConstrainedControl, AdaptiveControl):
         self._add_event_handler("focus", handler)
 
     # on_blur
+
     @property
     def on_blur(self):
         return self._get_event_handler("blur")

--- a/sdk/python/packages/flet-core/src/flet_core/text_style.py
+++ b/sdk/python/packages/flet-core/src/flet_core/text_style.py
@@ -3,10 +3,9 @@ from dataclasses import field
 from enum import Enum, IntFlag
 from typing import List, Optional, Union
 
-from flet_core.control import OptionalNumber
 from flet_core.painting import Paint
 from flet_core.shadow import BoxShadow
-from flet_core.types import FontWeight
+from flet_core.types import FontWeight, OptionalNumber
 
 
 class TextDecoration(IntFlag):

--- a/sdk/python/packages/flet-core/src/flet_core/textfield.py
+++ b/sdk/python/packages/flet-core/src/flet_core/textfield.py
@@ -5,7 +5,7 @@ from enum import Enum
 from typing import Any, Optional, Union
 
 from flet_core.adaptive_control import AdaptiveControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.form_field_control import FormFieldControl, InputBorder
 from flet_core.ref import Ref
 from flet_core.text_style import TextStyle
@@ -13,6 +13,7 @@ from flet_core.types import (
     AnimationValue,
     BorderRadiusValue,
     OffsetValue,
+    OptionalNumber,
     PaddingValue,
     ResponsiveNumber,
     RotateValue,
@@ -21,11 +22,6 @@ from flet_core.types import (
     VerticalAlignment,
 )
 from flet_core.utils import deprecated
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
 
 
 class KeyboardType(Enum):
@@ -323,6 +319,7 @@ class TextField(FormFieldControl, AdaptiveControl):
         self.focus()
 
     # value
+
     @property
     def value(self) -> Optional[str]:
         return self._get_attr("value", def_value="")
@@ -332,6 +329,7 @@ class TextField(FormFieldControl, AdaptiveControl):
         self._set_attr("value", value)
 
     # keyboard_type
+
     @property
     def keyboard_type(self) -> Optional[KeyboardType]:
         return self.__keyboard_type
@@ -342,6 +340,7 @@ class TextField(FormFieldControl, AdaptiveControl):
         self._set_enum_attr("keyboardType", value, KeyboardType)
 
     # text_align
+
     @property
     def text_align(self) -> Optional[TextAlign]:
         return self.__text_align
@@ -354,6 +353,7 @@ class TextField(FormFieldControl, AdaptiveControl):
         )
 
     # multiline
+
     @property
     def multiline(self) -> Optional[bool]:
         return self._get_attr("multiline", data_type="bool", def_value=False)
@@ -363,6 +363,7 @@ class TextField(FormFieldControl, AdaptiveControl):
         self._set_attr("multiline", value)
 
     # min_lines
+
     @property
     def min_lines(self) -> Optional[int]:
         return self._get_attr("minLines")
@@ -372,6 +373,7 @@ class TextField(FormFieldControl, AdaptiveControl):
         self._set_attr("minLines", value)
 
     # max_lines
+
     @property
     def max_lines(self) -> Optional[int]:
         return self._get_attr("maxLines")
@@ -381,6 +383,7 @@ class TextField(FormFieldControl, AdaptiveControl):
         self._set_attr("maxLines", value)
 
     # max_length
+
     @property
     def max_length(self) -> Optional[int]:
         return self._get_attr("maxLength")
@@ -390,6 +393,7 @@ class TextField(FormFieldControl, AdaptiveControl):
         self._set_attr("maxLength", value)
 
     # read_only
+
     @property
     def read_only(self) -> Optional[bool]:
         return self._get_attr("readOnly", data_type="bool", def_value=False)
@@ -399,6 +403,7 @@ class TextField(FormFieldControl, AdaptiveControl):
         self._set_attr("readOnly", value)
 
     # shift_enter
+
     @property
     def shift_enter(self) -> Optional[bool]:
         return self._get_attr("shiftEnter", data_type="bool", def_value=False)
@@ -408,6 +413,7 @@ class TextField(FormFieldControl, AdaptiveControl):
         self._set_attr("shiftEnter", value)
 
     # password
+
     @property
     def password(self) -> Optional[bool]:
         return self._get_attr("password", data_type="bool", def_value=False)
@@ -417,6 +423,7 @@ class TextField(FormFieldControl, AdaptiveControl):
         self._set_attr("password", value)
 
     # can_reveal_password
+
     @property
     def can_reveal_password(self) -> Optional[bool]:
         return self._get_attr("canRevealPassword", data_type="bool", def_value=False)
@@ -426,6 +433,7 @@ class TextField(FormFieldControl, AdaptiveControl):
         self._set_attr("canRevealPassword", value)
 
     # autofocus
+
     @property
     def autofocus(self) -> Optional[bool]:
         return self._get_attr("autofocus", data_type="bool", def_value=False)
@@ -435,6 +443,7 @@ class TextField(FormFieldControl, AdaptiveControl):
         self._set_attr("autofocus", value)
 
     # capitalization
+
     @property
     def capitalization(self) -> TextCapitalization:
         return self.__capitalization
@@ -445,6 +454,7 @@ class TextField(FormFieldControl, AdaptiveControl):
         self._set_enum_attr("capitalization", value, TextCapitalization)
 
     # autocorrect
+
     @property
     def autocorrect(self) -> Optional[bool]:
         return self._get_attr("autocorrect", data_type="bool", def_value=True)
@@ -454,6 +464,7 @@ class TextField(FormFieldControl, AdaptiveControl):
         self._set_attr("autocorrect", value)
 
     # show_cursor
+
     @property
     def show_cursor(self) -> Optional[bool]:
         return self._get_attr("showCursor", data_type="bool", def_value=True)
@@ -463,6 +474,7 @@ class TextField(FormFieldControl, AdaptiveControl):
         self._set_attr("showCursor", value)
 
     # enable_suggestions
+
     @property
     def enable_suggestions(self) -> Optional[bool]:
         return self._get_attr("enableSuggestions", data_type="bool", def_value=True)
@@ -472,6 +484,7 @@ class TextField(FormFieldControl, AdaptiveControl):
         self._set_attr("enableSuggestions", value)
 
     # smart_dashes_type
+
     @property
     def smart_dashes_type(self) -> Optional[bool]:
         return self._get_attr("smartDashesType", data_type="bool", def_value=True)
@@ -481,6 +494,7 @@ class TextField(FormFieldControl, AdaptiveControl):
         self._set_attr("smartDashesType", value)
 
     # smart_quotes_type
+
     @property
     def smart_quotes_type(self) -> Optional[bool]:
         return self._get_attr("smartQuotesType", data_type="bool", def_value=True)
@@ -490,6 +504,7 @@ class TextField(FormFieldControl, AdaptiveControl):
         self._set_attr("smartQuotesType", value)
 
     # cursor_color
+
     @property
     def cursor_color(self):
         return self._get_attr("cursorColor")
@@ -499,6 +514,7 @@ class TextField(FormFieldControl, AdaptiveControl):
         self._set_attr("cursorColor", value)
 
     # cursor_height
+
     @property
     def cursor_height(self) -> OptionalNumber:
         return self._get_attr("cursorHeight")
@@ -508,6 +524,7 @@ class TextField(FormFieldControl, AdaptiveControl):
         self._set_attr("cursorHeight", value)
 
     # cursor_width
+
     @property
     def cursor_width(self) -> OptionalNumber:
         return self._get_attr("cursorWidth")
@@ -517,6 +534,7 @@ class TextField(FormFieldControl, AdaptiveControl):
         self._set_attr("cursorWidth", value)
 
     # cursor_radius
+
     @property
     def cursor_radius(self) -> OptionalNumber:
         return self._get_attr("cursorRadius")
@@ -526,6 +544,7 @@ class TextField(FormFieldControl, AdaptiveControl):
         self._set_attr("cursorRadius", value)
 
     # selection_color
+
     @property
     def selection_color(self):
         return self._get_attr("selectionColor")
@@ -535,6 +554,7 @@ class TextField(FormFieldControl, AdaptiveControl):
         self._set_attr("selectionColor", value)
 
     # input_filter
+
     @property
     def input_filter(self) -> Optional[InputFilter]:
         return self.__input_filter
@@ -544,6 +564,7 @@ class TextField(FormFieldControl, AdaptiveControl):
         self.__input_filter = value
 
     # on_change
+
     @property
     def on_change(self):
         return self._get_event_handler("change")
@@ -557,6 +578,7 @@ class TextField(FormFieldControl, AdaptiveControl):
             self._set_attr("onchange", None)
 
     # on_submit
+
     @property
     def on_submit(self):
         return self._get_event_handler("submit")
@@ -566,6 +588,7 @@ class TextField(FormFieldControl, AdaptiveControl):
         self._add_event_handler("submit", handler)
 
     # on_focus
+
     @property
     def on_focus(self):
         return self._get_event_handler("focus")
@@ -575,6 +598,7 @@ class TextField(FormFieldControl, AdaptiveControl):
         self._add_event_handler("focus", handler)
 
     # on_blur
+
     @property
     def on_blur(self):
         return self._get_event_handler("blur")

--- a/sdk/python/packages/flet-core/src/flet_core/theme.py
+++ b/sdk/python/packages/flet-core/src/flet_core/theme.py
@@ -8,7 +8,6 @@ from flet_core.alignment import Alignment
 from flet_core.border import BorderSide
 from flet_core.border_radius import BorderRadius
 from flet_core.buttons import ButtonStyle, OutlinedBorder
-from flet_core.control import OptionalNumber
 from flet_core.navigation_bar import NavigationBarLabelBehavior
 from flet_core.navigation_rail import NavigationRailLabelType
 from flet_core.padding import Padding
@@ -24,6 +23,7 @@ from flet_core.types import (
     MaterialState,
     MouseCursor,
     OffsetValue,
+    OptionalNumber,
     PaddingValue,
 )
 
@@ -215,6 +215,7 @@ class CardTheme:
 @dataclasses.dataclass
 class ChipTheme:
     # color: Optional[str] = field(default=None)
+
     bgcolor: Optional[str] = field(default=None)
     shadow_color: Optional[str] = field(default=None)
     surface_tint_color: Optional[str] = field(default=None)
@@ -668,6 +669,7 @@ class NavigationBarTheme:
 @dataclasses.dataclass
 class SegmentedButtonTheme:
     # selected_icon: Optional[str] = field(default=None)
+
     style: Optional[ButtonStyle] = field(default=None)
 
 
@@ -706,6 +708,7 @@ class Theme:
     dialog_theme: Optional[DialogTheme] = field(default=None)
     divider_theme: Optional[DividerTheme] = field(default=None)
     # dropdown_menu_theme: Optional[DropdownMenuTheme] = field(default=None)
+
     expansion_tile_theme: Optional[ExpansionTileTheme] = field(default=None)
     list_tile_theme: Optional[ListTileTheme] = field(default=None)
     navigation_bar_theme: Optional[NavigationBarTheme] = field(default=None)
@@ -722,6 +725,7 @@ class Theme:
     scrollbar_theme: Optional[ScrollbarTheme] = field(default=None)
     search_bar_theme: Optional[SearchBarTheme] = field(default=None)
     # search_view_theme: Optional[SearchViewTheme] = field(default=None)
+
     segmented_button_theme: Optional[SegmentedButtonTheme] = field(default=None)
     slider_theme: Optional[SliderTheme] = field(default=None)
     snackbar_theme: Optional[SnackBarTheme] = field(default=None)

--- a/sdk/python/packages/flet-core/src/flet_core/time_picker.py
+++ b/sdk/python/packages/flet-core/src/flet_core/time_picker.py
@@ -3,10 +3,10 @@ from enum import Enum
 from typing import Any, Optional, Union
 
 from flet_core import ControlEvent
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.event_handler import EventHandler
 from flet_core.ref import Ref
-from flet_core.types import Orientation, ResponsiveNumber
+from flet_core.types import OptionalNumber, Orientation, ResponsiveNumber
 from flet_core.utils import deprecated
 
 
@@ -110,7 +110,9 @@ class TimePicker(Control):
             data=data,
         )
 
-        self.__on_entry_mode_change = EventHandler(lambda e: TimePickerEntryModeChangeEvent(e.data))
+        self.__on_entry_mode_change = EventHandler(
+            lambda e: TimePickerEntryModeChangeEvent(e.data)
+        )
         self._add_event_handler(
             "entryModeChange", self.__on_entry_mode_change.get_handler()
         )
@@ -145,6 +147,7 @@ class TimePicker(Control):
         self.pick_time()
 
     # open
+
     @property
     def open(self) -> Optional[bool]:
         return self._get_attr("open", data_type="bool", def_value=False)
@@ -154,6 +157,7 @@ class TimePicker(Control):
         self._set_attr("open", value)
 
     # value
+
     @property
     def value(self) -> Optional[time]:
         value_string = self._get_attr(
@@ -172,6 +176,7 @@ class TimePicker(Control):
         self._set_attr("value", value)
 
     # hour_label_text
+
     @property
     def hour_label_text(self) -> Optional[str]:
         return self._get_attr("hourLabelText", def_value=None)
@@ -181,6 +186,7 @@ class TimePicker(Control):
         self._set_attr("hourLabelText", value)
 
     # minute_label_text
+
     @property
     def minute_label_text(self) -> Optional[str]:
         return self._get_attr("minuteLabelText", def_value=None)
@@ -190,6 +196,7 @@ class TimePicker(Control):
         self._set_attr("minuteLabelText", value)
 
     # help_text
+
     @property
     def help_text(self) -> Optional[str]:
         return self._get_attr("helpText", def_value=None)
@@ -199,6 +206,7 @@ class TimePicker(Control):
         self._set_attr("helpText", value)
 
     # cancel_text
+
     @property
     def cancel_text(self) -> Optional[str]:
         return self._get_attr("cancelText", def_value=None)
@@ -208,6 +216,7 @@ class TimePicker(Control):
         self._set_attr("cancelText", value)
 
     # confirm_text
+
     @property
     def confirm_text(self) -> Optional[str]:
         return self._get_attr("confirmText", def_value=None)
@@ -217,6 +226,7 @@ class TimePicker(Control):
         self._set_attr("confirmText", value)
 
     # error_invalid_text
+
     @property
     def error_invalid_text(self) -> Optional[str]:
         return self._get_attr("errorInvalidText", def_value=None)
@@ -226,6 +236,7 @@ class TimePicker(Control):
         self._set_attr("errorInvalidText", value)
 
     # time_picker_entry_mode
+
     @property
     def time_picker_entry_mode(self) -> Optional[TimePickerEntryMode]:
         return self.__time_picker_entry_mode
@@ -236,6 +247,7 @@ class TimePicker(Control):
         self._set_enum_attr("timePickerEntryMode", value, TimePickerEntryMode)
 
     # orientation
+
     @property
     def orientation(self) -> Optional[Orientation]:
         return self.__orientation
@@ -246,6 +258,7 @@ class TimePicker(Control):
         self._set_enum_attr("orientation", value, Orientation)
 
     # on_change
+
     @property
     def on_change(self):
         return self._get_event_handler("change")
@@ -255,6 +268,7 @@ class TimePicker(Control):
         self._add_event_handler("change", handler)
 
     # on_dismiss
+
     @property
     def on_dismiss(self):
         return self._get_event_handler("dismiss")
@@ -264,6 +278,7 @@ class TimePicker(Control):
         self._add_event_handler("dismiss", handler)
 
     # on_entry_mode_change
+
     @property
     def on_entry_mode_change(self):
         return self.__on_entry_mode_change

--- a/sdk/python/packages/flet-core/src/flet_core/tooltip.py
+++ b/sdk/python/packages/flet-core/src/flet_core/tooltip.py
@@ -1,7 +1,7 @@
 from typing import Any, Optional
 
 from flet_core.border import Border
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.gradients import Gradient
 from flet_core.ref import Ref
 from flet_core.text_style import TextStyle
@@ -9,6 +9,7 @@ from flet_core.types import (
     BorderRadiusValue,
     BoxShape,
     MarginValue,
+    OptionalNumber,
     PaddingValue,
     TextAlign,
 )
@@ -139,6 +140,7 @@ class Tooltip(Control):
         return children
 
     # enable_feedback
+
     @property
     def enable_feedback(self) -> Optional[bool]:
         return self._get_attr("enableFeedback", data_type="bool", def_value=True)
@@ -148,6 +150,7 @@ class Tooltip(Control):
         self._set_attr("enableFeedback", value)
 
     # enable_tap_to_dismiss
+
     @property
     def enable_tap_to_dismiss(self) -> Optional[bool]:
         return self._get_attr("enableTapToDismiss", data_type="bool", def_value=True)
@@ -157,6 +160,7 @@ class Tooltip(Control):
         self._set_attr("enableTapToDismiss", value)
 
     # exclude_from_semantics
+
     @property
     def exclude_from_semantics(self) -> Optional[bool]:
         return self._get_attr("excludeFromSemantics", data_type="bool", def_value=False)
@@ -166,6 +170,7 @@ class Tooltip(Control):
         self._set_attr("excludeFromSemantics", value)
 
     # margin
+
     @property
     def margin(self) -> MarginValue:
         return self.__margin
@@ -175,6 +180,7 @@ class Tooltip(Control):
         self.__margin = value
 
     # padding
+
     @property
     def padding(self) -> PaddingValue:
         return self.__padding
@@ -184,6 +190,7 @@ class Tooltip(Control):
         self.__padding = value
 
     # bgcolor
+
     @property
     def bgcolor(self):
         return self._get_attr("bgColor")
@@ -193,6 +200,7 @@ class Tooltip(Control):
         self._set_attr("bgColor", value)
 
     # gradient
+
     @property
     def gradient(self) -> Optional[Gradient]:
         return self.__gradient
@@ -202,6 +210,7 @@ class Tooltip(Control):
         self.__gradient = value
 
     # border
+
     @property
     def border(self) -> Optional[Border]:
         return self.__border
@@ -211,6 +220,7 @@ class Tooltip(Control):
         self.__border = value
 
     # border_radius
+
     @property
     def border_radius(self) -> BorderRadiusValue:
         return self.__border_radius
@@ -220,6 +230,7 @@ class Tooltip(Control):
         self.__border_radius = value
 
     # shape
+
     @property
     def shape(self) -> Optional[BoxShape]:
         return self.__shape
@@ -230,6 +241,7 @@ class Tooltip(Control):
         self._set_attr("shape", value.value if isinstance(value, BoxShape) else value)
 
     # message
+
     @property
     def message(self) -> Optional[str]:
         return self._get_attr("message")
@@ -239,6 +251,7 @@ class Tooltip(Control):
         self._set_attr("message", value)
 
     # text_align
+
     @property
     def text_align(self) -> Optional[TextAlign]:
         return self.__text_align
@@ -251,6 +264,7 @@ class Tooltip(Control):
         )
 
     # text_style
+
     @property
     def text_style(self) -> Optional[TextStyle]:
         return self.__text_style
@@ -260,6 +274,7 @@ class Tooltip(Control):
         self.__text_style = value
 
     # prefer_below
+
     @property
     def prefer_below(self) -> Optional[bool]:
         return self._get_attr("preferBelow", data_type="bool", def_value=False)
@@ -269,6 +284,7 @@ class Tooltip(Control):
         self._set_attr("preferBelow", value)
 
     # height
+
     @property
     def height(self) -> OptionalNumber:
         return self._get_attr("height")
@@ -278,6 +294,7 @@ class Tooltip(Control):
         self._set_attr("height", value)
 
     # vertical_offset
+
     @property
     def vertical_offset(self) -> OptionalNumber:
         return self._get_attr("verticalOffset")
@@ -287,6 +304,7 @@ class Tooltip(Control):
         self._set_attr("verticalOffset", value)
 
     # show_duration
+
     @property
     def show_duration(self) -> Optional[int]:
         return self._get_attr("showDuration")
@@ -296,6 +314,7 @@ class Tooltip(Control):
         self._set_attr("showDuration", value)
 
     # wait_duration
+
     @property
     def wait_duration(self) -> Optional[int]:
         return self._get_attr("waitDuration")
@@ -305,6 +324,7 @@ class Tooltip(Control):
         self._set_attr("waitDuration", value)
 
     # content
+
     @property
     def content(self) -> Optional[Control]:
         return self.__content

--- a/sdk/python/packages/flet-core/src/flet_core/transparent_pointer.py
+++ b/sdk/python/packages/flet-core/src/flet_core/transparent_pointer.py
@@ -1,9 +1,15 @@
 from typing import Any, Optional, Union
 
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
-from flet_core.types import AnimationValue, OffsetValue, RotateValue, ScaleValue
+from flet_core.types import (
+    AnimationValue,
+    OffsetValue,
+    OptionalNumber,
+    RotateValue,
+    ScaleValue,
+)
 
 
 class TransparentPointer(ConstrainedControl):
@@ -81,6 +87,7 @@ class TransparentPointer(ConstrainedControl):
         return children
 
     # content
+
     @property
     def content(self) -> Optional[Control]:
         return self.__content

--- a/sdk/python/packages/flet-core/src/flet_core/types.py
+++ b/sdk/python/packages/flet-core/src/flet_core/types.py
@@ -35,19 +35,19 @@ class UrlTarget(Enum):
     # UNFENCED_TOP = "_unfencedTop"
 
 
-PaddingValue = Union[None, int, float, Padding]
+PaddingValue = Optional[Union[int, float, Padding]]
 
-MarginValue = Union[None, int, float, Margin]
+MarginValue = Optional[Union[int, float, Margin]]
 
-BorderRadiusValue = Union[None, int, float, BorderRadius]
+BorderRadiusValue = Optional[Union[int, float, BorderRadius]]
 
-RotateValue = Union[None, int, float, Rotate]
+RotateValue = Optional[Union[int, float, Rotate]]
 
-ScaleValue = Union[None, int, float, Scale]
+ScaleValue = Optional[Union[int, float, Scale]]
 
-OffsetValue = Union[None, Offset, Tuple[Union[float, int], Union[float, int]]]
+OffsetValue = Optional[Union[Offset, Tuple[Union[float, int], Union[float, int]]]]
 
-AnimationValue = Union[None, bool, int, Animation]
+AnimationValue = Optional[Union[bool, int, Animation]]
 
 
 class FontWeight(Enum):
@@ -76,6 +76,9 @@ class NotchShape(Enum):
 
 ResponsiveNumber = Union[Dict[str, Union[int, float]], int, float]
 OptionalNumber = Optional[Union[int, float]]
+
+# str type alias
+IconStr = Optional[str]
 
 
 class MaterialState(Enum):

--- a/sdk/python/packages/flet-core/src/flet_core/types.py
+++ b/sdk/python/packages/flet-core/src/flet_core/types.py
@@ -78,6 +78,7 @@ ResponsiveNumber = Union[Dict[str, Union[int, float]], int, float]
 OptionalNumber = Optional[Union[int, float]]
 
 # str type alias
+ColorStr = Optional[str]
 IconStr = Optional[str]
 
 

--- a/sdk/python/packages/flet-core/src/flet_core/types.py
+++ b/sdk/python/packages/flet-core/src/flet_core/types.py
@@ -1,8 +1,9 @@
 from enum import Enum
-from typing import Dict, Tuple, Union
+from typing import Callable, Dict, Tuple, Union, Optional
 
 from flet_core.animation import Animation
 from flet_core.border_radius import BorderRadius
+from flet_core.control_event import ControlEvent
 from flet_core.margin import Margin
 from flet_core.padding import Padding
 from flet_core.transform import Offset, Rotate, Scale
@@ -74,6 +75,7 @@ class NotchShape(Enum):
 
 
 ResponsiveNumber = Union[Dict[str, Union[int, float]], int, float]
+OptionalNumber = Optional[Union[int, float]]
 
 
 class MaterialState(Enum):
@@ -290,3 +292,6 @@ class MouseCursor(Enum):
     WAIT = "wait"
     ZOOM_IN = "zoomIn"
     ZOOM_OUT = "zoomOut"
+
+# Events
+ControlEventFunction = Callable[[ControlEvent], None]

--- a/sdk/python/packages/flet-core/src/flet_core/vertical_divider.py
+++ b/sdk/python/packages/flet-core/src/flet_core/vertical_divider.py
@@ -1,7 +1,8 @@
 from typing import Any, Optional
 
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
+from flet_core.types import OptionalNumber
 
 
 class VerticalDivider(Control):
@@ -79,6 +80,7 @@ class VerticalDivider(Control):
         return "verticaldivider"
 
     # width
+
     @property
     def width(self) -> OptionalNumber:
         return self._get_attr("width", data_type="float")
@@ -88,6 +90,7 @@ class VerticalDivider(Control):
         self._set_attr("width", value)
 
     # thickness
+
     @property
     def thickness(self) -> OptionalNumber:
         return self._get_attr("thickness", data_type="float")
@@ -97,6 +100,7 @@ class VerticalDivider(Control):
         self._set_attr("thickness", value)
 
     # color
+
     @property
     def color(self):
         return self._get_attr("color")
@@ -106,6 +110,7 @@ class VerticalDivider(Control):
         self._set_attr("color", value)
 
     # leading_indent
+
     @property
     def leading_indent(self) -> OptionalNumber:
         return self._get_attr("leadingIndent", data_type="float")
@@ -115,6 +120,7 @@ class VerticalDivider(Control):
         self._set_attr("leadingIndent", value)
 
     # trailing_indent
+
     @property
     def trailing_indent(self) -> OptionalNumber:
         return self._get_attr("trailingIndent", data_type="float")

--- a/sdk/python/packages/flet-core/src/flet_core/video.py
+++ b/sdk/python/packages/flet-core/src/flet_core/video.py
@@ -1,16 +1,16 @@
 import dataclasses
 from enum import Enum
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, cast, Dict, List, Optional, Union
 
 from flet_core.alignment import Alignment
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import OptionalNumber
 from flet_core.ref import Ref
 from flet_core.text_style import TextStyle
 from flet_core.types import (
     AnimationValue,
     ImageFit,
     OffsetValue,
+    OptionalNumber,
     PaddingValue,
     ResponsiveNumber,
     RotateValue,
@@ -360,11 +360,13 @@ class Video(ConstrainedControl):
         return int(sr) if sr else None
 
     # playlist
+
     @property
     def playlist(self) -> Optional[List[VideoMedia]]:
         return self.__playlist
 
     # fit
+
     @property
     def fit(self) -> Optional[ImageFit]:
         return self.__fit
@@ -375,6 +377,7 @@ class Video(ConstrainedControl):
         self._set_attr("fit", value.value if isinstance(value, ImageFit) else value)
 
     # subtitle_configuration
+
     @property
     def subtitle_configuration(self) -> Optional[VideoSubtitleConfiguration]:
         return self.__subtitle_configuration
@@ -384,6 +387,7 @@ class Video(ConstrainedControl):
         self.__subtitle_configuration = value
 
     # fill_color
+
     @property
     def fill_color(self) -> Optional[str]:
         return self._get_attr("fillColor")
@@ -393,6 +397,7 @@ class Video(ConstrainedControl):
         self._set_attr("fillColor", value)
 
     # wakelock
+
     @property
     def wakelock(self) -> Optional[bool]:
         return self._get_attr("wakelock", data_type="bool", def_value=True)
@@ -402,6 +407,7 @@ class Video(ConstrainedControl):
         self._set_attr("wakelock", value)
 
     # autoplay
+
     @property
     def autoplay(self) -> Optional[bool]:
         return self._get_attr("autoPlay", data_type="bool", def_value=False)
@@ -411,6 +417,7 @@ class Video(ConstrainedControl):
         self._set_attr("autoPlay", value)
 
     # muted
+
     @property
     def muted(self) -> Optional[bool]:
         return self._get_attr("muted", data_type="bool", def_value=False)
@@ -420,6 +427,7 @@ class Video(ConstrainedControl):
         self._set_attr("muted", value)
 
     # shuffle_playlist
+
     @property
     def shuffle_playlist(self) -> Optional[bool]:
         return self._get_attr("shufflePlaylist", data_type="bool", def_value=False)
@@ -429,6 +437,7 @@ class Video(ConstrainedControl):
         self._set_attr("shufflePlaylist", value)
 
     # show_controls
+
     @property
     def show_controls(self) -> Optional[bool]:
         return self._get_attr("showControls", data_type="bool", def_value=True)
@@ -438,6 +447,7 @@ class Video(ConstrainedControl):
         self._set_attr("showControls", value)
 
     # pitch
+
     @property
     def pitch(self) -> OptionalNumber:
         return self._get_attr("pitch")
@@ -447,6 +457,7 @@ class Video(ConstrainedControl):
         self._set_attr("pitch", value)
 
     # volume
+
     @property
     def volume(self) -> OptionalNumber:
         return self._get_attr("volume")
@@ -456,6 +467,7 @@ class Video(ConstrainedControl):
         self._set_attr("volume", value)
 
     # playback_rate
+
     @property
     def playback_rate(self) -> OptionalNumber:
         return self._get_attr("playbackRate")
@@ -465,6 +477,7 @@ class Video(ConstrainedControl):
         self._set_attr("playbackRate", value)
 
     # title
+
     @property
     def title(self) -> Optional[str]:
         return self._get_attr("title")
@@ -474,6 +487,7 @@ class Video(ConstrainedControl):
         self._set_attr("title", value)
 
     # pause_upon_entering_background_mode
+
     @property
     def pause_upon_entering_background_mode(self) -> Optional[bool]:
         return cast(
@@ -488,6 +502,7 @@ class Video(ConstrainedControl):
         self._set_attr("pauseUponEnteringBackgroundMode", value)
 
     # resume_upon_entering_foreground_mode
+
     @property
     def resume_upon_entering_foreground_mode(self) -> Optional[bool]:
         return cast(
@@ -502,6 +517,7 @@ class Video(ConstrainedControl):
         self._set_attr("resumeUponEnteringForegroundMode", value)
 
     # alignment
+
     @property
     def alignment(self) -> Optional[Alignment]:
         return self.__alignment
@@ -511,6 +527,7 @@ class Video(ConstrainedControl):
         self.__alignment = value
 
     # filter_quality
+
     @property
     def filter_quality(self) -> Optional[FilterQuality]:
         return self.__filter_quality
@@ -521,6 +538,7 @@ class Video(ConstrainedControl):
         self._set_enum_attr("filterQuality", value, FilterQuality)
 
     # playlist_mode
+
     @property
     def playlist_mode(self) -> Optional[PlaylistMode]:
         return self.__playlist_mode
@@ -531,6 +549,7 @@ class Video(ConstrainedControl):
         self._set_enum_attr("playlistMode", value, PlaylistMode)
 
     # on_enter_fullscreen
+
     @property
     def on_enter_fullscreen(self):
         return self._get_event_handler("enter_fullscreen")
@@ -541,6 +560,7 @@ class Video(ConstrainedControl):
         self._set_attr("onEnterFullscreen", True if handler is not None else None)
 
     # on_exit_fullscreen
+
     @property
     def on_exit_fullscreen(self):
         return self._get_event_handler("exit_fullscreen")
@@ -551,6 +571,7 @@ class Video(ConstrainedControl):
         self._set_attr("onExitFullscreen", True if handler is not None else None)
 
     # on_loaded
+
     @property
     def on_loaded(self):
         return self._get_event_handler("loaded")
@@ -561,6 +582,7 @@ class Video(ConstrainedControl):
         self._add_event_handler("loaded", handler)
 
     # on_error
+
     @property
     def on_error(self):
         return self._get_event_handler("error")

--- a/sdk/python/packages/flet-core/src/flet_core/view.py
+++ b/sdk/python/packages/flet-core/src/flet_core/view.py
@@ -4,7 +4,6 @@ from flet_core import Control
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.app_bar import AppBar
 from flet_core.bottom_app_bar import BottomAppBar
-from flet_core.control import OptionalNumber
 from flet_core.cupertino_app_bar import CupertinoAppBar
 from flet_core.cupertino_navigation_bar import CupertinoNavigationBar
 from flet_core.floating_action_button import FloatingActionButton
@@ -16,6 +15,7 @@ from flet_core.types import (
     FloatingActionButtonLocation,
     MainAxisAlignment,
     OffsetValue,
+    OptionalNumber,
     PaddingValue,
     ScrollMode,
 )
@@ -126,6 +126,7 @@ class View(ScrollableControl, AdaptiveControl):
         return children
 
     # route
+
     @property
     def route(self):
         return self._get_attr("route")
@@ -135,6 +136,7 @@ class View(ScrollableControl, AdaptiveControl):
         self._set_attr("route", value)
 
     # controls
+
     @property
     def controls(self) -> List[Control]:
         return self.__controls
@@ -144,6 +146,7 @@ class View(ScrollableControl, AdaptiveControl):
         self.__controls = value
 
     # appbar
+
     @property
     def appbar(self) -> Union[AppBar, CupertinoAppBar, None]:
         return self.__appbar
@@ -153,6 +156,7 @@ class View(ScrollableControl, AdaptiveControl):
         self.__appbar = value
 
     # bottom_appbar
+
     @property
     def bottom_appbar(self) -> Optional[BottomAppBar]:
         return self.__bottom_appbar
@@ -162,6 +166,7 @@ class View(ScrollableControl, AdaptiveControl):
         self.__bottom_appbar = value
 
     # floating_action_button
+
     @property
     def floating_action_button(self) -> Optional[FloatingActionButton]:
         return self.__fab
@@ -171,6 +176,7 @@ class View(ScrollableControl, AdaptiveControl):
         self.__fab = value
 
     # floating_action_button_location
+
     @property
     def floating_action_button_location(
         self,
@@ -188,6 +194,7 @@ class View(ScrollableControl, AdaptiveControl):
         )
 
     # navigation_bar
+
     @property
     def navigation_bar(self) -> Union[NavigationBar, CupertinoNavigationBar, None]:
         return self.__navigation_bar
@@ -197,6 +204,7 @@ class View(ScrollableControl, AdaptiveControl):
         self.__navigation_bar = value
 
     # drawer
+
     @property
     def drawer(self) -> Optional[NavigationDrawer]:
         return self.__drawer
@@ -206,6 +214,7 @@ class View(ScrollableControl, AdaptiveControl):
         self.__drawer = value
 
     # end_drawer
+
     @property
     def end_drawer(self) -> Optional[NavigationDrawer]:
         return self.__end_drawer
@@ -215,6 +224,7 @@ class View(ScrollableControl, AdaptiveControl):
         self.__end_drawer = value
 
     # horizontal_alignment
+
     @property
     def horizontal_alignment(self) -> CrossAxisAlignment:
         return self.__horizontal_alignment
@@ -228,6 +238,7 @@ class View(ScrollableControl, AdaptiveControl):
         )
 
     # vertical_alignment
+
     @property
     def vertical_alignment(self) -> MainAxisAlignment:
         return self.__vertical_alignment
@@ -241,6 +252,7 @@ class View(ScrollableControl, AdaptiveControl):
         )
 
     # spacing
+
     @property
     def spacing(self) -> OptionalNumber:
         return self._get_attr("spacing")
@@ -250,6 +262,7 @@ class View(ScrollableControl, AdaptiveControl):
         self._set_attr("spacing", value)
 
     # padding
+
     @property
     def padding(self) -> PaddingValue:
         return self.__padding
@@ -259,6 +272,7 @@ class View(ScrollableControl, AdaptiveControl):
         self.__padding = value
 
     # bgcolor
+
     @property
     def bgcolor(self):
         return self._get_attr("bgcolor")
@@ -268,6 +282,7 @@ class View(ScrollableControl, AdaptiveControl):
         self._set_attr("bgcolor", value)
 
     # fullscreen_dialog
+
     @property
     def fullscreen_dialog(self) -> Optional[bool]:
         return self._get_attr("fullscreenDialog", data_type="bool", def_value=False)

--- a/sdk/python/packages/flet-core/src/flet_core/webview.py
+++ b/sdk/python/packages/flet-core/src/flet_core/webview.py
@@ -1,11 +1,11 @@
 from typing import Any, Optional, Union
 
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import OptionalNumber
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -149,6 +149,7 @@ class WebView(ConstrainedControl):
         self.bgcolor = bgcolor
 
         # events
+
         self.on_page_started = on_page_started
         self.on_page_ended = on_page_ended
         self.on_web_resource_error = on_web_resource_error
@@ -157,6 +158,7 @@ class WebView(ConstrainedControl):
         return "webview"
 
     # bgcolor
+
     @property
     def bgcolor(self):
         return self._get_attr("bgcolor")
@@ -166,6 +168,7 @@ class WebView(ConstrainedControl):
         self._set_attr("bgcolor", value)
 
     # url
+
     @property
     def url(self):
         return self._get_attr("url")
@@ -175,6 +178,7 @@ class WebView(ConstrainedControl):
         self._set_attr("url", value)
 
     # javascript_enabled
+
     @property
     def javascript_enabled(self):
         return self._get_attr("javascriptEnabled")
@@ -184,6 +188,7 @@ class WebView(ConstrainedControl):
         self._set_attr("javascriptEnabled", value)
 
     # prevent_link
+
     @property
     def prevent_link(self):
         return self._get_attr("prevent_link")
@@ -195,6 +200,7 @@ class WebView(ConstrainedControl):
     ## EVENTS
 
     # on_page_started
+
     @property
     def on_page_started(self):
         return self._get_event_handler("page_started")
@@ -204,6 +210,7 @@ class WebView(ConstrainedControl):
         self._add_event_handler("page_started", handler)
 
     # on_page_ended
+
     @property
     def on_page_ended(self):
         return self._get_event_handler("page_ended")
@@ -213,6 +220,7 @@ class WebView(ConstrainedControl):
         self._add_event_handler("page_ended", handler)
 
     # on_web_resource_error
+
     @property
     def on_web_resource_error(self):
         return self._get_event_handler("web_resource_error")

--- a/sdk/python/packages/flet-core/src/flet_core/window_drag_area.py
+++ b/sdk/python/packages/flet-core/src/flet_core/window_drag_area.py
@@ -1,11 +1,12 @@
 from typing import Any, Optional, Union
 
 from flet_core.constrained_control import ConstrainedControl
-from flet_core.control import Control, OptionalNumber
+from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     OffsetValue,
+    OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
@@ -123,6 +124,7 @@ class WindowDragArea(ConstrainedControl):
         return children
 
     # content
+
     @property
     def content(self):
         return self.__content
@@ -132,6 +134,7 @@ class WindowDragArea(ConstrainedControl):
         self.__content = value
 
     # maximizable
+
     @property
     def maximizable(self) -> Optional[bool]:
         return self._get_attr("maximizable", data_type="bool", def_value=True)


### PR DESCRIPTION
Checklist:
- [x] Rename `NavigationDesttination` to `NavigationBarDestination`
- [ ] Type hinting:
    - [ ] Add type alias:
        - [x] ControlEventFunction
        - [x] IconStr
        - [x] ColorStr
    - [x] `navigation_bar.py`, `navigation_drawer.py`, `navigation_rail.py`
    - [ ] `page.py`, `control.py`
- [x] Move `OptionalNumber` to `types.py`