### PR TITLE
Add `AutoComplete.selected_index` read-only property

### DIFF
--- a/packages/flet/lib/src/controls/auto_complete.dart
+++ b/packages/flet/lib/src/controls/auto_complete.dart
@@ -28,6 +28,8 @@ class AutoCompleteControl extends StatelessWidget {
     var auto = Autocomplete(
       optionsMaxHeight: suggestionsMaxHeight,
       onSelected: (AutoCompleteSuggestion selection) {
+        backend.updateControlState(control.id,
+            {"selectedIndex": suggestions.indexOf(selection).toString()});
         backend.triggerControlEvent(
             control.id,
             "select",

--- a/sdk/python/packages/flet-core/src/flet_core/__init__.py
+++ b/sdk/python/packages/flet-core/src/flet_core/__init__.py
@@ -23,6 +23,11 @@ from flet_core.animation import Animation, AnimationCurve
 from flet_core.app_bar import AppBar
 from flet_core.audio import Audio
 from flet_core.audio_recorder import AudioEncoder, AudioRecorder
+from flet_core.auto_complete import (
+    AutoComplete,
+    AutoCompleteSuggestion,
+    AutoCompleteSelectEvent,
+)
 from flet_core.autofill_group import (
     AutofillGroup,
     AutofillGroupDisposeAction,

--- a/sdk/python/packages/flet-core/src/flet_core/auto_complete.py
+++ b/sdk/python/packages/flet-core/src/flet_core/auto_complete.py
@@ -46,7 +46,6 @@ class AutoComplete(Control):
         )
 
         def convert_event_data(e):
-            print(e.data)
             d = json.loads(e.data)
             return AutoCompleteSelectEvent(**d)
 
@@ -62,6 +61,11 @@ class AutoComplete(Control):
 
     def before_update(self):
         self._set_attr_json("suggestions", self.__suggestions)
+
+    # selected_index
+    @property
+    def selected_index(self) -> Optional[int]:
+        return self._get_attr("selectedIndex", data_type="int")
 
     # suggestions_max_height
     @property


### PR DESCRIPTION
## Test Code
```py
import flet as ft


def main(page: ft.Page):
    page.add(
        ft.AutoComplete(
            suggestions=[
                ft.AutoCompleteSuggestion(key="one 1", value="One"),
                ft.AutoCompleteSuggestion(key="two 2", value="Two"),
                ft.AutoCompleteSuggestion(key="three 3", value="Three"),
            ],
            on_select=lambda e: print(e.control.selected_index),
        )
    )


ft.app(target=main)


```