### PR TITLE
An ability to access PubSubHub from outside Flet app

### DIFF
--- a/sdk/python/packages/flet/src/flet/fastapi/flet_app.py
+++ b/sdk/python/packages/flet/src/flet/fastapi/flet_app.py
@@ -33,9 +33,6 @@ logger = logging.getLogger(flet_fastapi.__name__)
 DEFAULT_FLET_SESSION_TIMEOUT = 3600
 DEFAULT_FLET_OAUTH_STATE_TIMEOUT = 600
 
-_pubsubhubs_lock = asyncio.Lock()
-_pubsubhubs = {}
-
 
 class FletApp(LocalConnection):
     def __init__(
@@ -98,13 +95,9 @@ class FletApp(LocalConnection):
             else ""
         )
 
-        async with _pubsubhubs_lock:
-            psh = _pubsubhubs.get(self.__session_handler, None)
-            if psh is None:
-                psh = PubSubHub(loop=self.__loop, executor=app_manager.executor)
-                _pubsubhubs[self.__session_handler] = psh
-            self.pubsubhub = psh
-
+        self.pubsubhub = app_manager.get_pubsubhub(
+            self.__session_handler, loop=self.__loop
+        )
         self.page_url = str(websocket.url).rsplit("/", 1)[0]
         self.page_name = websocket.url.path.rsplit("/", 1)[0].lstrip("/")
 

--- a/sdk/python/packages/flet/src/flet/fastapi/flet_app_manager.py
+++ b/sdk/python/packages/flet/src/flet/fastapi/flet_app_manager.py
@@ -32,7 +32,7 @@ class FletAppManager:
         self.__evict_oauth_states_task = None
         self.__temp_dirs = {}
         self.__executor = ThreadPoolExecutor(thread_name_prefix="flet_fastapi")
-        self.__pubsubhubs_lock = threading.Lock()
+        self.__pubsubhubs_lock = threading.Lock() if not is_pyodide() else NopeLock()
         self.__pubsubhubs = {}
 
     @property

--- a/sdk/python/packages/flet/src/flet/fastapi/flet_app_manager.py
+++ b/sdk/python/packages/flet/src/flet/fastapi/flet_app_manager.py
@@ -46,7 +46,7 @@ class FletAppManager:
             psh = self.__pubsubhubs.get(session_handler, None)
             if psh is None:
                 psh = PubSubHub(
-                    loop=loop if loop else asyncio.get_running_loop(),
+                    loop=loop or asyncio.get_running_loop(),
                     executor=self.__executor,
                 )
                 self.__pubsubhubs[session_handler] = psh

--- a/sdk/python/packages/flet/src/flet/fastapi/flet_app_manager.py
+++ b/sdk/python/packages/flet/src/flet/fastapi/flet_app_manager.py
@@ -12,6 +12,7 @@ from flet.fastapi.oauth_state import OAuthState
 from flet_core.connection import Connection
 from flet_core.locks import NopeLock
 from flet_core.page import Page
+from flet_core.pubsub.pubsub_hub import PubSubHub
 from flet_core.utils.concurrency_utils import is_pyodide
 
 logger = logging.getLogger(flet_fastapi.__name__)
@@ -31,10 +32,25 @@ class FletAppManager:
         self.__evict_oauth_states_task = None
         self.__temp_dirs = {}
         self.__executor = ThreadPoolExecutor(thread_name_prefix="flet_fastapi")
+        self.__pubsubhubs_lock = threading.Lock()
+        self.__pubsubhubs = {}
 
     @property
     def executor(self):
         return self.__executor
+
+    def get_pubsubhub(
+        self, session_handler, loop: Optional[asyncio.AbstractEventLoop] = None
+    ):
+        with self.__pubsubhubs_lock:
+            psh = self.__pubsubhubs.get(session_handler, None)
+            if psh is None:
+                psh = PubSubHub(
+                    loop=loop if loop else asyncio.get_running_loop(),
+                    executor=self.__executor,
+                )
+                self.__pubsubhubs[session_handler] = psh
+            return psh
 
     async def start(self):
         """


### PR DESCRIPTION
Close #3445

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces a new feature that allows accessing PubSubHub from outside the Flet app. It also includes a refactoring to centralize the management of PubSubHub instances within FletAppManager, enhancing code maintainability.

* **New Features**:
    - Introduced the ability to access PubSubHub from outside the Flet app by adding a method to retrieve or create a PubSubHub instance.
* **Enhancements**:
    - Refactored the handling of PubSubHub instances to use a centralized method in FletAppManager, improving code maintainability and reducing redundancy.

<!-- Generated by sourcery-ai[bot]: end summary -->