### PR TITLE
SearchView popup not to be opened on tap

### DIFF
--- a/packages/flet/lib/src/controls/search_anchor.dart
+++ b/packages/flet/lib/src/controls/search_anchor.dart
@@ -202,7 +202,6 @@ class _SearchAnchorControlState extends State<SearchAnchorControl> {
               if (onTap) {
                 widget.backend.triggerControlEvent(widget.control.id, "tap");
               }
-              controller.openView();
             },
             onSubmitted: onSubmit
                 ? (String value) {


### PR DESCRIPTION
Currently, search View popup is opened on tap. Removed it so that user can call it from python instead.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Removed the automatic opening of the search view on tap, allowing users to control this behavior from Python instead.

<!-- Generated by sourcery-ai[bot]: end summary -->