### PR TITLE
Fix: make github templates show up 

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -21,7 +21,11 @@ body:
     attributes:
       label: "Code"
       description: "If you want your issue to be quickly addressed provide some runnable code which reproduces the issue."
-      placeholder: ```py ```
+      placeholder: "
+      ```py 
+      # Your code here
+      ```
+      "
     validations:
       required: false
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/02_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/02_feature_request.yml
@@ -19,8 +19,8 @@ body:
   - type: textarea
     id: "suggestion"
     attributes:
-      label: "Suggest A Solution"
-      description: ""
+      label: "Suggest a solution"
+      description: "Share with us your idea on how to solve the problem. If you have multiple solutions, please present each one separately."
       placeholder: "A concise description of your preferred solution. Things to address include:
       
       * Details of the technical implementation, e.g. Flutter widget solving the problem.

--- a/.github/PR_TEMPLATE/01_pr_template.md
+++ b/.github/PR_TEMPLATE/01_pr_template.md
@@ -14,7 +14,7 @@ Fixes #(issue)
 
 ## Type of change
 
-Please delete options that are not relevant.
+<!-- Please delete options that are not relevant. -->
 
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
@@ -27,9 +27,7 @@ Please delete options that are not relevant.
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] My changes generate no new warnings
-
 <!-- - [ ] I have added tests that prove my fix is effective or that my feature works as expected -->
-
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] I have made corresponding changes to the [documentation](https://github.com/flet-dev/website) (if applicable)
 
@@ -37,4 +35,4 @@ Please delete options that are not relevant.
 
 ## Additional details
 
-Add any other context to be known about this PR.
+<!-- Add any other context to be known about this PR. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,12 +23,14 @@ Fixes #(issue)
 
 ## Checklist:
 
+- [ ] I signed the CLA.
 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] My changes generate no new warnings
 <!-- - [ ] I have added tests that prove my fix is effective or that my feature works as expected -->
-- [ ] New and existing unit tests pass locally with my changes
+
+- [ ] New and existing tests pass locally with my changes
 - [ ] I have made corresponding changes to the [documentation](https://github.com/flet-dev/website) (if applicable)
 
 ## Screenshots (if applicable):

--- a/sdk/python/packages/flet-core/src/flet_core/datatable.py
+++ b/sdk/python/packages/flet-core/src/flet_core/datatable.py
@@ -255,7 +255,7 @@ class DataRow(Control):
     def before_update(self):
         super().before_update()
         assert (
-                len(list(filter(lambda cell: cell.visible, self.__cells))) > 0
+            len(list(filter(lambda cell: cell.visible, self.__cells))) > 0
         ), "cells must contain at minimum one visible DataCell"
         self._set_attr_json("color", self.__color)
 
@@ -437,12 +437,23 @@ class DataTable(ConstrainedControl):
         visible_columns = list(filter(lambda column: column.visible, self.__columns))
         visible_rows = list(filter(lambda row: row.visible, self.__rows))
         assert (
-                len(visible_columns) > 0
+            len(visible_columns) > 0
         ), "columns must contain at minimum one visible DataColumn"
         assert all(
             len(list(filter(lambda c: c.visible, row.cells))) == len(visible_columns)
             for row in visible_rows
-        ), "each visible DataRow must contain exactly as many visible DataCells as there are visible DataColumns"
+        ), f"each visible DataRow must contain exactly as many visible DataCells as there are visible DataColumns ({len(visible_columns)})"
+        assert (
+            self.data_row_min_height is None
+            or self.data_row_max_height is None
+            or (self.data_row_min_height <= self.data_row_max_height)
+        ), "data_row_min_height must be less than or equal to data_row_max_height"
+        assert (
+            self.divider_thickness is None or self.divider_thickness >= 0
+        ), "divider_thickness must be greater than or equal to 0"
+        assert self.sort_column_index is None or (
+            0 <= self.sort_column_index < len(visible_columns)
+        ), f"sort_column_index must be greater than or equal to 0 and less than the number of columns ({len(visible_columns)})"
         self._set_attr_json("border", self.__border)
         self._set_attr_json("gradient", self.__gradient)
         self._set_attr_json("borderRadius", self.__border_radius)

--- a/sdk/python/packages/flet-core/src/flet_core/slider.py
+++ b/sdk/python/packages/flet-core/src/flet_core/slider.py
@@ -161,6 +161,15 @@ class Slider(ConstrainedControl, AdaptiveControl):
 
     def before_update(self):
         super().before_update()
+        assert (
+            self.min is None or self.max is None or self.min <= self.max
+        ), "min must be less than or equal to max"
+        assert (
+            self.min is None or self.value is None or (self.value >= self.min)
+        ), "value must be greater than or equal to min"
+        assert (
+            self.max is None or self.value is None or (self.value <= self.max)
+        ), "value must be less than or equal to max"
         self._set_attr_json("overlayColor", self.__overlay_color)
 
     # value
@@ -170,11 +179,6 @@ class Slider(ConstrainedControl, AdaptiveControl):
 
     @value.setter
     def value(self, value: OptionalNumber):
-        if value is not None:
-            if self.min is not None:
-                assert value >= self.min, "value must be greater than or equal to min"
-            if self.max is not None:
-                assert value <= self.max, "value must be less than or equal to max"
         self._set_attr("value", value)
 
     # label
@@ -203,9 +207,6 @@ class Slider(ConstrainedControl, AdaptiveControl):
 
     @min.setter
     def min(self, value: OptionalNumber):
-        if value is not None:
-            if self.max is not None:
-                assert value <= self.max, "min must be less than or equal to max"
         self._set_attr("min", value)
 
     # secondary_track_value
@@ -242,9 +243,6 @@ class Slider(ConstrainedControl, AdaptiveControl):
 
     @max.setter
     def max(self, value: OptionalNumber):
-        if value is not None:
-            if self.min is not None:
-                assert value >= self.min, "max must be greater than or equal to min"
         self._set_attr("max", value)
 
     # divisions

--- a/sdk/python/packages/flet-core/src/flet_core/types.py
+++ b/sdk/python/packages/flet-core/src/flet_core/types.py
@@ -1,3 +1,4 @@
+import inspect
 from enum import Enum, EnumMeta
 from typing import Any, Callable, Dict, Optional, Protocol, Tuple, Union
 from warnings import warn
@@ -84,13 +85,15 @@ OptionalString = Optional[str]
 
 class MaterialStateDeprecated(EnumMeta):
     def __getattribute__(self, item):
-        warn(
-            "MaterialState enum is deprecated and will be removed in v1.0. "
-            "Use ControlState enum instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return EnumMeta.__getattribute__(self, item)
+        # Check if the call is coming from outside the enum module
+        if not any(frame.filename.endswith("enum.py") for frame in inspect.stack()):
+            warn(
+                "MaterialState enum is deprecated and will be removed in v1.0. "
+                "Use ControlState enum instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        return super().__getattribute__(item)
 
 
 class MaterialState(Enum, metaclass=MaterialStateDeprecated):


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request enhances validation logic in `slider.py` and `datatable.py` by adding new assertions to ensure property values are within valid ranges. It also refines the deprecation warning in `types.py` and updates GitHub templates for better clarity.

* **Enhancements**:
    - Added assertions in the `before_update` method of `slider.py` to ensure `min`, `max`, and `value` properties are within valid ranges.
    - Enhanced `datatable.py` to include additional assertions for `data_row_min_height`, `divider_thickness`, and `sort_column_index` properties.
    - Improved the deprecation warning in `types.py` to only trigger when the call is from outside the enum module.
* **Chores**:
    - Updated GitHub pull request and issue templates to improve clarity and usability.

<!-- Generated by sourcery-ai[bot]: end summary -->