### PR TITLE
improve type hint for run_task and run_thread

### DIFF
--- a/sdk/python/packages/flet-core/src/flet_core/page.py
+++ b/sdk/python/packages/flet-core/src/flet_core/page.py
@@ -23,7 +23,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
-    cast,
+    cast
 )
 from typing_extensions import ParamSpec
 from urllib.parse import urlparse
@@ -542,7 +542,7 @@ class Page(AdaptiveControl):
         handler: Callable[InputT, Awaitable[RetT]],
         *args: InputT.args,
         **kwargs: InputT.kwargs,
-    ) -> Future[RetT]:
+    ) -> "Future[RetT]":
         _session_page.set(self)
         assert asyncio.iscoroutinefunction(handler)
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
Optimized the type annotations for run_task and run_thread, ensuring that the user's function can still retain annotation information even after wrapping another layer of run_task or run_thread.

In addition, it also supports kwargs for run_thread.

<!-- If it fixes an open issue, please link to the issue here. -->


## Test Code

```python
# Test code for the review of this PR
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I signed the CLA.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
<!-- - [ ] I have added tests that prove my fix is effective or that my feature works as expected -->

- [x] New and existing tests pass locally with my changes
- [x] I have made corresponding changes to the [documentation](https://github.com/flet-dev/website) (if applicable)

## Screenshots (if applicable):
![defb238bfd0b1c140d60fb6a88336398](https://github.com/flet-dev/flet/assets/46243324/91035b88-754b-4513-a40f-f15ea17b6a03)
->
![71fdf5ba954fcc32cd9779fbe0aa9a72](https://github.com/flet-dev/flet/assets/46243324/cbd40799-8c4d-47e2-8c22-94827afb7886)


## Additional details

<!-- Add any other context to be known about this PR. -->
