### PR TITLE
Urgent fix `open_{control_name}()` + fix `NavigationDestination`'s import

### DIFF
--- a/sdk/python/packages/flet-core/src/flet_core/__init__.py
+++ b/sdk/python/packages/flet-core/src/flet_core/__init__.py
@@ -180,6 +180,7 @@ from flet_core.menu_bar import MenuBar, MenuStyle
 from flet_core.menu_item_button import MenuItemButton
 from flet_core.navigation_bar import (
     NavigationBar,
+    NavigationDestination,
     NavigationBarDestination,
     NavigationBarLabelBehavior,
 )

--- a/sdk/python/packages/flet-core/src/flet_core/page.py
+++ b/sdk/python/packages/flet-core/src/flet_core/page.py
@@ -1012,7 +1012,7 @@ class Page(AdaptiveControl):
             base.update()
         else:
             raise Exception(
-                f"Please define {control_name} before open_{control_name}() method"
+                f"The control {control_name} must be defined before calling open_{control_name}() method"
             )
 
     def __close_control(

--- a/sdk/python/packages/flet-core/src/flet_core/page.py
+++ b/sdk/python/packages/flet-core/src/flet_core/page.py
@@ -1026,7 +1026,7 @@ class Page(AdaptiveControl):
             base.update()
         else:
             raise Exception(
-                f"Please define {control_name} before close_{control_name}() method"
+                f"The control {control_name} must be defined before calling close_{control_name}() method"
             )
 
     #

--- a/sdk/python/packages/flet-core/src/flet_core/page.py
+++ b/sdk/python/packages/flet-core/src/flet_core/page.py
@@ -1012,7 +1012,7 @@ class Page(AdaptiveControl):
             base.update()
         else:
             raise Exception(
-                f"Please define {control_name} before show_{control_name}() method"
+                f"Please define {control_name} before open_{control_name}() method"
             )
 
     def __close_control(


### PR DESCRIPTION
After last my pull (#3172) i've seen that in `Exception` message string there is `show_...()` method, but in this pull all `show_...()` methods have been renamed to `open_...()`. I fixed this message string.

Also i fixed NavigationDestination's import in __init__.py

@FeodorFitsner Can you quickly merge this pull?