### PR TITLE
Add `rtl` prop to more controls

### DIFF
--- a/packages/flet/lib/src/controls/app_bar.dart
+++ b/packages/flet/lib/src/controls/app_bar.dart
@@ -92,7 +92,7 @@ class AppBarControl extends StatelessWidget
         toolbarTextStyle:
             parseTextStyle(Theme.of(context), control, "toolbarTextStyle"),
       );
-      return constrainedControl(context, appBar, parent, control);
+      return baseControl(context, appBar, parent, control);
     });
   }
 

--- a/packages/flet/lib/src/controls/app_bar.dart
+++ b/packages/flet/lib/src/controls/app_bar.dart
@@ -49,43 +49,25 @@ class AppBarControl extends StatelessWidget
       var titleCtrls = children.where((c) => c.name == "title" && c.isVisible);
       var actionCtrls =
           children.where((c) => c.name == "action" && c.isVisible);
-
-      var leadingWidth = control.attrDouble("leadingWidth");
-      var elevation = control.attrDouble("elevation");
-      var toolbarOpacity = control.attrDouble("toolbarOpacity", 1)!;
-      var centerTitle = control.attrBool("centerTitle", false)!;
-      var automaticallyImplyLeading =
-          control.attrBool("automaticallyImplyLeading", true)!;
-      var color = control.attrColor("color", context);
-      var bgcolor = control.attrColor("bgcolor", context);
-      var shadowColor = control.attrColor("shadowColor", context);
-      var surfaceTintColor = control.attrColor("surfaceTintColor", context);
-      var elevationOnScroll = control.attrDouble("elevationOnScroll");
-      var forceMaterialTransparency =
-          control.attrBool("forceMaterialTransparency", false)!;
       var isSecondary = control.attrBool("isSecondary", false)!;
-      var excludeHeaderSemantics =
-          control.attrBool("excludeHeaderSemantics", false)!;
-      var titleSpacing = control.attrDouble("titleSpacing");
 
-      var clipBehavior = parseClip(control.attrString("clipBehavior"));
-
-      return AppBar(
+      var appBar = AppBar(
         leading: leadingCtrls.isNotEmpty
             ? createControl(control, leadingCtrls.first.id, control.isDisabled,
                 parentAdaptive: adaptive)
             : null,
-        leadingWidth: leadingWidth,
-        automaticallyImplyLeading: automaticallyImplyLeading,
+        leadingWidth: control.attrDouble("leadingWidth"),
+        automaticallyImplyLeading:
+            control.attrBool("automaticallyImplyLeading", true)!,
         title: titleCtrls.isNotEmpty
             ? createControl(control, titleCtrls.first.id, control.isDisabled,
                 parentAdaptive: adaptive)
             : null,
-        centerTitle: centerTitle,
+        centerTitle: control.attrBool("centerTitle", false)!,
         toolbarHeight: preferredSize.height,
-        foregroundColor: color,
-        backgroundColor: bgcolor,
-        elevation: elevation,
+        foregroundColor: control.attrColor("color", context),
+        backgroundColor: control.attrColor("bgcolor", context),
+        elevation: control.attrDouble("elevation"),
         actions: actionCtrls
             .map((c) => createControl(control, c.id, control.isDisabled,
                 parentAdaptive: adaptive))
@@ -93,21 +75,24 @@ class AppBarControl extends StatelessWidget
         systemOverlayStyle: Theme.of(context)
             .extension<SystemUiOverlayStyleTheme>()
             ?.systemUiOverlayStyle,
-        shadowColor: shadowColor,
-        surfaceTintColor: surfaceTintColor,
-        scrolledUnderElevation: elevationOnScroll,
-        forceMaterialTransparency: forceMaterialTransparency,
+        shadowColor: control.attrColor("shadowColor", context),
+        surfaceTintColor: control.attrColor("surfaceTintColor", context),
+        scrolledUnderElevation: control.attrDouble("elevationOnScroll"),
+        forceMaterialTransparency:
+            control.attrBool("forceMaterialTransparency", false)!,
         primary: !isSecondary,
-        titleSpacing: titleSpacing,
-        excludeHeaderSemantics: excludeHeaderSemantics,
-        clipBehavior: clipBehavior,
+        titleSpacing: control.attrDouble("titleSpacing"),
+        excludeHeaderSemantics:
+            control.attrBool("excludeHeaderSemantics", false)!,
+        clipBehavior: parseClip(control.attrString("clipBehavior")),
         titleTextStyle:
             parseTextStyle(Theme.of(context), control, "titleTextStyle"),
         shape: parseOutlinedBorder(control, "shape"),
-        toolbarOpacity: toolbarOpacity,
+        toolbarOpacity: control.attrDouble("toolbarOpacity", 1)!,
         toolbarTextStyle:
             parseTextStyle(Theme.of(context), control, "toolbarTextStyle"),
       );
+      return constrainedControl(context, appBar, parent, control);
     });
   }
 

--- a/packages/flet/lib/src/controls/cupertino_app_bar.dart
+++ b/packages/flet/lib/src/controls/cupertino_app_bar.dart
@@ -37,25 +37,21 @@ class CupertinoAppBarControl extends StatelessWidget
     var trailingCtrls = children.where(
         (c) => (c.name == "trailing" || c.name == "action") && c.isVisible);
 
-    var automaticallyImplyLeading =
-        control.attrBool("automaticallyImplyLeading", true)!;
-    var automaticallyImplyMiddle =
-        control.attrBool("automaticallyImplyMiddle", true)!;
-    var transitionBetweenRoutes =
-        control.attrBool("transitionBetweenRoutes", true)!;
-    var bgcolor = control.attrColor("bgcolor", context);
-
-    return CupertinoNavigationBar(
+    var bar = CupertinoNavigationBar(
       leading: leadingCtrls.isNotEmpty
           ? createControl(control, leadingCtrls.first.id, control.isDisabled,
               parentAdaptive: parentAdaptive)
           : null,
-      automaticallyImplyLeading: automaticallyImplyLeading,
-      automaticallyImplyMiddle: automaticallyImplyMiddle,
-      transitionBetweenRoutes: transitionBetweenRoutes,
+      automaticallyImplyLeading:
+          control.attrBool("automaticallyImplyLeading", true)!,
+      automaticallyImplyMiddle:
+          control.attrBool("automaticallyImplyMiddle", true)!,
+      transitionBetweenRoutes:
+          control.attrBool("transitionBetweenRoutes", true)!,
       border: parseBorder(Theme.of(context), control, "border"),
       previousPageTitle: control.attrString("previousPageTitle"),
       padding: parseEdgeInsetsDirectional(control, "padding"),
+      backgroundColor: control.attrColor("bgcolor", context),
       middle: middleCtrls.isNotEmpty
           ? createControl(control, middleCtrls.first.id, control.isDisabled,
               parentAdaptive: parentAdaptive)
@@ -73,8 +69,8 @@ class CupertinoAppBarControl extends StatelessWidget
                       .toList(),
                 )
               : null,
-      backgroundColor: bgcolor,
     );
+    return constrainedControl(context, bar, parent, control);
   }
 
   @override

--- a/packages/flet/lib/src/controls/cupertino_app_bar.dart
+++ b/packages/flet/lib/src/controls/cupertino_app_bar.dart
@@ -70,7 +70,7 @@ class CupertinoAppBarControl extends StatelessWidget
                 )
               : null,
     );
-    return constrainedControl(context, bar, parent, control);
+    return baseControl(context, bar, parent, control);
   }
 
   @override

--- a/packages/flet/lib/src/controls/cupertino_bottom_sheet.dart
+++ b/packages/flet/lib/src/controls/cupertino_bottom_sheet.dart
@@ -49,9 +49,8 @@ class _CupertinoBottomSheetControlState
         : const SizedBox.shrink();
 
     if (contentCtrls.isNotEmpty &&
-        (contentCtrls.first.type == "cupertinopicker" ||
-            contentCtrls.first.type == "cupertinotimerpicker" ||
-            contentCtrls.first.type == "cupertinodatepicker")) {
+        ["cupertinopicker", "cupertinotimerpicker", "cupertinodatepicker"]
+            .contains(contentCtrls.first.type)) {
       content = Container(
         height: height,
         padding: padding,
@@ -112,8 +111,7 @@ class _CupertinoBottomSheetControlState
           if (shouldDismiss) {
             widget.backend
                 .updateControlState(widget.control.id, {"open": "false"});
-            widget.backend
-                .triggerControlEvent(widget.control.id, "dismiss", "");
+            widget.backend.triggerControlEvent(widget.control.id, "dismiss");
           }
         });
       });

--- a/packages/flet/lib/src/controls/navigation_drawer.dart
+++ b/packages/flet/lib/src/controls/navigation_drawer.dart
@@ -54,7 +54,7 @@ class _NavigationDrawerControlState extends State<NavigationDrawerControl>
       _selectedIndex = selectedIndex;
     }
 
-    var navDrawer = withControls(
+    return withControls(
         widget.children
             .where((c) => c.isVisible && c.name == null)
             .map((c) => c.id), (content, viewModel) {
@@ -102,9 +102,8 @@ class _NavigationDrawerControlState extends State<NavigationDrawerControl>
         children: children,
       );
 
-      return constrainedControl(context, drawer, widget.parent, widget.control);
+      return baseControl(context, drawer, widget.parent, widget.control);
     });
 
-    return navDrawer;
   }
 }

--- a/packages/flet/lib/src/controls/navigation_drawer.dart
+++ b/packages/flet/lib/src/controls/navigation_drawer.dart
@@ -60,7 +60,6 @@ class _NavigationDrawerControlState extends State<NavigationDrawerControl>
             .map((c) => c.id), (content, viewModel) {
       List<Widget> children = viewModel.controlViews.map((destView) {
         if (destView.control.type == "navigationdrawerdestination") {
-          var icon = parseIcon(destView.control.attrString("icon"));
           var iconContentCtrls = destView.children
               .where((c) => c.name == "icon_content" && c.isVisible);
           var selectedIcon =
@@ -73,7 +72,7 @@ class _NavigationDrawerControlState extends State<NavigationDrawerControl>
                 ? createControl(
                     destView.control, iconContentCtrls.first.id, disabled,
                     parentAdaptive: widget.parentAdaptive)
-                : Icon(icon),
+                : Icon(parseIcon(destView.control.attrString("icon"))),
             label: Text(destView.control.attrString("label", "")!),
             selectedIcon: selectedIconContentCtrls.isNotEmpty
                 ? createControl(destView.control,
@@ -88,7 +87,8 @@ class _NavigationDrawerControlState extends State<NavigationDrawerControl>
               parentAdaptive: widget.parentAdaptive);
         }
       }).toList();
-      return NavigationDrawer(
+
+      var drawer = NavigationDrawer(
         elevation: widget.control.attrDouble("elevation"),
         indicatorColor: widget.control.attrColor("indicatorColor", context),
         indicatorShape: parseOutlinedBorder(widget.control, "indicatorShape"),
@@ -101,6 +101,8 @@ class _NavigationDrawerControlState extends State<NavigationDrawerControl>
         onDestinationSelected: _destinationChanged,
         children: children,
       );
+
+      return constrainedControl(context, drawer, widget.parent, widget.control);
     });
 
     return navDrawer;

--- a/packages/flet/lib/src/controls/navigation_rail.dart
+++ b/packages/flet/lib/src/controls/navigation_rail.dart
@@ -37,7 +37,7 @@ class _NavigationRailControlState extends State<NavigationRailControl>
 
   void _destinationChanged(int index) {
     _selectedIndex = index;
-    debugPrint("Selected index: $_selectedIndex");
+    debugPrint("NavigationRail selectedIndex: $_selectedIndex");
     widget.backend.updateControlState(
         widget.control.id, {"selectedindex": _selectedIndex.toString()});
     widget.backend.triggerControlEvent(
@@ -87,7 +87,7 @@ class _NavigationRailControlState extends State<NavigationRailControl>
                     "Control's height is unbounded. Either set \"expand\" property, set a fixed \"height\" or nest NavigationRail inside another control with a fixed height.");
           }
 
-          var rail = NavigationRail(
+          var r = NavigationRail(
               labelType: extended ? NavigationRailLabelType.none : labelType,
               extended: extended,
               elevation: widget.control.attrDouble("elevation"),
@@ -156,11 +156,11 @@ class _NavigationRailControlState extends State<NavigationRailControl>
               }).toList());
 
           return constrainedControl(
-              context, rail, widget.parent, widget.control);
+              context, r, widget.parent, widget.control);
         },
       );
     });
 
-    return constrainedControl(context, rail, widget.parent, widget.control);
+    return rail;
   }
 }

--- a/packages/flet/lib/src/controls/navigation_rail.dart
+++ b/packages/flet/lib/src/controls/navigation_rail.dart
@@ -81,13 +81,13 @@ class _NavigationRailControlState extends State<NavigationRailControl>
               "NavigationRail constraints.maxHeight: ${constraints.maxHeight}");
 
           if (constraints.maxHeight == double.infinity &&
-              widget.control.attrs["height"] == null) {
+              widget.control.attrDouble("height") == null) {
             return const ErrorControl("Error displaying NavigationRail",
                 description:
                     "Control's height is unbounded. Either set \"expand\" property, set a fixed \"height\" or nest NavigationRail inside another control with a fixed height.");
           }
 
-          return NavigationRail(
+          var rail = NavigationRail(
               labelType: extended ? NavigationRailLabelType.none : labelType,
               extended: extended,
               elevation: widget.control.attrDouble("elevation", 0),
@@ -154,6 +154,9 @@ class _NavigationRailControlState extends State<NavigationRailControl>
                             parentAdaptive: widget.parentAdaptive)
                         : Text(label));
               }).toList());
+
+          return constrainedControl(
+              context, rail, widget.parent, widget.control);
         },
       );
     });

--- a/packages/flet/lib/src/controls/navigation_rail.dart
+++ b/packages/flet/lib/src/controls/navigation_rail.dart
@@ -90,7 +90,7 @@ class _NavigationRailControlState extends State<NavigationRailControl>
           var rail = NavigationRail(
               labelType: extended ? NavigationRailLabelType.none : labelType,
               extended: extended,
-              elevation: widget.control.attrDouble("elevation", 0),
+              elevation: widget.control.attrDouble("elevation"),
               selectedLabelTextStyle: parseTextStyle(
                   Theme.of(context), widget.control, "selectedLabelTextStyle"),
               unselectedLabelTextStyle: parseTextStyle(Theme.of(context),

--- a/packages/flet/lib/src/controls/navigation_rail.dart
+++ b/packages/flet/lib/src/controls/navigation_rail.dart
@@ -87,7 +87,7 @@ class _NavigationRailControlState extends State<NavigationRailControl>
                     "Control's height is unbounded. Either set \"expand\" property, set a fixed \"height\" or nest NavigationRail inside another control with a fixed height.");
           }
 
-          var r = NavigationRail(
+          return NavigationRail(
               labelType: extended ? NavigationRailLabelType.none : labelType,
               extended: extended,
               elevation: widget.control.attrDouble("elevation"),
@@ -154,13 +154,10 @@ class _NavigationRailControlState extends State<NavigationRailControl>
                             parentAdaptive: widget.parentAdaptive)
                         : Text(label));
               }).toList());
-
-          return constrainedControl(
-              context, r, widget.parent, widget.control);
         },
       );
     });
 
-    return rail;
+    return constrainedControl(context, rail, widget.parent, widget.control);
   }
 }

--- a/sdk/python/packages/flet-core/src/flet_core/app_bar.py
+++ b/sdk/python/packages/flet-core/src/flet_core/app_bar.py
@@ -83,9 +83,12 @@ class AppBar(AdaptiveControl):
         visible: Optional[bool] = None,
         disabled: Optional[bool] = None,
         data: Any = None,
+        rtl: Optional[bool] = None,
         adaptive: Optional[bool] = None,
     ):
-        Control.__init__(self, ref=ref, visible=visible, disabled=disabled, data=data)
+        Control.__init__(
+            self, ref=ref, visible=visible, disabled=disabled, data=data, rtl=rtl
+        )
 
         AdaptiveControl.__init__(self, adaptive=adaptive)
 

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_app_bar.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_app_bar.py
@@ -53,8 +53,11 @@ class CupertinoAppBar(Control):
         visible: Optional[bool] = None,
         disabled: Optional[bool] = None,
         data: Any = None,
+        rtl: Optional[bool] = None,
     ):
-        Control.__init__(self, ref=ref, visible=visible, disabled=disabled, data=data)
+        Control.__init__(
+            self, ref=ref, visible=visible, disabled=disabled, data=data, rtl=rtl
+        )
 
         self.leading = leading
         self.middle = middle

--- a/sdk/python/packages/flet-core/src/flet_core/navigation_drawer.py
+++ b/sdk/python/packages/flet-core/src/flet_core/navigation_drawer.py
@@ -189,6 +189,7 @@ class NavigationDrawer(Control):
         disabled: Optional[bool] = None,
         visible: Optional[bool] = None,
         data: Any = None,
+        rtl: Optional[bool] = None,
     ):
         Control.__init__(
             self,
@@ -196,6 +197,7 @@ class NavigationDrawer(Control):
             visible=visible,
             disabled=disabled,
             data=data,
+            rtl=rtl,
         )
 
         self.open = open

--- a/sdk/python/packages/flet-core/src/flet_core/navigation_rail.py
+++ b/sdk/python/packages/flet-core/src/flet_core/navigation_rail.py
@@ -411,7 +411,7 @@ class NavigationRail(ConstrainedControl):
 
     @elevation.setter
     def elevation(self, value: OptionalNumber):
-        assert value is None or value > 0, "elevation cannot be negative"
+        assert value is None or value > 0, "elevation must be greater than 0"
         self._set_attr("elevation", value)
 
     # extended

--- a/sdk/python/packages/flet-core/src/flet_core/navigation_rail.py
+++ b/sdk/python/packages/flet-core/src/flet_core/navigation_rail.py
@@ -26,24 +26,25 @@ class NavigationRailLabelType(Enum):
 
 class NavigationRailDestination(Control):
     def __init__(
-            self,
-            icon: Optional[str] = None,
-            icon_content: Optional[Control] = None,
-            selected_icon: Optional[str] = None,
-            selected_icon_content: Optional[Control] = None,
-            label: Optional[str] = None,
-            label_content: Optional[Control] = None,
-            padding: PaddingValue = None,
-            indicator_color: Optional[str] = None,
-            indicator_shape: Optional[OutlinedBorder] = None,
-            #
-            # Control
-            #
-            ref: Optional[Ref] = None,
-            disabled: Optional[bool] = None,
-            data: Any = None,
+        self,
+        icon: Optional[str] = None,
+        icon_content: Optional[Control] = None,
+        selected_icon: Optional[str] = None,
+        selected_icon_content: Optional[Control] = None,
+        label: Optional[str] = None,
+        label_content: Optional[Control] = None,
+        padding: PaddingValue = None,
+        indicator_color: Optional[str] = None,
+        indicator_shape: Optional[OutlinedBorder] = None,
+        #
+        # Control
+        #
+        ref: Optional[Ref] = None,
+        disabled: Optional[bool] = None,
+        data: Any = None,
+        rtl: Optional[bool] = None,
     ) -> None:
-        Control.__init__(self, ref=ref, disabled=disabled, data=data)
+        Control.__init__(self, ref=ref, disabled=disabled, data=data, rtl=rtl)
         self.label = label
         self.icon = icon
         self.icon_content = icon_content
@@ -262,6 +263,7 @@ class NavigationRail(ConstrainedControl):
         visible: Optional[bool] = None,
         disabled: Optional[bool] = None,
         data: Any = None,
+        rtl: Optional[bool] = False,
     ):
         ConstrainedControl.__init__(
             self,
@@ -290,6 +292,7 @@ class NavigationRail(ConstrainedControl):
             visible=visible,
             disabled=disabled,
             data=data,
+            rtl=rtl,
         )
 
         self.destinations = destinations
@@ -408,7 +411,7 @@ class NavigationRail(ConstrainedControl):
 
     @elevation.setter
     def elevation(self, value: OptionalNumber):
-        assert value is None or value >= 0, "elevation cannot be negative"
+        assert value is None or value > 0, "elevation cannot be negative"
         self._set_attr("elevation", value)
 
     # extended

--- a/sdk/python/packages/flet-core/src/flet_core/page.py
+++ b/sdk/python/packages/flet-core/src/flet_core/page.py
@@ -1122,11 +1122,9 @@ class Page(AdaptiveControl):
         if not self.web:
             if self.platform in ["ios", "android"]:
                 # close web view on mobile
-
                 self.close_in_app_web_view()
             else:
                 # activate desktop window
-
                 self.window_to_front()
         login_evt = LoginEvent(
             error=d["error"],

--- a/sdk/python/packages/flet-core/tests/test_navigation_rail.py
+++ b/sdk/python/packages/flet-core/tests/test_navigation_rail.py
@@ -1,5 +1,4 @@
 import flet_core as ft
-import pytest
 from flet_core.protocol import Command
 
 
@@ -11,7 +10,7 @@ def test_instance_no_attrs_set():
             indent=0,
             name=None,
             values=["navigationrail"],
-            attrs={},
+            attrs={"rtl": "false"},
             commands=[],
         )
     ], "Test failed"


### PR DESCRIPTION
Fixes #3637

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces the `rtl` property to several controls to support right-to-left layouts, fixes an assertion in `NavigationRail`, and includes various refactorings to streamline control creation and logic.

- **New Features**:
    - Added `rtl` (right-to-left) property to various controls including `NavigationRailDestination`, `NavigationRail`, `AppBar`, `CupertinoAppBar`, and `NavigationDrawer` to support right-to-left layouts.
- **Bug Fixes**:
    - Fixed an assertion in `NavigationRail` to ensure elevation must be greater than 0.
- **Enhancements**:
    - Refactored the creation of `AppBar`, `CupertinoAppBar`, `NavigationRail`, and `NavigationDrawer` controls to use a more concise and consistent approach.
    - Simplified conditional checks and control creation logic in `CupertinoBottomSheet` and `NavigationDrawer`.

<!-- Generated by sourcery-ai[bot]: end summary -->