### PR TITLE
Set `Theme.color_scheme.primary` as default color

### DIFF
--- a/packages/flet/lib/src/controls/container.dart
+++ b/packages/flet/lib/src/controls/container.dart
@@ -132,7 +132,8 @@ class ContainerControl extends StatelessWidget with FletStoreMixin {
           image: image,
           backgroundBlendMode:
               bgColor != null || gradient != null ? blendMode : null,
-          border: parseBorder(Theme.of(context), control, "border"),
+          border: parseBorder(Theme.of(context), control, "border",
+              Theme.of(context).colorScheme.primary),
           borderRadius: borderRadius,
           shape: shape,
           boxShadow: parseBoxShadow(Theme.of(context), control, "shadow"));

--- a/packages/flet/lib/src/utils/borders.dart
+++ b/packages/flet/lib/src/utils/borders.dart
@@ -27,7 +27,7 @@ Radius? parseRadius(Control control, String propName, [Radius? defaultValue]) {
 }
 
 Border? parseBorder(ThemeData theme, Control control, String propName,
-    {Color? defaultSideColor}) {
+    [Color? defaultSideColor]) {
   var v = control.attrString(propName, null);
   if (v == null) {
     return null;


### PR DESCRIPTION
Closes #2256 

Works well with the code in the issue. 
Should we somehow make this the default throughout (at more areas)?

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request enhances the `ContainerControl` widget by setting the default border color to the Theme's `colorScheme.primary`, ensuring a consistent appearance across the application.

* **Enhancements**:
    - Set the default border color to the Theme's `colorScheme.primary` in the `ContainerControl` widget.

<!-- Generated by sourcery-ai[bot]: end summary -->