### PR TITLE
Fix `PieChartEvent.type` on web

### DIFF
--- a/sdk/python/packages/flet-core/src/flet_core/charts/pie_chart.py
+++ b/sdk/python/packages/flet-core/src/flet_core/charts/pie_chart.py
@@ -1,4 +1,5 @@
 import json
+from enum import Enum
 from typing import Any, List, Optional, Union, Callable
 
 from flet_core.charts.pie_chart_section import PieChartSection
@@ -176,11 +177,31 @@ class PieChart(ConstrainedControl):
         self._set_attr("onChartEvent", True if handler is not None else None)
 
 
+class PieChartEventType(Enum):
+    POINTER_ENTER = "pointerEnter"
+    POINTER_EXIT = "pointerExit"
+    POINTER_HOVER = "pointerHover"
+    PAN_CANCEL = "panCancel"
+    PAN_DOWN = "panDown"
+    PAN_END = "panEnd"
+    PAN_START = "panStart"
+    PAN_UPDATE = "panUpdate"
+    LONG_PRESS_END = "longPressEnd"
+    LONG_PRESS_MOVE_UPDATE = "longPressMoveUpdate"
+    LONG_PRESS_START = "longPressStart"
+    TAP_CANCEL = "tapCancel"
+    TAP_DOWN = "tapDown"
+    TAP_UP = "tapUp"
+    UNDEFINED = "undefined"
+
+
 class PieChartEvent(ControlEvent):
     def __init__(self, e: ControlEvent):
         super().__init__(e.target, e.name, e.data, e.control, e.page)
         d = json.loads(e.data)
-        self.type: str = d["type"]
+        self.type: PieChartEventType = PieChartEventType(d.get("type"))
         self.section_index: int = d["section_index"]
+        self.local_x: Optional[float] = d.get("lx")
+        self.local_y: Optional[float] = d.get("ly")
         # self.radius: float = d["radius"]
         # self.angle: float = d["angle"]

--- a/sdk/python/packages/flet-core/src/flet_core/scrollable_control.py
+++ b/sdk/python/packages/flet-core/src/flet_core/scrollable_control.py
@@ -135,6 +135,3 @@ class OnScrollEvent(ControlEvent):
         self.direction: Optional[str] = d["dir"]
         self.overscroll: Optional[float] = d["os"]
         self.velocity: Optional[float] = d["v"]
-
-    def __str__(self):
-        return f"{self.event_type}: pixels={self.pixels}, min_scroll_extent={self.min_scroll_extent}, max_scroll_extent={self.max_scroll_extent}, viewport_dimension={self.viewport_dimension}, scroll_delta={self.scroll_delta}, direction={self.direction}, overscroll={self.overscroll}, velocity={self.velocity}"

--- a/sdk/python/packages/flet-core/src/flet_core/theme.py
+++ b/sdk/python/packages/flet-core/src/flet_core/theme.py
@@ -710,4 +710,6 @@ class Theme:
     text_theme: Optional[TextTheme] = field(default=None)
     time_picker_theme: Optional[TimePickerTheme] = field(default=None)
     tooltip_theme: Optional[TooltipTheme] = field(default=None)
-    visual_density: ThemeVisualDensity = field(default=ThemeVisualDensity.STANDARD)
+    visual_density: Union[VisualDensity, ThemeVisualDensity] = field(
+        default=VisualDensity.STANDARD
+    )


### PR DESCRIPTION
Fixes https://github.com/flet-dev/flet/issues/3546

Tried another approach, but the issue is still present.

AI's opinion on the cause of the issue:
> When you run your Flutter application on the web, the Dart compiler minifies the code to reduce the size of the JavaScript output. This process often includes renaming classes and variables to shorter names (e.g., aj_) to optimize the code for performance and load times. As a result, PointerHoverEvent might be minified to something like aj_, making it harder to understand directly from the debug output.

What I found strange is the fact that, when testing on web using `flutter run -d chrome` it works (shows the right types).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses the issue with `PieChartEvent.type` on web by mapping Flutter event types to readable event names. It also enhances the event data by adding local position information and introduces an enum for event types in the Python SDK.

- **Bug Fixes**:
    - Fixed the issue with `PieChartEvent.type` on web by mapping Flutter event types to readable event names.
- **Enhancements**:
    - Added `localPosition` to `PieChartEventData` to capture the local position of events.
    - Introduced `PieChartEventType` enum in Python to standardize event type values.

<!-- Generated by sourcery-ai[bot]: end summary -->