### PR TITLE
Prepare Flet 0.23.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Flet changelog
 
+# 0.23.2
+
+* CHANGED: Enhance Typing of Event Handlers ([#3523](https://github.com/flet-dev/flet/issues/3523))
+* CHANGED: Delete Page.window.on_resize | deprecate Page.on_resize in favor of Page.on_resized ([#3516](https://github.com/flet-dev/flet/issues/3516))
+* CHANGED: View is not opened on tap ([#3513](https://github.com/flet-dev/flet/issues/3513))
+* FIXED: `Slider.value` defaults to `min` ([#3503](https://github.com/flet-dev/flet/issues/3503))
+* FIXED: add "hide" and "show" to WindowEventType enum ([#3505](https://github.com/flet-dev/flet/issues/3505))
+* FIXED: TypeError raised for isinstance check with Union in before_update method ([#3499](https://github.com/flet-dev/flet/issues/3499))
+* FIXED: Corrected `isinstance` check in `SnackBar.before_update` to use a tuple of types instead of Union, resolving TypeError: "Subscripted generics cannot be used with class and instance checks".
+* FIXED: `Page.open()` breaking after multiple calls.
+* FIXED: Typo in on_resized setter decorator
+
 # 0.23.1
 
 * FIX: Fix parseFloatingActionButtonLocation() to work on desktop ([#3496](https://github.com/flet-dev/flet/issues/3496))

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -239,77 +239,77 @@ packages:
       path: "../packages/flet"
       relative: true
     source: path
-    version: "0.23.1"
+    version: "0.23.2"
   flet_audio:
     dependency: "direct main"
     description:
       path: "../packages/flet_audio"
       relative: true
     source: path
-    version: "0.23.1"
+    version: "0.23.2"
   flet_audio_recorder:
     dependency: "direct main"
     description:
       path: "../packages/flet_audio_recorder"
       relative: true
     source: path
-    version: "0.23.1"
+    version: "0.23.2"
   flet_flashlight:
     dependency: "direct main"
     description:
       path: "../packages/flet_flashlight"
       relative: true
     source: path
-    version: "0.23.1"
+    version: "0.23.2"
   flet_geolocator:
     dependency: "direct main"
     description:
       path: "../packages/flet_geolocator"
       relative: true
     source: path
-    version: "0.23.1"
+    version: "0.23.2"
   flet_lottie:
     dependency: "direct main"
     description:
       path: "../packages/flet_lottie"
       relative: true
     source: path
-    version: "0.23.1"
+    version: "0.23.2"
   flet_map:
     dependency: "direct main"
     description:
       path: "../packages/flet_map"
       relative: true
     source: path
-    version: "0.23.1"
+    version: "0.23.2"
   flet_permission_handler:
     dependency: "direct main"
     description:
       path: "../packages/flet_permission_handler"
       relative: true
     source: path
-    version: "0.23.1"
+    version: "0.23.2"
   flet_rive:
     dependency: "direct main"
     description:
       path: "../packages/flet_rive"
       relative: true
     source: path
-    version: "0.23.1"
+    version: "0.23.2"
   flet_video:
     dependency: "direct main"
     description:
       path: "../packages/flet_video"
       relative: true
     source: path
-    version: "0.23.1"
+    version: "0.23.2"
   flet_webview:
     dependency: "direct main"
     description:
       path: "../packages/flet_webview"
       relative: true
     source: path
-    version: "0.23.1"
+    version: "0.23.2"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/packages/flet/CHANGELOG.md
+++ b/packages/flet/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 0.23.2
+
+* CHANGED: Enhance Typing of Event Handlers ([#3523](https://github.com/flet-dev/flet/issues/3523))
+* CHANGED: Delete Page.window.on_resize | deprecate Page.on_resize in favor of Page.on_resized ([#3516](https://github.com/flet-dev/flet/issues/3516))
+* CHANGED: View is not opened on tap ([#3513](https://github.com/flet-dev/flet/issues/3513))
+* FIXED: `Slider.value` defaults to `min` ([#3503](https://github.com/flet-dev/flet/issues/3503))
+* FIXED: add "hide" and "show" to WindowEventType enum ([#3505](https://github.com/flet-dev/flet/issues/3505))
+* FIXED: TypeError raised for isinstance check with Union in before_update method ([#3499](https://github.com/flet-dev/flet/issues/3499))
+* FIXED: Corrected `isinstance` check in `SnackBar.before_update` to use a tuple of types instead of Union, resolving TypeError: "Subscripted generics cannot be used with class and instance checks".
+* FIXED: `Page.open()` breaking after multiple calls.
+* FIXED: Typo in on_resized setter decorator
+
 # 0.23.1
 
 * FIX: Fix parseFloatingActionButtonLocation() to work on desktop ([#3496](https://github.com/flet-dev/flet/issues/3496))

--- a/packages/flet/pubspec.yaml
+++ b/packages/flet/pubspec.yaml
@@ -2,7 +2,7 @@ name: flet
 description: Write entire Flutter app in Python or add server-driven UI experience into existing Flutter app.
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/flet/packages/flet
-version: 0.23.1
+version: 0.23.2
 
 # This package supports all platforms listed below.
 platforms:

--- a/packages/flet_audio/CHANGELOG.md
+++ b/packages/flet_audio/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.23.2
+
+No changes in this release. Version bumped to follow parent `flet` package.
+
 # 0.23.1
 
 No changes in this release. Version bumped to follow parent `flet` package.

--- a/packages/flet_audio/pubspec.yaml
+++ b/packages/flet_audio/pubspec.yaml
@@ -2,7 +2,7 @@ name: flet_audio
 description: Flet Audio control
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/flet/packages/flet_audio
-version: 0.23.1
+version: 0.23.2
 
 environment:
   sdk: '>=3.2.3 <4.0.0'

--- a/packages/flet_audio_recorder/CHANGELOG.md
+++ b/packages/flet_audio_recorder/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.23.2
+
+No changes in this release. Version bumped to follow parent `flet` package.
+
 # 0.23.1
 
 No changes in this release. Version bumped to follow parent `flet` package.

--- a/packages/flet_audio_recorder/pubspec.yaml
+++ b/packages/flet_audio_recorder/pubspec.yaml
@@ -2,7 +2,7 @@ name: flet_audio_recorder
 description: Flet AudioRecorder control
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/flet/packages/flet_audio_recorder
-version: 0.23.1
+version: 0.23.2
 
 environment:
   sdk: '>=3.2.3 <4.0.0'

--- a/packages/flet_flashlight/CHANGELOG.md
+++ b/packages/flet_flashlight/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.23.2
+
+No changes in this release. Version bumped to follow parent `flet` package.
+
 # 0.23.1
 
 No changes in this release. Version bumped to follow parent `flet` package.

--- a/packages/flet_flashlight/pubspec.yaml
+++ b/packages/flet_flashlight/pubspec.yaml
@@ -2,7 +2,7 @@ name: flet_flashlight
 description: Flet Flashlight control
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/flet/packages/flet_flashlight
-version: 0.23.1
+version: 0.23.2
 
 
 environment:

--- a/packages/flet_geolocator/CHANGELOG.md
+++ b/packages/flet_geolocator/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.23.2
+
+No changes in this release. Version bumped to follow parent `flet` package.
+
 # 0.23.1
 
 No changes in this release. Version bumped to follow parent `flet` package.

--- a/packages/flet_geolocator/pubspec.yaml
+++ b/packages/flet_geolocator/pubspec.yaml
@@ -2,7 +2,7 @@ name: flet_geolocator
 description: Flet Geolocator control
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/flet/packages/flet_geolocator
-version: 0.23.1
+version: 0.23.2
 
 environment:
   sdk: '>=3.2.3 <4.0.0'

--- a/packages/flet_lottie/CHANGELOG.md
+++ b/packages/flet_lottie/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.23.2
+
+No changes in this release. Version bumped to follow parent `flet` package.
+
 # 0.23.1
 
 No changes in this release. Version bumped to follow parent `flet` package.

--- a/packages/flet_lottie/pubspec.yaml
+++ b/packages/flet_lottie/pubspec.yaml
@@ -2,7 +2,7 @@ name: flet_lottie
 description: Flet Lottie control
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/flet/packages/flet_lottie
-version: 0.23.1
+version: 0.23.2
 
 environment:
   sdk: '>=3.2.3 <4.0.0'

--- a/packages/flet_map/CHANGELOG.md
+++ b/packages/flet_map/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.23.2
+
+No changes in this release. Version bumped to follow parent `flet` package.
+
 # 0.23.1
 
 No changes in this release. Version bumped to follow parent `flet` package.

--- a/packages/flet_map/pubspec.yaml
+++ b/packages/flet_map/pubspec.yaml
@@ -2,7 +2,7 @@ name: flet_map
 description: Flet Map control
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/flet/packages/flet_map
-version: 0.23.1
+version: 0.23.2
 
 environment:
   sdk: '>=3.2.3 <4.0.0'

--- a/packages/flet_permission_handler/CHANGELOG.md
+++ b/packages/flet_permission_handler/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.23.2
+
+No changes in this release. Version bumped to follow parent `flet` package.
+
 # 0.23.1
 
 No changes in this release. Version bumped to follow parent `flet` package.

--- a/packages/flet_permission_handler/pubspec.yaml
+++ b/packages/flet_permission_handler/pubspec.yaml
@@ -2,7 +2,7 @@ name: flet_permission_handler
 description: Flet PermissionHandler control
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/flet/packages/flet_permission_handler
-version: 0.23.1
+version: 0.23.2
 
 environment:
   sdk: '>=3.2.3 <4.0.0'

--- a/packages/flet_rive/CHANGELOG.md
+++ b/packages/flet_rive/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.23.2
+
+No changes in this release. Version bumped to follow parent `flet` package.
+
 # 0.23.1
 
 No changes in this release. Version bumped to follow parent `flet` package.

--- a/packages/flet_rive/pubspec.yaml
+++ b/packages/flet_rive/pubspec.yaml
@@ -2,7 +2,7 @@ name: flet_rive
 description: Flet Rive control
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/flet/packages/flet_rive
-version: 0.23.1
+version: 0.23.2
 
 environment:
   sdk: '>=3.2.3 <4.0.0'

--- a/packages/flet_video/CHANGELOG.md
+++ b/packages/flet_video/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.23.2
+
+No changes in this release. Version bumped to follow parent `flet` package.
+
 # 0.23.1
 
 No changes in this release. Version bumped to follow parent `flet` package.

--- a/packages/flet_video/pubspec.yaml
+++ b/packages/flet_video/pubspec.yaml
@@ -2,7 +2,7 @@ name: flet_video
 description: Flet Video control
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/flet/packages/flet_video
-version: 0.23.1
+version: 0.23.2
 
 environment:
   sdk: '>=3.2.3 <4.0.0'

--- a/packages/flet_webview/CHANGELOG.md
+++ b/packages/flet_webview/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.23.2
+
+No changes in this release. Version bumped to follow parent `flet` package.
+
 # 0.23.1
 
 No changes in this release. Version bumped to follow parent `flet` package.

--- a/packages/flet_webview/pubspec.yaml
+++ b/packages/flet_webview/pubspec.yaml
@@ -2,7 +2,7 @@ name: flet_webview
 description: Flet WebView control
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/flet/packages/flet_webview
-version: 0.23.1
+version: 0.23.2
 
 environment:
   sdk: '>=3.2.3 <4.0.0'


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request prepares the release of Flet 0.23.2, including enhancements to event handler typing, deprecation of `Page.on_resize`, and several bug fixes. The version is also bumped to 0.23.2 for `flet` and all related packages.

- **Bug Fixes**:
    - `Slider.value` now defaults to `min`.
    - Added `hide` and `show` to `WindowEventType` enum.
    - Resolved `TypeError` for `isinstance` check with `Union` in `before_update` method.
    - Corrected `isinstance` check in `SnackBar.before_update` to use a tuple of types instead of `Union`.
    - Fixed `Page.open()` breaking after multiple calls.
    - Fixed typo in `on_resized` setter decorator.
- **Enhancements**:
    - Enhanced typing of event handlers.
    - Deprecated `Page.on_resize` in favor of `Page.on_resized` and deleted `Page.window.on_resize`.
    - Updated behavior to prevent view from opening on tap.
- **Build**:
    - Bumped version to 0.23.2 for `flet` and all related packages.

<!-- Generated by sourcery-ai[bot]: end summary -->