### PR TITLE
Enable/Disable Browser Context Menu

### DIFF
--- a/packages/flet/lib/src/reducers.dart
+++ b/packages/flet/lib/src/reducers.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:flet/src/utils/browser_context_menu.dart';
 import 'package:flutter/foundation.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -291,6 +292,14 @@ AppState appReducer(AppState state, dynamic action) {
               .then((value) => sendMethodResult(result: value))
               .onError((error, stackTrace) =>
                   sendMethodResult(error: error?.toString()));
+          break;
+        case "enableBrowserContextMenu":
+          enableBrowserContextMenu().onError((error, stackTrace) =>
+              sendMethodResult(error: error?.toString()));
+          break;
+        case "disableBrowserContextMenu":
+          disableBrowserContextMenu().onError((error, stackTrace) =>
+              sendMethodResult(error: error?.toString()));
           break;
         case "windowToFront":
           windowToFront();

--- a/packages/flet/lib/src/utils/browser_context_menu.dart
+++ b/packages/flet/lib/src/utils/browser_context_menu.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/services.dart';
+
+Future<void> disableBrowserContextMenu() async {
+  return BrowserContextMenu.disableContextMenu();
+}
+
+Future<void> enableBrowserContextMenu() async {
+  return BrowserContextMenu.enableContextMenu();
+}

--- a/sdk/python/packages/flet-core/src/flet_core/page.py
+++ b/sdk/python/packages/flet-core/src/flet_core/page.py
@@ -813,6 +813,12 @@ class Page(AdaptiveControl):
             "getClipboard", wait_for_result=True, wait_timeout=wait_timeout
         )
 
+    def enable_browser_context_menu(self, wait_timeout: Optional[float] = 10):
+        self._invoke_method("enableBrowserContextMenu", wait_timeout=wait_timeout)
+
+    def disable_browser_context_menu(self, wait_timeout: Optional[float] = 10):
+        self._invoke_method("disableBrowserContextMenu", wait_timeout=wait_timeout)
+
     def launch_url(
         self,
         url: str,


### PR DESCRIPTION
Closes #2896

## Test Code
```py
import flet as ft


def main(page: ft.Page):
    page.add(
        ft.OutlinedButton(
            "Disable browser context menu",
            on_click=lambda _: page.disable_browser_context_menu(),
        ),
        ft.OutlinedButton(
            "Enable browser context menu",
            on_click=lambda _: page.enable_browser_context_menu(),
        ),
    )


ft.app(target=main)
```

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces the ability to enable and disable the browser context menu within the Flet framework. New methods have been added to the Page class to facilitate this functionality.

* **New Features**:
    - Added functionality to enable and disable the browser context menu through the Flet framework.
* **Enhancements**:
    - Introduced new methods in the Page class to control the browser context menu.

<!-- Generated by sourcery-ai[bot]: end summary -->