### PR TITLE
Add `dropdown.Option.text_style` property

### DIFF
--- a/packages/flet/lib/src/controls/dropdown.dart
+++ b/packages/flet/lib/src/controls/dropdown.dart
@@ -97,15 +97,22 @@ class _DropdownControlState extends State<DropdownControl> with FletStoreMixin {
           .map((v) => v.control)
           .where((c) => c.name == null && c.isVisible)
           .map<DropdownMenuItem<String>>((Control itemCtrl) {
+        bool itemDisabled = disabled || itemCtrl.isDisabled;
+        TextStyle? textStyle =
+            parseTextStyle(Theme.of(context), itemCtrl, "textStyle");
+        if (itemDisabled && textStyle != null) {
+          textStyle = textStyle.apply(color: Theme.of(context).disabledColor);
+        }
         Widget itemChild = Text(
           itemCtrl.attrs["text"] ?? itemCtrl.attrs["key"] ?? itemCtrl.id,
+          style: textStyle,
         );
         var align = parseAlignment(itemCtrl, "alignment");
         if (align != null) {
           itemChild = Container(alignment: align, child: itemChild);
         }
         return DropdownMenuItem<String>(
-          enabled: !(disabled || itemCtrl.isDisabled),
+          enabled: !itemDisabled,
           value: itemCtrl.attrs["key"] ?? itemCtrl.attrs["text"] ?? itemCtrl.id,
           alignment: align ?? AlignmentDirectional.centerStart,
           onTap: !(disabled || itemCtrl.isDisabled)

--- a/sdk/python/packages/flet-core/src/flet_core/dropdown.py
+++ b/sdk/python/packages/flet-core/src/flet_core/dropdown.py
@@ -24,6 +24,7 @@ class Option(Control):
         key: Optional[str] = None,
         text: Optional[str] = None,
         alignment: Optional[Alignment] = None,
+        text_style: Optional[TextStyle] = None,
         on_click=None,
         #
         # Control
@@ -39,6 +40,7 @@ class Option(Control):
         self.text = text
         self.on_click = on_click
         self.alignment = alignment
+        self.text_style = text_style
 
     def _get_control_name(self):
         return "dropdownoption"
@@ -46,6 +48,8 @@ class Option(Control):
     def before_update(self):
         super().before_update()
         self._set_attr_json("alignment", self.__alignment)
+        if isinstance(self.__text_style, TextStyle):
+            self._set_attr_json("textStyle", self.__text_style)
 
     # key
     @property
@@ -73,6 +77,15 @@ class Option(Control):
     @alignment.setter
     def alignment(self, value: Optional[Alignment]):
         self.__alignment = value
+
+    # text_style
+    @property
+    def text_style(self) -> Optional[TextStyle]:
+        return self.__text_style
+
+    @text_style.setter
+    def text_style(self, value: Optional[TextStyle]):
+        self.__text_style = value
 
     # on_click
     @property


### PR DESCRIPTION
## Test Code
```python
import flet as ft


def main(page: ft.Page):
    page.add(
        ft.Dropdown(
            width=100,
            options=[
                ft.dropdown.Option(
                    "Red",
                    text_style=ft.TextStyle(color=ft.colors.RED, italic=True),
                    disabled=True,
                ),
                ft.dropdown.Option(
                    "Green", text_style=ft.TextStyle(color=ft.colors.GREEN, italic=True)
                ),
                ft.dropdown.Option("Blue", text_style=ft.TextStyle(color=ft.colors.BLUE)),
            ],
        )
    )


ft.app(target=main)

```