### PR TITLE
Fix `project` option in `build` cli command

### DIFF
--- a/sdk/python/packages/flet/src/flet/cli/commands/build.py
+++ b/sdk/python/packages/flet/src/flet/cli/commands/build.py
@@ -385,7 +385,7 @@ class Command(BaseCommand):
             )
 
             base_url = options.base_url.strip("/").strip()
-            project_name = options.product_name or slugify(
+            project_name = slugify(
                 options.project_name or python_app_path.name
             ).replace("-", "_")
             product_name = options.product_name or project_name


### PR DESCRIPTION
Fixes #3606

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a bug in the `build` CLI command where the `project` option was not being handled correctly. The fix ensures that the project name is properly slugified and used consistently.

- **Bug Fixes**:
    - Fixed the handling of the `project` option in the `build` CLI command to ensure the correct project name is used.

<!-- Generated by sourcery-ai[bot]: end summary -->