### PR TITLE
Fix `Map`-related issues

### DIFF
--- a/sdk/python/packages/flet-core/src/flet_core/map/map.py
+++ b/sdk/python/packages/flet-core/src/flet_core/map/map.py
@@ -27,7 +27,7 @@ class Map(ConstrainedControl):
     def __init__(
         self,
         layers: List[MapLayer],
-        configuration: Optional[MapConfiguration] = None,
+        configuration: MapConfiguration = MapConfiguration(),
         #
         # ConstrainedControl
         #
@@ -101,11 +101,11 @@ class Map(ConstrainedControl):
 
     # configuration
     @property
-    def configuration(self) -> Optional[MapConfiguration]:
+    def configuration(self) -> MapConfiguration:
         return self.__configuration
 
     @configuration.setter
-    def configuration(self, value: Optional[MapConfiguration]):
+    def configuration(self, value: MapConfiguration):
         self.__configuration = value
 
     # layers

--- a/sdk/python/packages/flet-core/src/flet_core/map/map_layer.py
+++ b/sdk/python/packages/flet-core/src/flet_core/map/map_layer.py
@@ -18,7 +18,6 @@ class MapLayer(Control):
         visible: Optional[bool] = None,
         data: Any = None,
     ):
-
         Control.__init__(
             self,
             ref=ref,

--- a/sdk/python/packages/flet-core/src/flet_core/map/marker_layer.py
+++ b/sdk/python/packages/flet-core/src/flet_core/map/marker_layer.py
@@ -31,7 +31,6 @@ class Marker(Control):
         visible: Optional[bool] = None,
         data: Any = None,
     ):
-
         Control.__init__(
             self,
             ref=ref,
@@ -135,7 +134,6 @@ class MarkerLayer(MapLayer):
         visible: Optional[bool] = None,
         data: Any = None,
     ):
-
         MapLayer.__init__(
             self,
             ref=ref,

--- a/sdk/python/packages/flet-core/src/flet_core/map/polygon_layer.py
+++ b/sdk/python/packages/flet-core/src/flet_core/map/polygon_layer.py
@@ -36,7 +36,6 @@ class PolygonMarker(Control):
         visible: Optional[bool] = None,
         data: Any = None,
     ):
-
         Control.__init__(
             self,
             ref=ref,
@@ -60,8 +59,7 @@ class PolygonMarker(Control):
 
     def before_update(self):
         super().before_update()
-        if isinstance(self.__coordinates, list):
-            self._set_attr_json("coordinates", self.__coordinates)
+        self._set_attr_json("coordinates", self.__coordinates)
         if isinstance(self.__label_text_style, TextStyle):
             self._set_attr_json("labelTextStyle", self.__label_text_style)
 
@@ -151,11 +149,11 @@ class PolygonMarker(Control):
 
     # coordinates
     @property
-    def coordinates(self) -> Optional[List[MapLatitudeLongitude]]:
+    def coordinates(self) -> List[MapLatitudeLongitude]:
         return self.__coordinates
 
     @coordinates.setter
-    def coordinates(self, value: Optional[List[MapLatitudeLongitude]]):
+    def coordinates(self, value: List[MapLatitudeLongitude]):
         self.__coordinates = value
 
 
@@ -183,7 +181,6 @@ class PolygonLayer(MapLayer):
         visible: Optional[bool] = None,
         data: Any = None,
     ):
-
         MapLayer.__init__(
             self,
             ref=ref,

--- a/sdk/python/packages/flet-core/src/flet_core/map/polyline_layer.py
+++ b/sdk/python/packages/flet-core/src/flet_core/map/polyline_layer.py
@@ -74,7 +74,6 @@ class PolylineMarker(Control):
         visible: Optional[bool] = None,
         data: Any = None,
     ):
-
         Control.__init__(
             self,
             ref=ref,
@@ -99,8 +98,7 @@ class PolylineMarker(Control):
 
     def before_update(self):
         super().before_update()
-        if isinstance(self.__coordinates, list):
-            self._set_attr_json("coordinates", self.__coordinates)
+        self._set_attr_json("coordinates", self.__coordinates)
         if isinstance(self.__colors_stop, list):
             self._set_attr_json("colorsStop", self.__colors_stop)
         if isinstance(self.__gradient_colors, list):
@@ -205,11 +203,11 @@ class PolylineMarker(Control):
 
     # coordinates
     @property
-    def coordinates(self) -> Optional[List[MapLatitudeLongitude]]:
+    def coordinates(self) -> List[MapLatitudeLongitude]:
         return self.__coordinates
 
     @coordinates.setter
-    def coordinates(self, value: Optional[List[MapLatitudeLongitude]]):
+    def coordinates(self, value: List[MapLatitudeLongitude]):
         self.__coordinates = value
 
 
@@ -235,7 +233,6 @@ class PolylineLayer(MapLayer):
         visible: Optional[bool] = None,
         data: Any = None,
     ):
-
         MapLayer.__init__(
             self,
             ref=ref,
@@ -265,8 +262,8 @@ class PolylineLayer(MapLayer):
 
     # culling_margin
     @property
-    def culling_margin(self) -> OptionalNumber:
-        return self._get_attr("cullingMargin", data_type="float", def_value=10)
+    def culling_margin(self) -> float:
+        return self._get_attr("cullingMargin", data_type="float", def_value=10.0)
 
     @culling_margin.setter
     def culling_margin(self, value: OptionalNumber):
@@ -274,7 +271,7 @@ class PolylineLayer(MapLayer):
 
     # simplification_tolerance
     @property
-    def simplification_tolerance(self) -> OptionalNumber:
+    def simplification_tolerance(self) -> float:
         return self._get_attr(
             "simplificationTolerance", data_type="float", def_value=0.4
         )
@@ -285,8 +282,8 @@ class PolylineLayer(MapLayer):
 
     # min_hittable_radius
     @property
-    def min_hittable_radius(self) -> OptionalNumber:
-        return self._get_attr("minHittableRadius", data_type="float", def_value=10)
+    def min_hittable_radius(self) -> float:
+        return self._get_attr("minHittableRadius", data_type="float", def_value=10.0)
 
     @min_hittable_radius.setter
     def min_hittable_radius(self, value: OptionalNumber):

--- a/sdk/python/packages/flet-core/src/flet_core/map/rich_attribution.py
+++ b/sdk/python/packages/flet-core/src/flet_core/map/rich_attribution.py
@@ -64,6 +64,7 @@ class RichAttribution(MapLayer):
     def before_update(self):
         super().before_update()
         self._set_attr_json("popupBorderRadius", self.__popup_border_radius)
+        self._set_attr_json("alignment", self.__alignment)
 
     # permanent_height
     @property


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses several `Map`-related issues by fixing attribute initialization and type annotations. It ensures that certain attributes are always set correctly and removes redundant type checks.

- **Bug Fixes**:
    - Fixed issue where `coordinates` attribute was not always set correctly in `PolylineLayer` and `PolygonLayer`.
    - Ensured `configuration` attribute in `Map` class is always initialized with a default `MapConfiguration` object.
- **Enhancements**:
    - Changed type annotations for several attributes in `PolylineLayer`, `PolygonLayer`, and `Map` classes to ensure they are non-optional and have default values.
    - Removed unnecessary type checks before setting JSON attributes in `PolylineLayer` and `PolygonLayer` classes.

<!-- Generated by sourcery-ai[bot]: end summary -->