### PR TITLE
`SliverListView` and `SliverGridView` controls

### DIFF
--- a/packages/flet/lib/src/controls/create_control.dart
+++ b/packages/flet/lib/src/controls/create_control.dart
@@ -101,6 +101,7 @@ import 'semantics_service.dart';
 import 'shader_mask.dart';
 import 'shake_detector.dart';
 import 'slider.dart';
+import 'sliver_grid_view.dart';
 import 'sliver_list_view.dart';
 import 'snack_bar.dart';
 import 'stack.dart';
@@ -707,6 +708,15 @@ Widget createWidget(
           backend: backend);
     case "gridview":
       return GridViewControl(
+          key: key,
+          parent: parent,
+          control: controlView.control,
+          children: controlView.children,
+          parentDisabled: parentDisabled,
+          parentAdaptive: parentAdaptive,
+          backend: backend);
+    case "sliver_grid_view":
+      return SliverGridViewControl(
           key: key,
           parent: parent,
           control: controlView.control,

--- a/packages/flet/lib/src/controls/create_control.dart
+++ b/packages/flet/lib/src/controls/create_control.dart
@@ -101,6 +101,7 @@ import 'semantics_service.dart';
 import 'shader_mask.dart';
 import 'shake_detector.dart';
 import 'slider.dart';
+import 'sliver_list_view.dart';
 import 'snack_bar.dart';
 import 'stack.dart';
 import 'submenu_button.dart';
@@ -688,6 +689,15 @@ Widget createWidget(
           backend: backend);
     case "listview":
       return ListViewControl(
+          key: key,
+          parent: parent,
+          control: controlView.control,
+          children: controlView.children,
+          parentDisabled: parentDisabled,
+          parentAdaptive: parentAdaptive,
+          backend: backend);
+    case "sliver_list_view":
+      return SliverListViewControl(
           key: key,
           parent: parent,
           control: controlView.control,

--- a/packages/flet/lib/src/controls/list_view.dart
+++ b/packages/flet/lib/src/controls/list_view.dart
@@ -133,7 +133,7 @@ class _ListViewControlState extends State<ListViewControl> {
 
         child = ScrollableControl(
             control: widget.control,
-            scrollDirection: horizontal ? Axis.horizontal : Axis.vertical,
+            scrollDirection: scrollDirection,
             scrollController: _controller,
             backend: widget.backend,
             parentAdaptive: adaptive,

--- a/packages/flet/lib/src/controls/sliver_list_view.dart
+++ b/packages/flet/lib/src/controls/sliver_list_view.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+
+import '../flet_control_backend.dart';
+import '../models/control.dart';
+import '../utils/desktop.dart';
+import '../utils/others.dart';
+import '../widgets/adjustable_scroll_controller.dart';
+import 'create_control.dart';
+import 'scroll_notification_control.dart';
+import 'scrollable_control.dart';
+
+class SliverListViewControl extends StatefulWidget {
+  final Control? parent;
+  final Control control;
+  final bool parentDisabled;
+  final List<Control> children;
+  final bool? parentAdaptive;
+  final FletControlBackend backend;
+
+  const SliverListViewControl(
+      {super.key,
+      this.parent,
+      required this.control,
+      required this.children,
+      required this.parentDisabled,
+      required this.parentAdaptive,
+      required this.backend});
+
+  @override
+  State<SliverListViewControl> createState() => _SliverListViewControlState();
+}
+
+class _SliverListViewControlState extends State<SliverListViewControl> {
+  late final ScrollController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller =
+        isWindowsDesktop() ? AdjustableScrollController() : ScrollController();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    debugPrint("SliverListViewControl build: ${widget.control.id}");
+
+    bool disabled = widget.control.isDisabled || widget.parentDisabled;
+    bool? adaptive =
+        widget.control.attrBool("adaptive") ?? widget.parentAdaptive;
+
+    final horizontal = widget.control.attrBool("horizontal", false)!;
+    final spacing = widget.control.attrDouble("spacing", 0)!;
+    final dividerThickness = widget.control.attrDouble("dividerThickness", 0)!;
+    final cacheExtent = widget.control.attrDouble("cacheExtent");
+    var clipBehavior =
+        parseClip(widget.control.attrString("clipBehavior"), Clip.hardEdge)!;
+
+    List<Control> visibleControls =
+        widget.children.where((c) => c.isVisible).toList();
+    var scrollDirection = horizontal ? Axis.horizontal : Axis.vertical;
+
+    Widget child = spacing > 0
+        ? SliverList.separated(
+            itemCount: widget.children.length,
+            itemBuilder: (context, index) {
+              return createControl(
+                  widget.control, visibleControls[index].id, disabled,
+                  parentAdaptive: adaptive);
+            },
+            separatorBuilder: (context, index) {
+              return horizontal
+                  ? dividerThickness == 0
+                      ? SizedBox(width: spacing)
+                      : VerticalDivider(
+                          width: spacing, thickness: dividerThickness)
+                  : dividerThickness == 0
+                      ? SizedBox(height: spacing)
+                      : Divider(height: spacing, thickness: dividerThickness);
+            },
+          )
+        : SliverList.builder(
+            itemCount: widget.children.length,
+            itemBuilder: (context, index) {
+              return createControl(
+                  widget.control, visibleControls[index].id, disabled,
+                  parentAdaptive: adaptive);
+            },
+          );
+    child = CustomScrollView(
+      slivers: [child],
+      cacheExtent: cacheExtent,
+      clipBehavior: clipBehavior,
+      scrollDirection: scrollDirection,
+    );
+    child = ScrollableControl(
+        control: widget.control,
+        scrollDirection: scrollDirection,
+        scrollController: _controller,
+        backend: widget.backend,
+        parentAdaptive: adaptive,
+        child: child);
+    if (widget.control.attrBool("onScroll", false)!) {
+      child = ScrollNotificationControl(
+          control: widget.control, backend: widget.backend, child: child);
+    }
+
+    return constrainedControl(context, child, widget.parent, widget.control);
+  }
+}

--- a/sdk/python/packages/flet-core/src/flet_core/__init__.py
+++ b/sdk/python/packages/flet-core/src/flet_core/__init__.py
@@ -245,6 +245,7 @@ from flet_core.shader_mask import ShaderMask
 from flet_core.shadow import BoxShadow, ShadowBlurStyle
 from flet_core.shake_detector import ShakeDetector
 from flet_core.slider import Slider, SliderInteraction
+from flet_core.sliver_grid_view import SliverGridView
 from flet_core.sliver_list_view import SliverListView
 from flet_core.snack_bar import DismissDirection, SnackBar, SnackBarBehavior
 from flet_core.stack import Stack, StackFit

--- a/sdk/python/packages/flet-core/src/flet_core/__init__.py
+++ b/sdk/python/packages/flet-core/src/flet_core/__init__.py
@@ -245,6 +245,7 @@ from flet_core.shader_mask import ShaderMask
 from flet_core.shadow import BoxShadow, ShadowBlurStyle
 from flet_core.shake_detector import ShakeDetector
 from flet_core.slider import Slider, SliderInteraction
+from flet_core.sliver_list_view import SliverListView
 from flet_core.snack_bar import DismissDirection, SnackBar, SnackBarBehavior
 from flet_core.stack import Stack, StackFit
 from flet_core.submenu_button import SubmenuButton

--- a/sdk/python/packages/flet-core/src/flet_core/sliver_grid_view.py
+++ b/sdk/python/packages/flet-core/src/flet_core/sliver_grid_view.py
@@ -16,30 +16,28 @@ from flet_core.types import (
 )
 
 
-class SliverListView(ConstrainedControl, ScrollableControl, AdaptiveControl):
+class SliverGridView(ConstrainedControl, ScrollableControl, AdaptiveControl):
     """
-    A scrollable list of controls arranged linearly.
+    A scrollable, 2D array of controls.
 
     -----
 
-    Online docs: https://flet.dev/docs/controls/sliverlistview
+    Online docs: https://flet.dev/docs/controls/slivergridview
     """
 
     def __init__(
         self,
         controls: Optional[List[Control]] = None,
         horizontal: Optional[bool] = None,
+        runs_count: Optional[int] = None,
+        max_extent: Optional[int] = None,
         spacing: OptionalNumber = None,
-        divider_thickness: OptionalNumber = None,
+        run_spacing: OptionalNumber = None,
+        child_aspect_ratio: OptionalNumber = None,
         padding: PaddingValue = None,
         clip_behavior: Optional[ClipBehavior] = None,
+        semantic_child_count: Optional[int] = None,
         cache_extent: OptionalNumber = None,
-        #
-        # ScrollableControl
-        #
-        on_scroll_interval: OptionalNumber = None,
-        on_scroll: Any = None,
-        reverse: Optional[bool] = None,
         #
         # ConstrainedControl
         #
@@ -69,6 +67,13 @@ class SliverListView(ConstrainedControl, ScrollableControl, AdaptiveControl):
         visible: Optional[bool] = None,
         disabled: Optional[bool] = None,
         data: Any = None,
+        #
+        # ScrollableControl
+        #
+        auto_scroll: Optional[bool] = None,
+        reverse: Optional[bool] = None,
+        on_scroll_interval: OptionalNumber = None,
+        on_scroll: Any = None,
         #
         # AdaptiveControl
         #
@@ -106,23 +111,29 @@ class SliverListView(ConstrainedControl, ScrollableControl, AdaptiveControl):
 
         ScrollableControl.__init__(
             self,
+            auto_scroll=auto_scroll,
+            reverse=reverse,
             on_scroll_interval=on_scroll_interval,
             on_scroll=on_scroll,
-            reverse=reverse,
         )
 
         AdaptiveControl.__init__(self, adaptive=adaptive)
 
+        self.__controls: List[Control] = []
         self.controls = controls
         self.horizontal = horizontal
+        self.runs_count = runs_count
+        self.max_extent = max_extent
         self.spacing = spacing
-        self.divider_thickness = divider_thickness
+        self.run_spacing = run_spacing
+        self.child_aspect_ratio = child_aspect_ratio
         self.padding = padding
         self.clip_behavior = clip_behavior
+        self.semantic_child_count = semantic_child_count
         self.cache_extent = cache_extent
 
     def _get_control_name(self):
-        return "sliver_list_view"
+        return "gridview"
 
     def before_update(self):
         super().before_update()
@@ -144,32 +155,59 @@ class SliverListView(ConstrainedControl, ScrollableControl, AdaptiveControl):
     def horizontal(self, value: Optional[bool]):
         self._set_attr("horizontal", value)
 
+    # cache_extent
+    @property
+    def cache_extent(self) -> OptionalNumber:
+        return self._get_attr("cacheExtent")
+
+    @cache_extent.setter
+    def cache_extent(self, value: OptionalNumber):
+        self._set_attr("cacheExtent", value)
+
+    # runs_count
+    @property
+    def runs_count(self) -> Optional[int]:
+        return self._get_attr("runsCount")
+
+    @runs_count.setter
+    def runs_count(self, value: Optional[int]):
+        self._set_attr("runsCount", value)
+
+    # max_extent
+    @property
+    def max_extent(self) -> OptionalNumber:
+        return self._get_attr("maxExtent")
+
+    @max_extent.setter
+    def max_extent(self, value: OptionalNumber):
+        self._set_attr("maxExtent", value)
+
     # spacing
     @property
     def spacing(self) -> OptionalNumber:
-        return self._get_attr("spacing", data_type="float")
+        return self._get_attr("spacing")
 
     @spacing.setter
     def spacing(self, value: OptionalNumber):
         self._set_attr("spacing", value)
 
-    # divider_thickness
+    # run_spacing
     @property
-    def divider_thickness(self) -> OptionalNumber:
-        return self._get_attr("dividerThickness")
+    def run_spacing(self) -> OptionalNumber:
+        return self._get_attr("runSpacing")
 
-    @divider_thickness.setter
-    def divider_thickness(self, value: OptionalNumber):
-        self._set_attr("dividerThickness", value)
+    @run_spacing.setter
+    def run_spacing(self, value: OptionalNumber):
+        self._set_attr("runSpacing", value)
 
-    # cache_extent
+    # child_aspect_ratio
     @property
-    def cache_extent(self) -> OptionalNumber:
-        return self._get_attr("cacheExtent", data_type="float")
+    def child_aspect_ratio(self) -> OptionalNumber:
+        return self._get_attr("childAspectRatio")
 
-    @cache_extent.setter
-    def cache_extent(self, value: OptionalNumber):
-        self._set_attr("cacheExtent", value)
+    @child_aspect_ratio.setter
+    def child_aspect_ratio(self, value: OptionalNumber):
+        self._set_attr("childAspectRatio", value)
 
     # padding
     @property
@@ -182,11 +220,11 @@ class SliverListView(ConstrainedControl, ScrollableControl, AdaptiveControl):
 
     # controls
     @property
-    def controls(self) -> List[Control]:
+    def controls(self):
         return self.__controls
 
     @controls.setter
-    def controls(self, value: List[Control]):
+    def controls(self, value):
         self.__controls = value if value is not None else []
 
     # clip_behavior
@@ -198,3 +236,12 @@ class SliverListView(ConstrainedControl, ScrollableControl, AdaptiveControl):
     def clip_behavior(self, value: Optional[ClipBehavior]):
         self.__clip_behavior = value
         self._set_enum_attr("clipBehavior", value, ClipBehavior)
+
+    # semantic_child_count
+    @property
+    def semantic_child_count(self) -> Optional[int]:
+        return self._get_attr("semanticChildCount", data_type="int")
+
+    @semantic_child_count.setter
+    def semantic_child_count(self, value: Optional[int]):
+        self._set_attr("semanticChildCount", value)

--- a/sdk/python/packages/flet-core/src/flet_core/sliver_list_view.py
+++ b/sdk/python/packages/flet-core/src/flet_core/sliver_list_view.py
@@ -1,0 +1,198 @@
+from typing import Any, List, Optional, Union
+
+from flet_core.adaptive_control import AdaptiveControl
+from flet_core.constrained_control import ConstrainedControl
+from flet_core.control import Control, OptionalNumber
+from flet_core.ref import Ref
+from flet_core.scrollable_control import ScrollableControl
+from flet_core.types import (
+    AnimationValue,
+    OffsetValue,
+    PaddingValue,
+    ResponsiveNumber,
+    RotateValue,
+    ScaleValue,
+    ClipBehavior,
+)
+
+
+class SliverListView(ConstrainedControl, ScrollableControl, AdaptiveControl):
+    """
+    A scrollable list of controls arranged linearly.
+
+    -----
+
+    Online docs: https://flet.dev/docs/controls/sliverlistview
+    """
+
+    def __init__(
+        self,
+        controls: Optional[List[Control]] = None,
+        horizontal: Optional[bool] = None,
+        spacing: OptionalNumber = None,
+        divider_thickness: OptionalNumber = None,
+        padding: PaddingValue = None,
+        clip_behavior: Optional[ClipBehavior] = None,
+        cache_extent: OptionalNumber = None,
+        #
+        # ScrollableControl specific
+        #
+        on_scroll_interval: OptionalNumber = None,
+        on_scroll: Any = None,
+        #
+        # ConstrainedControl
+        #
+        ref: Optional[Ref] = None,
+        key: Optional[str] = None,
+        width: OptionalNumber = None,
+        height: OptionalNumber = None,
+        left: OptionalNumber = None,
+        top: OptionalNumber = None,
+        right: OptionalNumber = None,
+        bottom: OptionalNumber = None,
+        expand: Union[None, bool, int] = None,
+        expand_loose: Optional[bool] = None,
+        col: Optional[ResponsiveNumber] = None,
+        opacity: OptionalNumber = None,
+        rotate: RotateValue = None,
+        scale: ScaleValue = None,
+        offset: OffsetValue = None,
+        aspect_ratio: OptionalNumber = None,
+        animate_opacity: AnimationValue = None,
+        animate_size: AnimationValue = None,
+        animate_position: AnimationValue = None,
+        animate_rotation: AnimationValue = None,
+        animate_scale: AnimationValue = None,
+        animate_offset: AnimationValue = None,
+        on_animation_end=None,
+        visible: Optional[bool] = None,
+        disabled: Optional[bool] = None,
+        data: Any = None,
+        #
+        # AdaptiveControl
+        #
+        adaptive: Optional[bool] = None,
+    ):
+        ConstrainedControl.__init__(
+            self,
+            ref=ref,
+            key=key,
+            width=width,
+            height=height,
+            left=left,
+            top=top,
+            right=right,
+            bottom=bottom,
+            expand=expand,
+            expand_loose=expand_loose,
+            col=col,
+            opacity=opacity,
+            rotate=rotate,
+            scale=scale,
+            offset=offset,
+            aspect_ratio=aspect_ratio,
+            animate_opacity=animate_opacity,
+            animate_size=animate_size,
+            animate_position=animate_position,
+            animate_rotation=animate_rotation,
+            animate_scale=animate_scale,
+            animate_offset=animate_offset,
+            on_animation_end=on_animation_end,
+            visible=visible,
+            disabled=disabled,
+            data=data,
+        )
+
+        ScrollableControl.__init__(
+            self,
+            on_scroll_interval=on_scroll_interval,
+            on_scroll=on_scroll,
+        )
+
+        AdaptiveControl.__init__(self, adaptive=adaptive)
+
+        self.controls = controls
+        self.horizontal = horizontal
+        self.spacing = spacing
+        self.divider_thickness = divider_thickness
+        self.padding = padding
+        self.clip_behavior = clip_behavior
+        self.cache_extent = cache_extent
+
+    def _get_control_name(self):
+        return "sliver_list_view"
+
+    def before_update(self):
+        super().before_update()
+        self._set_attr_json("padding", self.__padding)
+
+    def _get_children(self):
+        return self.__controls
+
+    def clean(self):
+        super().clean()
+        self.__controls.clear()
+
+    # horizontal
+    @property
+    def horizontal(self) -> Optional[bool]:
+        return self._get_attr("horizontal")
+
+    @horizontal.setter
+    def horizontal(self, value: Optional[bool]):
+        self._set_attr("horizontal", value)
+
+    # spacing
+    @property
+    def spacing(self) -> OptionalNumber:
+        return self._get_attr("spacing", data_type="float")
+
+    @spacing.setter
+    def spacing(self, value: OptionalNumber):
+        self._set_attr("spacing", value)
+
+    # divider_thickness
+    @property
+    def divider_thickness(self) -> OptionalNumber:
+        return self._get_attr("dividerThickness")
+
+    @divider_thickness.setter
+    def divider_thickness(self, value: OptionalNumber):
+        self._set_attr("dividerThickness", value)
+
+    # cache_extent
+    @property
+    def cache_extent(self) -> OptionalNumber:
+        return self._get_attr("cacheExtent", data_type="float")
+
+    @cache_extent.setter
+    def cache_extent(self, value: OptionalNumber):
+        self._set_attr("cacheExtent", value)
+
+    # padding
+    @property
+    def padding(self) -> PaddingValue:
+        return self.__padding
+
+    @padding.setter
+    def padding(self, value: PaddingValue):
+        self.__padding = value
+
+    # controls
+    @property
+    def controls(self) -> List[Control]:
+        return self.__controls
+
+    @controls.setter
+    def controls(self, value: List[Control]):
+        self.__controls = value if value is not None else []
+
+    # clip_behavior
+    @property
+    def clip_behavior(self) -> Optional[ClipBehavior]:
+        return self.__clip_behavior
+
+    @clip_behavior.setter
+    def clip_behavior(self, value: Optional[ClipBehavior]):
+        self.__clip_behavior = value
+        self._set_enum_attr("clipBehavior", value, ClipBehavior)


### PR DESCRIPTION
Closes #3427 and #3428

## Test Code
```py
from time import sleep
import flet as ft


def main(page: ft.Page):
    lv = ft.SliverListView(expand=1, spacing=10, padding=20)

    count = 1

    for i in range(0, 60):
        lv.controls.append(ft.Text(f"Line {count}"))
        count += 1

    page.add(lv)

    for i in range(0, 60):
        sleep(1)
        lv.controls.append(ft.Text(f"Line {count}"))
        count += 1
        page.update()


ft.app(target=main)
```

```py
import flet as ft


def main(page: ft.Page):
    grid = ft.SliverGridView(
        expand=1,
        runs_count=5,
        # max_extent=50,
        child_aspect_ratio=1,
        spacing=15,
        run_spacing=10,
        controls=[
            ft.Container(
                content=ft.Text(
                    f"Item {i}",
                    weight=ft.FontWeight.BOLD,
                    overflow=ft.TextOverflow.CLIP,
                ),
                alignment=ft.alignment.center,
                bgcolor=ft.colors.random_color(),
                border_radius=ft.border_radius.all(10),
            )
            for i in range(0, 60)
        ],
    )

    page.add(grid)


ft.app(target=main)
```


<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces the `SliverListView` control, allowing for the creation of scrollable lists with customizable spacing, padding, and orientation. The necessary widget creation logic has been updated to support this new control.

* **New Features**:
    - Introduced `SliverListView` control, a scrollable list of controls arranged linearly, with support for horizontal and vertical scrolling, spacing, padding, and other customization options.
* **Enhancements**:
    - Added `SliverListViewControl` to the widget creation logic in `create_control.dart` to support the new `SliverListView` control.

<!-- Generated by sourcery-ai[bot]: end summary -->