### PR TITLE
New property: `dropdown.Option.content`

### DIFF
--- a/packages/flet/lib/src/controls/dropdown.dart
+++ b/packages/flet/lib/src/controls/dropdown.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../flet_control_backend.dart';
 import '../models/control.dart';
+import '../models/control_view_model.dart';
 import '../utils/alignment.dart';
 import '../utils/borders.dart';
 import '../utils/edge_insets.dart';
@@ -94,19 +95,28 @@ class _DropdownControlState extends State<DropdownControl> with FletStoreMixin {
       }
 
       var items = itemsView.controlViews
-          .map((v) => v.control)
-          .where((c) => c.name == null && c.isVisible)
-          .map<DropdownMenuItem<String>>((Control itemCtrl) {
+          .where((c) => c.control.name == null && c.control.isVisible)
+          .map<DropdownMenuItem<String>>((ControlViewModel itemCtrlView) {
+        var itemCtrl = itemCtrlView.control;
         bool itemDisabled = disabled || itemCtrl.isDisabled;
         TextStyle? textStyle =
             parseTextStyle(Theme.of(context), itemCtrl, "textStyle");
         if (itemDisabled && textStyle != null) {
           textStyle = textStyle.apply(color: Theme.of(context).disabledColor);
         }
-        Widget itemChild = Text(
-          itemCtrl.attrs["text"] ?? itemCtrl.attrs["key"] ?? itemCtrl.id,
-          style: textStyle,
-        );
+        var contentCtrls = itemCtrlView.children
+            .where((c) => c.name == "content" && c.isVisible);
+        Widget? itemChild;
+        if (contentCtrls.isNotEmpty) {
+          // custom content
+          itemChild = createControl(
+              itemCtrlView.control, contentCtrls.first.id, itemDisabled);
+        } else {
+          itemChild = Text(
+            itemCtrl.attrs["text"] ?? itemCtrl.attrs["key"] ?? itemCtrl.id,
+            style: textStyle,
+          );
+        }
         var align = parseAlignment(itemCtrl, "alignment");
         if (align != null) {
           itemChild = Container(alignment: align, child: itemChild);

--- a/sdk/python/packages/flet-core/src/flet_core/dropdown.py
+++ b/sdk/python/packages/flet-core/src/flet_core/dropdown.py
@@ -1,5 +1,5 @@
 import time
-from typing import Any, Optional, Union, List
+from typing import Any, List, Optional, Union
 
 from flet_core.alignment import Alignment
 from flet_core.control import Control, OptionalNumber
@@ -23,6 +23,7 @@ class Option(Control):
         self,
         key: Optional[str] = None,
         text: Optional[str] = None,
+        content: Optional[Control] = None,
         alignment: Optional[Alignment] = None,
         text_style: Optional[TextStyle] = None,
         on_click=None,
@@ -38,12 +39,20 @@ class Option(Control):
         assert key is not None or text is not None, "key or text must be specified"
         self.key = key
         self.text = text
+        self.content = content
         self.on_click = on_click
         self.alignment = alignment
         self.text_style = text_style
 
     def _get_control_name(self):
         return "dropdownoption"
+
+    def _get_children(self):
+        children = []
+        if self.__content is not None:
+            self.__content._set_attr_internal("n", "content")
+            children.append(self.__content)
+        return children
 
     def before_update(self):
         super().before_update()
@@ -68,6 +77,15 @@ class Option(Control):
     @text.setter
     def text(self, value: Optional[str]):
         self._set_attr("text", value)
+
+    # content
+    @property
+    def content(self) -> Optional[Control]:
+        return self.__content
+
+    @content.setter
+    def content(self, value: Optional[Control]):
+        self.__content = value
 
     # alignment
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/dropdown.py
+++ b/sdk/python/packages/flet-core/src/flet_core/dropdown.py
@@ -36,7 +36,6 @@ class Option(Control):
         data: Any = None,
     ):
         Control.__init__(self, ref=ref, disabled=disabled, visible=visible, data=data)
-        assert key is not None or text is not None, "key or text must be specified"
         self.key = key
         self.text = text
         self.content = content
@@ -56,6 +55,9 @@ class Option(Control):
 
     def before_update(self):
         super().before_update()
+        assert (
+            self.key is not None or self.text is not None
+        ), "key or text must be specified"
         self._set_attr_json("alignment", self.__alignment)
         if isinstance(self.__text_style, TextStyle):
             self._set_attr_json("textStyle", self.__text_style)


### PR DESCRIPTION
Example:

```py
import flet as ft


def main(page: ft.Page):

    page.add(
        ft.Dropdown(
            width=200,
            options=[
                ft.dropdown.Option(
                    key="red",
                    content=ft.Row(
                        [
                            ft.Container(
                                width=24, height=24, bgcolor="red", border_radius=3
                            ),
                            ft.Text("Red"),
                        ]
                    ),
                ),
                ft.dropdown.Option("Green"),
                ft.dropdown.Option("Blue"),
            ],
        )
    )


ft.app(target=main)
```

Result:

<img width="231" alt="image" src="https://github.com/flet-dev/flet/assets/5041459/0b8a7859-1941-439f-8ab4-8dc805cc0aeb">

<img width="271" alt="image" src="https://github.com/flet-dev/flet/assets/5041459/4cbe13e9-5fed-43a6-a498-755440c6bdda">

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces a new `content` property for `dropdown.Option`, enabling the inclusion of custom widget content within dropdown options. The dropdown rendering logic has been updated to support this new feature, providing more flexibility in dropdown item presentation.

* **New Features**:
    - Introduced a new property `content` for `dropdown.Option` to allow custom widget content within dropdown options.
* **Enhancements**:
    - Updated the dropdown rendering logic to support custom content if the `content` property is provided, falling back to text otherwise.

<!-- Generated by sourcery-ai[bot]: end summary -->