### PR TITLE
change signal to SIG_DFL after exit_gracefully

### DIFF
--- a/sdk/python/packages/flet-runtime/src/flet_runtime/app.py
+++ b/sdk/python/packages/flet-runtime/src/flet_runtime/app.py
@@ -142,6 +142,8 @@ async def app_async(
     def exit_gracefully(signum, frame):
         logger.debug("Gracefully terminating Flet app...")
         loop.call_soon_threadsafe(terminate.set)
+        signal.signal(signal.SIGINT, signal.SIG_DFL)
+        signal.signal(signal.SIGTERM, signal.SIG_DFL)
 
     signal.signal(signal.SIGINT, exit_gracefully)
     signal.signal(signal.SIGTERM, exit_gracefully)


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
I want to create multiple windows in my program, so I ran multiple app_async functions. However, I found that when I ran multiple app_async functions, Ctrl+C could not terminate my program.

Modifying exit_gracefully to ensure that the default value of the signal is restored after execution seems to be a solution.

<!-- If it fixes an open issue, please link to the issue here. -->


## Test Code

```python
import asyncio
import flet as ft
import socket


def get_free_port():
    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
    s.bind(("", 0))
    _, port = s.getsockname()
    s.close()
    return port


def main(page):
    page.snack_bar = ft.SnackBar(
        content=ft.Text("Hello, world!"),
        action="Alright!",
    )

    page.add(ft.ElevatedButton("Open SnackBar"))


loop = asyncio.new_event_loop()


async def hello_world():
    loop.create_task(ft.app_async(target=main, port=get_free_port()))
    while True:
        await asyncio.sleep(1)


loop.create_task(hello_world())
loop.run_until_complete(hello_world())
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I signed the CLA.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
<!-- - [ ] I have added tests that prove my fix is effective or that my feature works as expected -->

- [x] New and existing tests pass locally with my changes
- [x] I have made corresponding changes to the [documentation](https://github.com/flet-dev/website) (if applicable)

## Screenshots (if applicable):

## Additional details

<!-- Add any other context to be known about this PR. -->

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses an issue where the program could not be terminated using Ctrl+C when running multiple app_async functions. The fix involves restoring the default signal handlers for SIGINT and SIGTERM after the exit_gracefully function is executed.

* **Bug Fixes**:
    - Restored default signal handlers for SIGINT and SIGTERM after executing the exit_gracefully function to ensure proper termination of the program when running multiple app_async functions.

<!-- Generated by sourcery-ai[bot]: end summary -->