### PR TITLE
Fix: `Container.on_tap_down` not called when `on_click` is not provided

### DIFF
--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -1173,7 +1173,7 @@ packages:
       sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   torch_light:
     dependency: transitive
     description:

--- a/packages/flet/lib/src/controls/container.dart
+++ b/packages/flet/lib/src/controls/container.dart
@@ -139,7 +139,7 @@ class ContainerControl extends StatelessWidget with FletStoreMixin {
 
       Widget? result;
 
-      if ((onClick || url != "" || onLongPress || onHover) &&
+      if ((onClick || url != "" || onLongPress || onHover || onTapDown) &&
           ink &&
           !disabled) {
         var ink = Material(
@@ -149,7 +149,7 @@ class ContainerControl extends StatelessWidget with FletStoreMixin {
               // Dummy callback to enable widget
               // see https://github.com/flutter/flutter/issues/50116#issuecomment-582047374
               // and https://github.com/flutter/flutter/blob/eed80afe2c641fb14b82a22279d2d78c19661787/packages/flutter/lib/src/material/ink_well.dart#L1125-L1129
-              onTap: onClick || url != ""
+              onTap: onClick || url != "" || onTapDown
                   ? () {
                       debugPrint("Container ${control.id} clicked!");
                       if (url != "") {


### PR DESCRIPTION
https://github.com/flet-dev/flet/issues/3064#issuecomment-2101437783

## Test Code
```py
import flet as ft

def main(page: ft.Page):
    page.vertical_alignment = ft.MainAxisAlignment.CENTER
    page.horizontal_alignment = ft.CrossAxisAlignment.CENTER

    t = ft.Text()

    def container_click(e: ft.ContainerTapEvent):
        t.value = f"local_x: {e.local_x}\nlocal_y: {e.local_y}\nglobal_x: {e.global_x}\nglobal_y: {e.global_y}"
        t.update()

    page.add(
        ft.Column(
            [
                ft.Container(
                    content=ft.Text("Clickable inside container"),
                    alignment=ft.alignment.center,
                    bgcolor=ft.colors.GREEN_200,
                    width=200,
                    height=200,
                    border_radius=10,
                    on_tap_down=container_click,
                ),
                t,
            ],
            horizontal_alignment=ft.CrossAxisAlignment.CENTER,
        ),
    )

ft.app(target=main)
```

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a bug where the `Container.on_tap_down` event was not triggered if the `on_click` event was not set. The fix ensures that `on_tap_down` is considered in the conditional checks, allowing the event to be properly handled.

* **Bug Fixes**:
    - Fixed an issue where `Container.on_tap_down` was not called when `on_click` was not provided.

<!-- Generated by sourcery-ai[bot]: end summary -->