### PR TITLE
Fix `parseFloatingActionButtonLocation()` to work on desktop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # 0.23.1
 
+* FIX: Fix parseFloatingActionButtonLocation() to work on desktop ([#3496](https://github.com/flet-dev/flet/issues/3496))
 * FIX: Flet 0.23 crashes on Ubuntu 22.04 ([#3495](https://github.com/flet-dev/flet/issues/3495))
 * FIX: View.floating_action_button_location: conditionally use _set_attr.
 * FIX: Import `ParamSpec` from `typing` for Python >3.10.

--- a/packages/flet/CHANGELOG.md
+++ b/packages/flet/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.23.1
 
+* FIX: Fix parseFloatingActionButtonLocation() to work on desktop ([#3496](https://github.com/flet-dev/flet/issues/3496))
 * FIX: Flet 0.23 crashes on Ubuntu 22.04 ([#3495](https://github.com/flet-dev/flet/issues/3495))
 * FIX: View.floating_action_button_location: conditionally use _set_attr.
 * FIX: Import `ParamSpec` from `typing` for Python >3.10.

--- a/packages/flet/lib/src/utils/buttons.dart
+++ b/packages/flet/lib/src/utils/buttons.dart
@@ -83,26 +83,26 @@ ButtonStyle? buttonStyleFromJSON(ThemeData theme, Map<String, dynamic>? json,
 
 FloatingActionButtonLocation parseFloatingActionButtonLocation(
     Control control, String propName, FloatingActionButtonLocation defValue) {
-  List<FloatingActionButtonLocation> fabLocations = [
-    FloatingActionButtonLocation.centerDocked,
-    FloatingActionButtonLocation.centerFloat,
-    FloatingActionButtonLocation.centerTop,
-    FloatingActionButtonLocation.endContained,
-    FloatingActionButtonLocation.endDocked,
-    FloatingActionButtonLocation.endFloat,
-    FloatingActionButtonLocation.endTop,
-    FloatingActionButtonLocation.miniCenterDocked,
-    FloatingActionButtonLocation.miniCenterFloat,
-    FloatingActionButtonLocation.miniCenterTop,
-    FloatingActionButtonLocation.miniEndFloat,
-    FloatingActionButtonLocation.miniEndTop,
-    FloatingActionButtonLocation.miniStartDocked,
-    FloatingActionButtonLocation.miniStartFloat,
-    FloatingActionButtonLocation.miniStartTop,
-    FloatingActionButtonLocation.startDocked,
-    FloatingActionButtonLocation.startFloat,
-    FloatingActionButtonLocation.startTop
-  ];
+  Map<String, FloatingActionButtonLocation> fabLocations = {
+    "centerdocked": FloatingActionButtonLocation.centerDocked,
+    "centerfloat": FloatingActionButtonLocation.centerFloat,
+    "centertop": FloatingActionButtonLocation.centerTop,
+    "endcontained": FloatingActionButtonLocation.endContained,
+    "enddocked": FloatingActionButtonLocation.endDocked,
+    "endfloat": FloatingActionButtonLocation.endFloat,
+    "endtop": FloatingActionButtonLocation.endTop,
+    "minicenterdocked": FloatingActionButtonLocation.miniCenterDocked,
+    "minicenterfloat": FloatingActionButtonLocation.miniCenterFloat,
+    "minicentertop": FloatingActionButtonLocation.miniCenterTop,
+    "miniendfloat": FloatingActionButtonLocation.miniEndFloat,
+    "miniendtop": FloatingActionButtonLocation.miniEndTop,
+    "ministartdocked": FloatingActionButtonLocation.miniStartDocked,
+    "ministartfloat": FloatingActionButtonLocation.miniStartFloat,
+    "ministarttop": FloatingActionButtonLocation.miniStartTop,
+    "startdocked": FloatingActionButtonLocation.startDocked,
+    "startfloat": FloatingActionButtonLocation.startFloat,
+    "starttop": FloatingActionButtonLocation.startTop
+  };
 
   try {
     OffsetDetails? fabLocationOffsetDetails = parseOffset(control, propName);
@@ -113,11 +113,8 @@ FloatingActionButtonLocation parseFloatingActionButtonLocation(
       return defValue;
     }
   } catch (e) {
-    return fabLocations.firstWhere(
-        (l) =>
-            l.toString().split('.').last.toLowerCase() ==
-            control.attrString(propName, "")!.toLowerCase(),
-        orElse: () => defValue);
+    var key = control.attrString(propName, "")!.toLowerCase();
+    return fabLocations.containsKey(key) ? fabLocations[key]! : defValue;
   }
 }
 

--- a/packages/flet/lib/src/utils/buttons.dart
+++ b/packages/flet/lib/src/utils/buttons.dart
@@ -83,7 +83,7 @@ ButtonStyle? buttonStyleFromJSON(ThemeData theme, Map<String, dynamic>? json,
 
 FloatingActionButtonLocation parseFloatingActionButtonLocation(
     Control control, String propName, FloatingActionButtonLocation defValue) {
-  Map<String, FloatingActionButtonLocation> fabLocations = {
+  const Map<String, FloatingActionButtonLocation> fabLocations = {
     "centerdocked": FloatingActionButtonLocation.centerDocked,
     "centerfloat": FloatingActionButtonLocation.centerFloat,
     "centertop": FloatingActionButtonLocation.centerTop,


### PR DESCRIPTION
Fix #3485

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a bug in the `parseFloatingActionButtonLocation()` function, ensuring it correctly maps string keys to `FloatingActionButtonLocation` values, which resolves an issue with the function's compatibility on desktop platforms.

- **Bug Fixes**:
    - Fixed `parseFloatingActionButtonLocation()` to correctly map string keys to `FloatingActionButtonLocation` values, ensuring compatibility on desktop platforms.

<!-- Generated by sourcery-ai[bot]: end summary -->