### PR TITLE
`Placeholder` Control

### DIFF
--- a/packages/flet/lib/src/controls/create_control.dart
+++ b/packages/flet/lib/src/controls/create_control.dart
@@ -84,6 +84,7 @@ import 'outlined_button.dart';
 import 'page.dart';
 import 'pagelet.dart';
 import 'piechart.dart';
+import 'placeholder.dart';
 import 'popup_menu_button.dart';
 import 'progress_bar.dart';
 import 'progress_ring.dart';
@@ -444,6 +445,14 @@ Widget createWidget(
           parentDisabled: parentDisabled,
           parentAdaptive: parentAdaptive,
           backend: backend);
+      case "placeholder":
+      return PlaceholderControl(
+          key: key,
+          parent: parent,
+          control: controlView.control,
+          children: controlView.children,
+          parentDisabled: parentDisabled,
+          parentAdaptive: parentAdaptive);
     case "cupertinoslidingsegmentedbutton":
       return CupertinoSlidingSegmentedButtonControl(
           key: key,

--- a/packages/flet/lib/src/controls/placeholder.dart
+++ b/packages/flet/lib/src/controls/placeholder.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+import '../models/control.dart';
+import 'create_control.dart';
+
+class PlaceholderControl extends StatelessWidget {
+  final Control? parent;
+  final Control control;
+  final List<Control> children;
+  final bool parentDisabled;
+  final bool? parentAdaptive;
+
+  const PlaceholderControl(
+      {super.key,
+      required this.parent,
+      required this.control,
+      required this.children,
+      required this.parentDisabled,
+      required this.parentAdaptive});
+
+  @override
+  Widget build(BuildContext context) {
+    debugPrint("Placeholder build: ${control.id}");
+    bool disabled = control.isDisabled || parentDisabled;
+    bool? adaptive = control.attrBool("adaptive") ?? parentAdaptive;
+    var contentCtrls = children.where((c) => c.isVisible);
+
+    return baseControl(
+        context,
+        Placeholder(
+            fallbackHeight: control.attrDouble("fallbackHeight", 400.0)!,
+            fallbackWidth: control.attrDouble("fallbackWidth", 400.0)!,
+            color:
+                control.attrColor("color", context, const Color(0xFF455A64))!,
+            strokeWidth: control.attrDouble("strokeWidth", 2.0)!,
+            child: contentCtrls.isNotEmpty
+                ? createControl(control, contentCtrls.first.id, disabled,
+                    parentAdaptive: adaptive)
+                : null),
+        parent,
+        control);
+  }
+}

--- a/sdk/python/packages/flet-core/src/flet_core/__init__.py
+++ b/sdk/python/packages/flet-core/src/flet_core/__init__.py
@@ -233,6 +233,7 @@ from flet_core.permission_handler import (
     PermissionType,
     PermissionStatus,
 )
+from flet_core.placeholder import Placeholder
 from flet_core.popup_menu_button import (
     PopupMenuButton,
     PopupMenuItem,

--- a/sdk/python/packages/flet-core/src/flet_core/divider.py
+++ b/sdk/python/packages/flet-core/src/flet_core/divider.py
@@ -57,6 +57,7 @@ class Divider(Control):
         #
         ref: Optional[Ref] = None,
         opacity: OptionalNumber = None,
+        tooltip: Optional[str] = None,
         visible: Optional[bool] = None,
         data: Any = None,
     ):
@@ -65,6 +66,7 @@ class Divider(Control):
             self,
             ref=ref,
             opacity=opacity,
+            tooltip=tooltip,
             visible=visible,
             data=data,
         )

--- a/sdk/python/packages/flet-core/src/flet_core/placeholder.py
+++ b/sdk/python/packages/flet-core/src/flet_core/placeholder.py
@@ -1,0 +1,99 @@
+from typing import Any, Optional
+
+from flet_core.control import Control, OptionalNumber
+from flet_core.ref import Ref
+
+
+class Placeholder(Control):
+    """
+    A placeholder box.
+
+    -----
+
+    Online docs: https://flet.dev/docs/controls/placeholder
+    """
+
+    def __init__(
+        self,
+        content: Optional[Control] = None,
+        color: Optional[str] = None,
+        fallback_height: OptionalNumber = None,
+        fallback_width: OptionalNumber = None,
+        stroke_width: OptionalNumber = None,
+        #
+        # Control
+        #
+        ref: Optional[Ref] = None,
+        opacity: OptionalNumber = None,
+        tooltip: Optional[str] = None,
+        visible: Optional[bool] = None,
+        data: Any = None,
+    ):
+
+        Control.__init__(
+            self,
+            ref=ref,
+            opacity=opacity,
+            tooltip=tooltip,
+            visible=visible,
+            data=data,
+        )
+
+        self.content = content
+        self.color = color
+        self.fallback_height = fallback_height
+        self.fallback_width = fallback_width
+        self.stroke_width = stroke_width
+
+    def _get_control_name(self):
+        return "placeholder"
+
+    def _get_children(self):
+        return [self.content] if self.content is not None else []
+
+    # fallback_height
+    @property
+    def fallback_height(self) -> OptionalNumber:
+        return self._get_attr("fallbackHeight", data_type="float", def_value=400.0)
+
+    @fallback_height.setter
+    def fallback_height(self, value: OptionalNumber):
+        assert value is None or value >= 0, "fallback_height cannot be negative"
+        self._set_attr("fallbackHeight", value)
+
+    # fallback_width
+    @property
+    def fallback_width(self) -> OptionalNumber:
+        return self._get_attr("fallbackWidth", data_type="float", def_value=400.0)
+
+    @fallback_width.setter
+    def fallback_width(self, value: OptionalNumber):
+        assert value is None or value >= 0, "fallback_width cannot be negative"
+        self._set_attr("fallbackWidth", value)
+
+    # stroke_width
+    @property
+    def stroke_width(self) -> OptionalNumber:
+        return self._get_attr("strokeWidth", data_type="float", def_value=2.0)
+
+    @stroke_width.setter
+    def stroke_width(self, value: OptionalNumber):
+        self._set_attr("strokeWidth", value)
+
+    # color
+    @property
+    def color(self) -> Optional[str]:
+        return self._get_attr("color", def_value="bluegrey700")
+
+    @color.setter
+    def color(self, value: Optional[str]):
+        self._set_attr("color", value)
+
+    # content
+    @property
+    def content(self) -> Optional[Control]:
+        return self.__content
+
+    @content.setter
+    def content(self, value: Optional[Control]):
+        self.__content = value

--- a/sdk/python/packages/flet-core/src/flet_core/placeholder.py
+++ b/sdk/python/packages/flet-core/src/flet_core/placeholder.py
@@ -1,10 +1,20 @@
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
-from flet_core.control import Control, OptionalNumber
+from flet_core.constrained_control import ConstrainedControl
+from flet_core.control import Control
+from flet_core.control import OptionalNumber
 from flet_core.ref import Ref
+from flet_core.types import (
+    AnimationValue,
+    OffsetValue,
+    ResponsiveNumber,
+    RotateValue,
+    ScaleValue,
+    OptionalEventCallable,
+)
 
 
-class Placeholder(Control):
+class Placeholder(ConstrainedControl):
     """
     A placeholder box.
 
@@ -21,22 +31,67 @@ class Placeholder(Control):
         fallback_width: OptionalNumber = None,
         stroke_width: OptionalNumber = None,
         #
-        # Control
+        # ConstrainedControl
         #
         ref: Optional[Ref] = None,
+        key: Optional[str] = None,
+        width: OptionalNumber = None,
+        height: OptionalNumber = None,
+        left: OptionalNumber = None,
+        top: OptionalNumber = None,
+        right: OptionalNumber = None,
+        bottom: OptionalNumber = None,
+        expand: Union[None, bool, int] = None,
+        expand_loose: Optional[bool] = None,
+        col: Optional[ResponsiveNumber] = None,
         opacity: OptionalNumber = None,
+        rotate: RotateValue = None,
+        scale: ScaleValue = None,
+        offset: OffsetValue = None,
+        aspect_ratio: OptionalNumber = None,
+        animate_opacity: AnimationValue = None,
+        animate_size: AnimationValue = None,
+        animate_position: AnimationValue = None,
+        animate_rotation: AnimationValue = None,
+        animate_scale: AnimationValue = None,
+        animate_offset: AnimationValue = None,
+        on_animation_end: OptionalEventCallable = None,
         tooltip: Optional[str] = None,
         visible: Optional[bool] = None,
+        disabled: Optional[bool] = None,
         data: Any = None,
+        rtl: Optional[bool] = None,
     ):
-
-        Control.__init__(
+        ConstrainedControl.__init__(
             self,
             ref=ref,
+            key=key,
+            width=width,
+            height=height,
+            left=left,
+            top=top,
+            right=right,
+            bottom=bottom,
+            expand=expand,
+            expand_loose=expand_loose,
+            col=col,
             opacity=opacity,
+            rotate=rotate,
+            scale=scale,
+            offset=offset,
+            aspect_ratio=aspect_ratio,
+            animate_opacity=animate_opacity,
+            animate_size=animate_size,
+            animate_position=animate_position,
+            animate_rotation=animate_rotation,
+            animate_scale=animate_scale,
+            animate_offset=animate_offset,
+            on_animation_end=on_animation_end,
             tooltip=tooltip,
             visible=visible,
+            disabled=disabled,
             data=data,
+            rtl=rtl,
         )
 
         self.content = content
@@ -53,7 +108,7 @@ class Placeholder(Control):
 
     # fallback_height
     @property
-    def fallback_height(self) -> OptionalNumber:
+    def fallback_height(self) -> float:
         return self._get_attr("fallbackHeight", data_type="float", def_value=400.0)
 
     @fallback_height.setter
@@ -63,7 +118,7 @@ class Placeholder(Control):
 
     # fallback_width
     @property
-    def fallback_width(self) -> OptionalNumber:
+    def fallback_width(self) -> float:
         return self._get_attr("fallbackWidth", data_type="float", def_value=400.0)
 
     @fallback_width.setter
@@ -73,7 +128,7 @@ class Placeholder(Control):
 
     # stroke_width
     @property
-    def stroke_width(self) -> OptionalNumber:
+    def stroke_width(self) -> float:
         return self._get_attr("strokeWidth", data_type="float", def_value=2.0)
 
     @stroke_width.setter
@@ -82,7 +137,7 @@ class Placeholder(Control):
 
     # color
     @property
-    def color(self) -> Optional[str]:
+    def color(self) -> str:
         return self._get_attr("color", def_value="bluegrey700")
 
     @color.setter


### PR DESCRIPTION
## Test Code
```py
import flet as ft


def main(page: ft.Page):
    page.add(
        ft.Placeholder(
            expand=True,
            color=ft.colors.random_color()
        )
    )


ft.app(main)
```

## Capture
![placeholder](https://github.com/user-attachments/assets/fdd0cbbf-3193-4e10-a6ef-28208afa872f)

## Summary by Sourcery
This pull request introduces a new Placeholder control to the Flet library, enabling the creation of customizable placeholder boxes. Additionally, it enhances the Divider control by adding support for a tooltip property.

- New Features:
    - Introduced a new Placeholder control in the Flet library, allowing users to add placeholder boxes with customizable properties such as color, fallback height, fallback width, and stroke width.
- Enhancements:
   - Added support for a tooltip property in the Divider control.
