### PR TITLE
Change type of `Flet version` field in bug report template to multiline.

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -74,7 +74,7 @@ body:
     id: "flet-version"
     attributes:
       label: "Flet version"
-      description: "run `pip show flet` in your terminal to view your Flet version"
+      placeholder: "run `pip show flet` in your terminal to view your Flet version"
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -70,7 +70,7 @@ body:
       description: "For example: Debian 11.2"
     validations:
       required: true
-  - type: input
+  - type: textarea
     id: "flet-version"
     attributes:
       label: "Flet version"


### PR DESCRIPTION
## Description

The `Flet version` field is bug report template was not multiline. It is now multiline. [Here is a test issue](https://github.com/taaaf11/flet/issues/1) for this change.


<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #3521

## Checklist:

- [x] I signed the CLA.
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the bug report template by changing the `Flet version` field from a single-line input to a multiline textarea, allowing for better readability and input flexibility.

- **Enhancements**:
    - Changed the `Flet version` field in the bug report template from a single-line input to a multiline textarea.

<!-- Generated by sourcery-ai[bot]: end summary -->