### PR TITLE
Unify all `open_...()` and `close_...()` methods into `open()` and `close()`

### DIFF
--- a/sdk/python/packages/flet-core/src/flet_core/page.py
+++ b/sdk/python/packages/flet-core/src/flet_core/page.py
@@ -1066,9 +1066,29 @@ class Page(AdaptiveControl):
 
     def open(self, control_name: Literal['snack_bar', 'dialog', 'banner', 'bottom_sheet', 'drawer', 'end_drawer'],
              control: Optional[Openable] = None):
-        # TODO: Type check `control` variable
+        supported_types = {
+            'snack_bar': SnackBar,
+            'dialog': (AlertDialog, CupertinoAlertDialog),
+            'banner': Banner,
+            'bottom_sheet': BottomSheet,
+            'drawer': NavigationDrawer,
+            'end_drawer': NavigationDrawer,
+        }
+
+        if control_name not in list(supported_types.keys()):
+            raise Exception(
+                f"control_name argument must be in list of supported controls. Supported controls: " +
+                ",".join(list(supported_types.keys()))
+            )
 
         if control:
+            t = supported_types[control_name]
+            if not isinstance(control, t):
+                raise Exception(
+                    f"The {control_name} property can have only the following types: " +
+                    ",".join([str(t)] if not isinstance(t, tuple) else [str(i) for i in t])
+                )
+
             self.__setattr__(self, control_name, control)
 
         self.__open_control(control_name, self.__getattribute__(self, control_name))

--- a/sdk/python/packages/flet-core/src/flet_core/page.py
+++ b/sdk/python/packages/flet-core/src/flet_core/page.py
@@ -1066,8 +1066,12 @@ class Page(AdaptiveControl):
 
     def open(self, control_name: Literal['snack_bar', 'dialog', 'banner', 'bottom_sheet', 'drawer', 'end_drawer'],
              control: Optional[Openable] = None):
-        # TODO: Realisation of open()
-        ...
+        # TODO: Type check `control` variable
+
+        if control:
+            self.__setattr__(self, control_name, control)
+
+        self.__open_control(control_name, self.__getattribute__(self, control_name))
 
     #
     # SnackBar

--- a/sdk/python/packages/flet-core/src/flet_core/page.py
+++ b/sdk/python/packages/flet-core/src/flet_core/page.py
@@ -1096,35 +1096,31 @@ class Page(AdaptiveControl):
     #
     # SnackBar
     #
-    @overload
-    def open_snack_bar(self) -> None:
-        ...
-
-    @overload
-    def open_snack_bar(self, snack_bar: SnackBar) -> None:
-        ...
-
-    def open_snack_bar(self, snack_bar=None) -> None:
-        if snack_bar:
-            self.__offstage.snack_bar = snack_bar
-        self.__open_control("snack_bar", self.__offstage.snack_bar, self.__offstage)
 
     # Deprecated
     @deprecated(
-        reason="Use open_snack_bar() method instead.",
+        reason="Use open('snack_bar') method instead.",
+        version="0.22.1",
+        delete_version="1.0",
+    )
+    def open_snack_bar(self, snack_bar=None) -> None:
+        self.open('snack_bar', snack_bar)
+
+    @deprecated(
+        reason="Use open('snack_bar') method instead.",
         version="0.22.1",
         delete_version="1.0",
     )
     def show_snack_bar(self, snack_bar: SnackBar = None):
-        self.open_snack_bar(snack_bar)
+        self.open('snack_bar', snack_bar)
 
     @deprecated(
-        reason="Use open_snack_bar() method instead.",
+        reason="Use open('snack_bar') method instead.",
         version="0.21.0",
         delete_version="1.0",
     )
     async def show_snack_bar_async(self, snack_bar: SnackBar = None):
-        self.open_snack_bar(snack_bar)
+        self.open('snack_bar', snack_bar)
 
     # End deprecated
 
@@ -1134,37 +1130,33 @@ class Page(AdaptiveControl):
     #
     # Dialogs
     #
-    @overload
-    def open_dialog(self) -> None:
-        ...
-
-    @overload
-    def open_dialog(self, dialog: Union[AlertDialog, CupertinoAlertDialog]) -> None:
-        ...
-
-    def open_dialog(self, dialog=None) -> None:
-        if dialog:
-            self.__offstage.dialog = dialog
-        self.__open_control("dialog", self.__offstage.dialog, self.__offstage)
 
     # Deprecated
     @deprecated(
-        reason="Use open_dialog() method instead.",
+        reason="Use open('dialog') method instead.",
+        version="0.22.1",
+        delete_version="1.0",
+    )
+    def open_dialog(self, dialog=None) -> None:
+        self.open('dialog', dialog)
+
+    @deprecated(
+        reason="Use open('dialog') method instead.",
         version="0.22.1",
         delete_version="1.0",
     )
     def show_dialog(self, dialog: Union[AlertDialog, CupertinoAlertDialog] = None):
-        self.open_dialog(dialog)
+        self.open('dialog', dialog)
 
     @deprecated(
-        reason="Use open_dialog() method instead.",
+        reason="Use open('dialog') method instead.",
         version="0.21.0",
         delete_version="1.0",
     )
     async def show_dialog_async(
         self, dialog: Union[AlertDialog, CupertinoAlertDialog] = None
     ):
-        self.open_dialog(dialog)
+        self.open('dialog', dialog)
 
     # End deprecated
 
@@ -1182,35 +1174,31 @@ class Page(AdaptiveControl):
     #
     # Banner
     #
-    @overload
-    def open_banner(self) -> None:
-        ...
-
-    @overload
-    def open_banner(self, banner: Banner) -> None:
-        ...
-
-    def open_banner(self, banner=None) -> None:
-        if banner:
-            self.__offstage.banner = banner
-        self.__open_control("banner", self.__offstage.banner, self.__offstage)
 
     # Deprecated
     @deprecated(
-        reason="Use open_banner() method instead.",
+        reason="Use open('banner') method instead.",
+        version="0.22.1",
+        delete_version="1.0",
+    )
+    def open_banner(self, banner=None) -> None:
+        self.open('banner', banner)
+
+    @deprecated(
+        reason="Use open('banner') method instead.",
         version="0.22.1",
         delete_version="1.0",
     )
     def show_banner(self, banner: Banner = None):
-        self.open_banner(banner)
+        self.open('banner', banner)
 
     @deprecated(
-        reason="Use open_banner() method instead.",
+        reason="Use open('banner') method instead.",
         version="0.21.0",
         delete_version="1.0",
     )
     async def show_banner_async(self, banner: Banner = None):
-        self.open_banner(banner)
+        self.open('banner', banner)
 
     # End deprecated
 
@@ -1228,43 +1216,35 @@ class Page(AdaptiveControl):
     #
     # BottomSheet
     #
-    @overload
-    def open_bottom_sheet(self) -> None:
-        ...
-
-    @overload
-    def open_bottom_sheet(
-        self, bottom_sheet: Union[BottomSheet, CupertinoBottomSheet]
-    ) -> None:
-        ...
-
-    def open_bottom_sheet(self, bottom_sheet=None) -> None:
-        if bottom_sheet:
-            self.__offstage.bottom_sheet = bottom_sheet
-        self.__open_control(
-            "bottom_sheet", self.__offstage.bottom_sheet, self.__offstage
-        )
 
     # Deprecated
     @deprecated(
-        reason="Use open_bottom_sheet() method instead.",
+        reason="Use open('bottom_sheet') method instead.",
+        version="0.22.1",
+        delete_version="1.0",
+    )
+    def open_bottom_sheet(self, bottom_sheet=None) -> None:
+        self.open('bottom_sheet', bottom_sheet)
+
+    @deprecated(
+        reason="Use open('bottom_sheet') method instead.",
         version="0.22.1",
         delete_version="1.0",
     )
     def show_bottom_sheet(
         self, bottom_sheet: Union[BottomSheet, CupertinoBottomSheet] = None
     ):
-        self.open_bottom_sheet(bottom_sheet)
+        self.open('bottom_sheet', bottom_sheet)
 
     @deprecated(
-        reason="Use open_bottom_sheet() method instead.",
+        reason="Use open('bottom_sheet') method instead.",
         version="0.21.0",
         delete_version="1.0",
     )
     async def show_bottom_sheet_async(
         self, bottom_sheet: Union[BottomSheet, CupertinoBottomSheet] = None
     ):
-        self.open_bottom_sheet(bottom_sheet)
+        self.open('bottom_sheet', bottom_sheet)
 
     # End deprecated
 
@@ -1284,35 +1264,31 @@ class Page(AdaptiveControl):
     #
     # Drawer
     #
-    @overload
-    def open_drawer(self) -> None:
-        ...
-
-    @overload
-    def open_drawer(self, drawer: NavigationDrawer) -> None:
-        ...
-
-    def open_drawer(self, drawer=None) -> None:
-        if drawer:
-            self.drawer = drawer
-        self.__open_control("drawer", self.drawer)
 
     # Deprecated
     @deprecated(
-        reason="Use open_drawer() method instead.",
+        reason="Use open('drawer') method instead.",
+        version="0.22.1",
+        delete_version="1.0",
+    )
+    def open_drawer(self, drawer=None) -> None:
+        self.open('drawer', drawer)
+
+    @deprecated(
+        reason="Use open('drawer') method instead.",
         version="0.22.1",
         delete_version="1.0",
     )
     def show_drawer(self, drawer: NavigationDrawer = None):
-        self.open_drawer(drawer)
+        self.open('drawer', drawer)
 
     @deprecated(
-        reason="Use open_drawer() method instead.",
+        reason="Use open('drawer') method instead.",
         version="0.21.0",
         delete_version="1.0",
     )
     async def show_drawer_async(self, drawer: NavigationDrawer = None):
-        self.open_drawer(drawer)
+        self.open('drawer', drawer)
 
     # End deprecated
 
@@ -1330,35 +1306,31 @@ class Page(AdaptiveControl):
     #
     # End_drawer
     #
-    @overload
-    def open_end_drawer(self) -> None:
-        ...
-
-    @overload
-    def open_end_drawer(self, end_drawer: NavigationDrawer) -> None:
-        ...
-
-    def open_end_drawer(self, end_drawer=None) -> None:
-        if end_drawer:
-            self.end_drawer = end_drawer
-        self.__open_control("end_drawer", self.end_drawer)
 
     # Deprecated
     @deprecated(
-        reason="Use open_end_drawer() method instead.",
+        reason="Use open('end_drawer') method instead.",
+        version="0.22.1",
+        delete_version="1.0",
+    )
+    def open_end_drawer(self, end_drawer=None) -> None:
+        self.open('end_drawer', end_drawer)
+
+    @deprecated(
+        reason="Use open('end_drawer') method instead.",
         version="0.22.1",
         delete_version="1.0",
     )
     def show_end_drawer(self, end_drawer: NavigationDrawer = None):
-        self.open_end_drawer(end_drawer)
+        self.open('end_drawer', end_drawer)
 
     @deprecated(
-        reason="Use open_end_drawer() method instead.",
+        reason="Use open('end_drawer') method instead.",
         version="0.21.0",
         delete_version="1.0",
     )
     async def show_end_drawer_async(self, end_drawer: NavigationDrawer = None):
-        self.open_end_drawer(end_drawer)
+        self.open('end_drawer', end_drawer)
 
     # End deprecated
 

--- a/sdk/python/packages/flet-core/src/flet_core/page.py
+++ b/sdk/python/packages/flet-core/src/flet_core/page.py
@@ -22,7 +22,7 @@ from typing import (
     TypeVar,
     Union,
     cast,
-    overload,
+    overload, Literal,
 )
 from urllib.parse import urlparse
 
@@ -64,6 +64,7 @@ from flet_core.types import (
     MainAxisAlignment,
     OffsetValue,
     OptionalNumber,
+    Openable,
     PaddingValue,
     PagePlatform,
     ScrollMode,
@@ -1029,8 +1030,36 @@ class Page(AdaptiveControl):
                 f"Please define {control_name} before close_{control_name}() method"
             )
 
-    # TODO: signature overloads with all supported types
-    def open(self, control_name: str, control: Optional[SnackBar, AlertDialog, CupertinoAlertDialog, Banner, BottomSheet, NavigationDrawer] = None):
+    @overload
+    def open(self, control_name: Literal['snack_bar', 'dialog', 'banner', 'bottom_sheet', 'drawer', 'end_drawer']):
+        ...
+
+    @overload
+    def open(self, control_name: Literal['snack_bar'], control: SnackBar):
+        ...
+
+    @overload
+    def open(self, control_name: Literal['dialog'], control: Union[AlertDialog, CupertinoAlertDialog]):
+        ...
+
+    @overload
+    def open(self, control_name: Literal['banner'], control: Banner):
+        ...
+
+    @overload
+    def open(self, control_name: Literal['bottom_sheet'], control: BottomSheet):
+        ...
+
+    @overload
+    def open(self, control_name: Literal['drawer'], control: NavigationDrawer):
+        ...
+
+    @overload
+    def open(self, control_name: Literal['end_drawer'], control: NavigationDrawer):
+        ...
+
+    def open(self, control_name: Literal['snack_bar', 'dialog', 'banner', 'bottom_sheet', 'drawer', 'end_drawer'],
+             control: Optional[Openable] = None):
         # TODO: Realisation of open()
         ...
 

--- a/sdk/python/packages/flet-core/src/flet_core/page.py
+++ b/sdk/python/packages/flet-core/src/flet_core/page.py
@@ -22,8 +22,14 @@ from typing import (
     TypeVar,
     Union,
     cast,
-    overload, Literal,
+    overload,
 )
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
+
 from urllib.parse import urlparse
 
 import flet_core

--- a/sdk/python/packages/flet-core/src/flet_core/page.py
+++ b/sdk/python/packages/flet-core/src/flet_core/page.py
@@ -1114,11 +1114,12 @@ class Page(AdaptiveControl):
 
         self.__close_control(control_name, self.__getattribute__(self, control_name))
 
+    # Start deprecated
+
     #
     # SnackBar
     #
 
-    # Deprecated
     @deprecated(
         reason="Use open('snack_bar') method instead.",
         version="0.22.1",
@@ -1143,16 +1144,18 @@ class Page(AdaptiveControl):
     async def show_snack_bar_async(self, snack_bar: SnackBar = None):
         self.open('snack_bar', snack_bar)
 
-    # End deprecated
-
+    @deprecated(
+        reason="Use close('snack_bar') method instead.",
+        version="0.21.1",
+        delete_version="1.0",
+    )
     def close_snack_bar(self) -> None:
-        self.__close_control("snack_bar", self.__offstage.snack_bar, self.__offstage)
+        self.close("snack_bar")
 
     #
     # Dialogs
     #
 
-    # Deprecated
     @deprecated(
         reason="Use open('dialog') method instead.",
         version="0.22.1",
@@ -1179,24 +1182,26 @@ class Page(AdaptiveControl):
     ):
         self.open('dialog', dialog)
 
-    # End deprecated
-
+    @deprecated(
+        reason="Use close('dialog') method instead.",
+        version="0.21.1",
+        delete_version="1.0",
+    )
     def close_dialog(self) -> None:
-        self.__close_control("dialog", self.__offstage.dialog, self.__offstage)
+        self.close('dialog')
 
     @deprecated(
-        reason="Use close_dialog() method instead.",
+        reason="Use close('dialog') method instead.",
         version="0.21.0",
         delete_version="1.0",
     )
     async def close_dialog_async(self):
-        self.close_dialog()
+        self.close('dialog')
 
     #
     # Banner
     #
 
-    # Deprecated
     @deprecated(
         reason="Use open('banner') method instead.",
         version="0.22.1",
@@ -1221,24 +1226,26 @@ class Page(AdaptiveControl):
     async def show_banner_async(self, banner: Banner = None):
         self.open('banner', banner)
 
-    # End deprecated
-
+    @deprecated(
+        reason="Use close('banner') method instead.",
+        version="0.21.1",
+        delete_version="1.0",
+    )
     def close_banner(self) -> None:
-        self.__close_control("banner", self.__offstage.banner, self.__offstage)
+        self.close('banner')
 
     @deprecated(
-        reason="Use close_banner() method instead.",
+        reason="Use close('banner') method instead.",
         version="0.21.0",
         delete_version="1.0",
     )
     async def close_banner_async(self):
-        self.close_banner()
+        self.close('banner')
 
     #
     # BottomSheet
     #
 
-    # Deprecated
     @deprecated(
         reason="Use open('bottom_sheet') method instead.",
         version="0.22.1",
@@ -1267,26 +1274,26 @@ class Page(AdaptiveControl):
     ):
         self.open('bottom_sheet', bottom_sheet)
 
-    # End deprecated
-
+    @deprecated(
+        reason="Use close('bottom_sheet') method instead.",
+        version="0.21.1",
+        delete_version="1.0",
+    )
     def close_bottom_sheet(self) -> None:
-        self.__close_control(
-            "bottom_sheet", self.__offstage.bottom_sheet, self.__offstage
-        )
+        self.close('bottom_sheet')
 
     @deprecated(
-        reason="Use close_bottom_sheet() method instead.",
+        reason="Use close('bottom_sheet') method instead.",
         version="0.21.0",
         delete_version="1.0",
     )
     async def close_bottom_sheet_async(self):
-        self.close_bottom_sheet()
+        self.close('bottom_sheet')
 
     #
     # Drawer
     #
 
-    # Deprecated
     @deprecated(
         reason="Use open('drawer') method instead.",
         version="0.22.1",
@@ -1311,24 +1318,25 @@ class Page(AdaptiveControl):
     async def show_drawer_async(self, drawer: NavigationDrawer = None):
         self.open('drawer', drawer)
 
-    # End deprecated
-
+    @deprecated(
+        reason="Use close('drawer') method instead.",
+        version="0.21.1",
+        delete_version="1.0",
+    )
     def close_drawer(self):
-        self.__close_control("drawer", self.drawer)
+        self.close('drawer')
 
     @deprecated(
-        reason="Use close_drawer() method instead.",
+        reason="Use close('drawer') method instead.",
         version="0.21.0",
         delete_version="1.0",
     )
     async def close_drawer_async(self):
-        self.close_drawer()
+        self.close('drawer')
 
     #
     # End_drawer
     #
-
-    # Deprecated
     @deprecated(
         reason="Use open('end_drawer') method instead.",
         version="0.22.1",
@@ -1353,18 +1361,23 @@ class Page(AdaptiveControl):
     async def show_end_drawer_async(self, end_drawer: NavigationDrawer = None):
         self.open('end_drawer', end_drawer)
 
-    # End deprecated
-
+    @deprecated(
+        reason="Use close('end_drawer') method instead.",
+        version="0.21.1",
+        delete_version="1.0",
+    )
     def close_end_drawer(self) -> None:
-        self.__close_control("end_drawer", self.end_drawer)
+        self.close('end_drawer')
 
     @deprecated(
-        reason="Use close_end_drawer() method instead.",
+        reason="Use close('end_drawer') method instead.",
         version="0.21.0",
         delete_version="1.0",
     )
     async def close_end_drawer_async(self):
-        self.close_end_drawer()
+        self.close('end_drawer')
+
+    # End deprecated
 
     def window_destroy(self) -> None:
         self._set_attr("windowDestroy", "true")

--- a/sdk/python/packages/flet-core/src/flet_core/page.py
+++ b/sdk/python/packages/flet-core/src/flet_core/page.py
@@ -1036,7 +1036,7 @@ class Page(AdaptiveControl):
                 f"Please define {control_name} before close('{control_name}') method"
             )
 
-    def __get_supported_types(self) -> Dict[str, Union[type, tuple[type, ...]]]:
+    def __get_supported_types(self) -> Dict[str, Union[type, Tuple[type, ...]]]:
         return {
             'snack_bar': SnackBar,
             'dialog': (AlertDialog, CupertinoAlertDialog),

--- a/sdk/python/packages/flet-core/src/flet_core/page.py
+++ b/sdk/python/packages/flet-core/src/flet_core/page.py
@@ -1029,6 +1029,11 @@ class Page(AdaptiveControl):
                 f"Please define {control_name} before close_{control_name}() method"
             )
 
+    # TODO: signature overloads with all supported types
+    def open(self, control_name: str, control: Optional[SnackBar, AlertDialog, CupertinoAlertDialog, Banner, BottomSheet, NavigationDrawer] = None):
+        # TODO: Realisation of open()
+        ...
+
     #
     # SnackBar
     #

--- a/sdk/python/packages/flet-core/src/flet_core/page.py
+++ b/sdk/python/packages/flet-core/src/flet_core/page.py
@@ -1019,7 +1019,7 @@ class Page(AdaptiveControl):
             base.update()
         else:
             raise Exception(
-                f"Please define {control_name} before show_{control_name}() method"
+                f"Please define {control_name} before open('{control_name}') method"
             )
 
     def __close_control(
@@ -1033,8 +1033,18 @@ class Page(AdaptiveControl):
             base.update()
         else:
             raise Exception(
-                f"Please define {control_name} before close_{control_name}() method"
+                f"Please define {control_name} before close('{control_name}') method"
             )
+
+    def __get_supported_types(self) -> Dict[str, Union[type, tuple[type, ...]]]:
+        return {
+            'snack_bar': SnackBar,
+            'dialog': (AlertDialog, CupertinoAlertDialog),
+            'banner': Banner,
+            'bottom_sheet': BottomSheet,
+            'drawer': NavigationDrawer,
+            'end_drawer': NavigationDrawer,
+        }
 
     @overload
     def open(self, control_name: Literal['snack_bar', 'dialog', 'banner', 'bottom_sheet', 'drawer', 'end_drawer']):
@@ -1065,15 +1075,8 @@ class Page(AdaptiveControl):
         ...
 
     def open(self, control_name: Literal['snack_bar', 'dialog', 'banner', 'bottom_sheet', 'drawer', 'end_drawer'],
-             control: Optional[Openable] = None):
-        supported_types = {
-            'snack_bar': SnackBar,
-            'dialog': (AlertDialog, CupertinoAlertDialog),
-            'banner': Banner,
-            'bottom_sheet': BottomSheet,
-            'drawer': NavigationDrawer,
-            'end_drawer': NavigationDrawer,
-        }
+             control: Optional[Openable] = None) -> None:
+        supported_types = self.__get_supported_types()
 
         if control_name not in list(supported_types.keys()):
             raise Exception(
@@ -1092,6 +1095,24 @@ class Page(AdaptiveControl):
             self.__setattr__(self, control_name, control)
 
         self.__open_control(control_name, self.__getattribute__(self, control_name))
+
+    def close(
+            self, control_name: Literal['snack_bar', 'dialog', 'banner', 'bottom_sheet', 'drawer', 'end_drawer']
+    ) -> None:
+        supported_types = self.__get_supported_types()
+
+        if control_name not in list(supported_types.keys()):
+            raise Exception(
+                f"control_name argument must be in list of supported controls. Supported controls: " +
+                ",".join(list(supported_types.keys()))
+            )
+
+        if not self.__getattribute__(self, control_name).open:
+            raise Exception(
+                f"{control_name} must be opened before closing."
+            )
+
+        self.__close_control(control_name, self.__getattribute__(self, control_name))
 
     #
     # SnackBar

--- a/sdk/python/packages/flet-core/src/flet_core/types.py
+++ b/sdk/python/packages/flet-core/src/flet_core/types.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional, Protocol, Tuple, Union
+from typing import Any, Callable, Dict, Optional, Protocol, Tuple, Union
 
 from flet_core.animation import Animation
 from flet_core.border_radius import BorderRadius
@@ -318,6 +318,13 @@ Wrapper = Callable[..., Any]
 
 
 # Protocols
+class Openable(Protocol):
+    @property
+    def open(self) -> Optional[bool]: ...
+
+    @open.setter
+    def open(self, value: Optional[bool]): ...
+
 class SupportsStr(Protocol):
     def __str__(self) -> str:
         ...


### PR DESCRIPTION
TODO:
- [ ] `open()`
  - [x] Signature
  - [x] Realisation
  - [x] Type check
  - [x] Deprecations
  - [ ] Documentation
- [ ] `close()`
  - [x] Signature
  - [x] Realisation
  - [x] Type check
  - [x] Deprecations
  - [ ] Documentation
- [ ] Isort and black formating

closes #3367
