### PR TITLE
improve type hint for OptionalEventCallable

### DIFF
--- a/sdk/python/packages/flet-core/src/flet_core/alert_dialog.py
+++ b/sdk/python/packages/flet-core/src/flet_core/alert_dialog.py
@@ -11,7 +11,7 @@ from flet_core.types import (
     MainAxisAlignment,
     PaddingValue,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -418,9 +418,9 @@ class AlertDialog(AdaptiveControl):
 
     # on_dismiss
     @property
-    def on_dismiss(self) -> DefaultOptionalEventCallable:
+    def on_dismiss(self) -> OptionalControlEventCallable:
         return self._get_event_handler("dismiss")
 
     @on_dismiss.setter
-    def on_dismiss(self, handler: DefaultOptionalEventCallable):
+    def on_dismiss(self, handler: OptionalControlEventCallable):
         self._add_event_handler("dismiss", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/alert_dialog.py
+++ b/sdk/python/packages/flet-core/src/flet_core/alert_dialog.py
@@ -11,6 +11,7 @@ from flet_core.types import (
     MainAxisAlignment,
     PaddingValue,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 
 
@@ -417,9 +418,9 @@ class AlertDialog(AdaptiveControl):
 
     # on_dismiss
     @property
-    def on_dismiss(self) -> OptionalEventCallable:
+    def on_dismiss(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("dismiss")
 
     @on_dismiss.setter
-    def on_dismiss(self, handler: OptionalEventCallable):
+    def on_dismiss(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("dismiss", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/audio.py
+++ b/sdk/python/packages/flet-core/src/flet_core/audio.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 
 from flet_core.control import Control, OptionalNumber
 from flet_core.ref import Ref
-from flet_core.types import OptionalEventCallable, DefaultOptionalEventCallable
+from flet_core.types import OptionalEventCallable, OptionalControlEventCallable
 from flet_core.utils import deprecated
 
 
@@ -246,7 +246,7 @@ class Audio(Control):
         return self._get_event_handler("loaded")
 
     @on_loaded.setter
-    def on_loaded(self, handler: DefaultOptionalEventCallable):
+    def on_loaded(self, handler: OptionalControlEventCallable):
         self._add_event_handler("loaded", handler)
 
     # on_duration_changed
@@ -255,7 +255,7 @@ class Audio(Control):
         return self._get_event_handler("duration_changed")
 
     @on_duration_changed.setter
-    def on_duration_changed(self, handler: DefaultOptionalEventCallable):
+    def on_duration_changed(self, handler: OptionalControlEventCallable):
         self._add_event_handler("duration_changed", handler)
 
     # on_state_changed
@@ -264,7 +264,7 @@ class Audio(Control):
         return self._get_event_handler("state_changed")
 
     @on_state_changed.setter
-    def on_state_changed(self, handler: DefaultOptionalEventCallable):
+    def on_state_changed(self, handler: OptionalControlEventCallable):
         self._add_event_handler("state_changed", handler)
 
     # on_position_changed
@@ -273,7 +273,7 @@ class Audio(Control):
         return self._get_event_handler("position_changed")
 
     @on_position_changed.setter
-    def on_position_changed(self, handler: DefaultOptionalEventCallable):
+    def on_position_changed(self, handler: OptionalControlEventCallable):
         self._add_event_handler("position_changed", handler)
         self._set_attr("onPositionChanged", True if handler is not None else None)
 
@@ -283,5 +283,5 @@ class Audio(Control):
         return self._get_event_handler("seek_complete")
 
     @on_seek_complete.setter
-    def on_seek_complete(self, handler: DefaultOptionalEventCallable):
+    def on_seek_complete(self, handler: OptionalControlEventCallable):
         self._add_event_handler("seek_complete", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/audio.py
+++ b/sdk/python/packages/flet-core/src/flet_core/audio.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 
 from flet_core.control import Control, OptionalNumber
 from flet_core.ref import Ref
-from flet_core.types import OptionalEventCallable
+from flet_core.types import OptionalEventCallable, DefaultOptionalEventCallable
 from flet_core.utils import deprecated
 
 
@@ -246,7 +246,7 @@ class Audio(Control):
         return self._get_event_handler("loaded")
 
     @on_loaded.setter
-    def on_loaded(self, handler: OptionalEventCallable):
+    def on_loaded(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("loaded", handler)
 
     # on_duration_changed
@@ -255,7 +255,7 @@ class Audio(Control):
         return self._get_event_handler("duration_changed")
 
     @on_duration_changed.setter
-    def on_duration_changed(self, handler: OptionalEventCallable):
+    def on_duration_changed(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("duration_changed", handler)
 
     # on_state_changed
@@ -264,7 +264,7 @@ class Audio(Control):
         return self._get_event_handler("state_changed")
 
     @on_state_changed.setter
-    def on_state_changed(self, handler: OptionalEventCallable):
+    def on_state_changed(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("state_changed", handler)
 
     # on_position_changed
@@ -273,7 +273,7 @@ class Audio(Control):
         return self._get_event_handler("position_changed")
 
     @on_position_changed.setter
-    def on_position_changed(self, handler: OptionalEventCallable):
+    def on_position_changed(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("position_changed", handler)
         self._set_attr("onPositionChanged", True if handler is not None else None)
 
@@ -283,5 +283,5 @@ class Audio(Control):
         return self._get_event_handler("seek_complete")
 
     @on_seek_complete.setter
-    def on_seek_complete(self, handler: OptionalEventCallable):
+    def on_seek_complete(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("seek_complete", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/audio_recorder.py
+++ b/sdk/python/packages/flet-core/src/flet_core/audio_recorder.py
@@ -4,7 +4,7 @@ from typing import Any, Optional
 
 from flet_core.control import Control, OptionalNumber
 from flet_core.ref import Ref
-from flet_core.types import DefaultOptionalEventCallable
+from flet_core.types import OptionalControlEventCallable
 from flet_core.utils import deprecated
 
 
@@ -284,9 +284,9 @@ class AudioRecorder(Control):
 
     # on_state_changed
     @property
-    def on_state_changed(self) -> DefaultOptionalEventCallable:
+    def on_state_changed(self) -> OptionalControlEventCallable:
         return self._get_event_handler("state_changed")
 
     @on_state_changed.setter
-    def on_state_changed(self, handler: DefaultOptionalEventCallable):
+    def on_state_changed(self, handler: OptionalControlEventCallable):
         self._add_event_handler("state_changed", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/audio_recorder.py
+++ b/sdk/python/packages/flet-core/src/flet_core/audio_recorder.py
@@ -4,7 +4,7 @@ from typing import Any, Optional
 
 from flet_core.control import Control, OptionalNumber
 from flet_core.ref import Ref
-from flet_core.types import OptionalEventCallable
+from flet_core.types import DefaultOptionalEventCallable
 from flet_core.utils import deprecated
 
 
@@ -284,9 +284,9 @@ class AudioRecorder(Control):
 
     # on_state_changed
     @property
-    def on_state_changed(self) -> OptionalEventCallable:
+    def on_state_changed(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("state_changed")
 
     @on_state_changed.setter
-    def on_state_changed(self, handler: OptionalEventCallable):
+    def on_state_changed(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("state_changed", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/auto_complete.py
+++ b/sdk/python/packages/flet-core/src/flet_core/auto_complete.py
@@ -1,11 +1,12 @@
 import json
 from dataclasses import dataclass, field
-from typing import Any, Optional, List, Callable
+from typing import Any, Optional, List
 
 from flet_core.control import Control, OptionalNumber
 from flet_core.control_event import ControlEvent
 from flet_core.event_handler import EventHandler
 from flet_core.ref import Ref
+from flet_core.types import OptionalEventCallable
 
 
 @dataclass
@@ -90,7 +91,7 @@ class AutoComplete(Control):
         return self._get_event_handler("select")
 
     @on_select.setter
-    def on_select(self, handler: Optional[Callable[["AutoCompleteSelectEvent"], None]]):
+    def on_select(self, handler: OptionalEventCallable["AutoCompleteSelectEvent"]):
         self.__on_select.subscribe(handler)
 
 

--- a/sdk/python/packages/flet-core/src/flet_core/banner.py
+++ b/sdk/python/packages/flet-core/src/flet_core/banner.py
@@ -7,7 +7,7 @@ from flet_core.types import (
     PaddingValue,
     MarginValue,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -269,9 +269,9 @@ class Banner(Control):
 
     # on_visible
     @property
-    def on_visible(self) -> DefaultOptionalEventCallable:
+    def on_visible(self) -> OptionalControlEventCallable:
         return self._get_event_handler("visible")
 
     @on_visible.setter
-    def on_visible(self, handler: DefaultOptionalEventCallable):
+    def on_visible(self, handler: OptionalControlEventCallable):
         self._add_event_handler("visible", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/banner.py
+++ b/sdk/python/packages/flet-core/src/flet_core/banner.py
@@ -3,7 +3,12 @@ from typing import Any, List, Optional
 from flet_core.control import Control, OptionalNumber
 from flet_core.ref import Ref
 from flet_core.text_style import TextStyle
-from flet_core.types import PaddingValue, MarginValue, OptionalEventCallable
+from flet_core.types import (
+    PaddingValue,
+    MarginValue,
+    OptionalEventCallable,
+    DefaultOptionalEventCallable,
+)
 
 
 class Banner(Control):
@@ -66,7 +71,7 @@ class Banner(Control):
         elevation: OptionalNumber = None,
         margin: MarginValue = None,
         content_text_style: Optional[TextStyle] = None,
-            on_visible: OptionalEventCallable = None,
+        on_visible: OptionalEventCallable = None,
         #
         # Control
         #
@@ -264,9 +269,9 @@ class Banner(Control):
 
     # on_visible
     @property
-    def on_visible(self) -> OptionalEventCallable:
+    def on_visible(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("visible")
 
     @on_visible.setter
-    def on_visible(self, handler: OptionalEventCallable):
+    def on_visible(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("visible", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/bottom_sheet.py
+++ b/sdk/python/packages/flet-core/src/flet_core/bottom_sheet.py
@@ -2,7 +2,7 @@ from typing import Any, Optional
 
 from flet_core.control import Control, OptionalNumber
 from flet_core.ref import Ref
-from flet_core.types import OptionalEventCallable, DefaultOptionalEventCallable
+from flet_core.types import OptionalEventCallable, OptionalControlEventCallable
 
 
 class BottomSheet(Control):
@@ -190,9 +190,9 @@ class BottomSheet(Control):
 
     # on_dismiss
     @property
-    def on_dismiss(self) -> DefaultOptionalEventCallable:
+    def on_dismiss(self) -> OptionalControlEventCallable:
         return self._get_event_handler("dismiss")
 
     @on_dismiss.setter
-    def on_dismiss(self, handler: DefaultOptionalEventCallable):
+    def on_dismiss(self, handler: OptionalControlEventCallable):
         self._add_event_handler("dismiss", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/bottom_sheet.py
+++ b/sdk/python/packages/flet-core/src/flet_core/bottom_sheet.py
@@ -2,7 +2,7 @@ from typing import Any, Optional
 
 from flet_core.control import Control, OptionalNumber
 from flet_core.ref import Ref
-from flet_core.types import OptionalEventCallable
+from flet_core.types import OptionalEventCallable, DefaultOptionalEventCallable
 
 
 class BottomSheet(Control):
@@ -190,9 +190,9 @@ class BottomSheet(Control):
 
     # on_dismiss
     @property
-    def on_dismiss(self) -> OptionalEventCallable:
+    def on_dismiss(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("dismiss")
 
     @on_dismiss.setter
-    def on_dismiss(self, handler: OptionalEventCallable):
+    def on_dismiss(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("dismiss", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/canvas/canvas.py
+++ b/sdk/python/packages/flet-core/src/flet_core/canvas/canvas.py
@@ -1,6 +1,6 @@
 import json
 from dataclasses import dataclass
-from typing import Any, List, Optional, Union, Callable
+from typing import Any, List, Optional, Union
 
 from flet_core.canvas.shape import Shape
 from flet_core.constrained_control import ConstrainedControl
@@ -146,7 +146,7 @@ class Canvas(ConstrainedControl):
         return self.__on_resize
 
     @on_resize.setter
-    def on_resize(self, handler: Optional[Callable[["CanvasResizeEvent"], None]]):
+    def on_resize(self, handler: OptionalEventCallable["CanvasResizeEvent"]):
         self.__on_resize.subscribe(handler)
         self._set_attr("onresize", True if handler is not None else None)
 

--- a/sdk/python/packages/flet-core/src/flet_core/charts/bar_chart.py
+++ b/sdk/python/packages/flet-core/src/flet_core/charts/bar_chart.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, List, Optional, Union, Callable
+from typing import Any, List, Optional, Union
 
 from flet_core.border import Border
 from flet_core.charts.bar_chart_group import BarChartGroup
@@ -39,7 +39,7 @@ class BarChart(ConstrainedControl):
         baseline_y: OptionalNumber = None,
         min_y: OptionalNumber = None,
         max_y: OptionalNumber = None,
-        on_chart_event: Optional[Callable[["BarChartEvent"], None]] = None,
+        on_chart_event: OptionalEventCallable["BarChartEvent"] = None,
         #
         # ConstrainedControl
         #
@@ -299,7 +299,7 @@ class BarChart(ConstrainedControl):
         return self.__on_chart_event
 
     @on_chart_event.setter
-    def on_chart_event(self, handler: Optional[Callable[["BarChartEvent"], None]]):
+    def on_chart_event(self, handler: OptionalEventCallable["BarChartEvent"]):
         self.__on_chart_event.subscribe(handler)
         self._set_attr("onChartEvent", True if handler is not None else None)
 

--- a/sdk/python/packages/flet-core/src/flet_core/charts/line_chart.py
+++ b/sdk/python/packages/flet-core/src/flet_core/charts/line_chart.py
@@ -1,5 +1,5 @@
 import json
-from typing import List, Optional, Union, Any, Callable
+from typing import List, Optional, Union, Any
 
 from flet_core.border import Border
 from flet_core.charts.chart_axis import ChartAxis
@@ -43,7 +43,7 @@ class LineChart(ConstrainedControl):
         baseline_y: OptionalNumber = None,
         min_y: OptionalNumber = None,
         max_y: OptionalNumber = None,
-        on_chart_event: Optional[Callable[["LineChartEvent"], None]] = None,
+        on_chart_event: OptionalEventCallable["LineChartEvent"] = None,
         #
         # ConstrainedControl
         #
@@ -343,7 +343,7 @@ class LineChart(ConstrainedControl):
         return self.__on_chart_event
 
     @on_chart_event.setter
-    def on_chart_event(self, handler: Optional[Callable[["LineChartEvent"], None]]):
+    def on_chart_event(self, handler: OptionalEventCallable["LineChartEvent"]):
         self.__on_chart_event.subscribe(handler)
         self._set_attr("onChartEvent", True if handler is not None else None)
 

--- a/sdk/python/packages/flet-core/src/flet_core/charts/pie_chart.py
+++ b/sdk/python/packages/flet-core/src/flet_core/charts/pie_chart.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, List, Optional, Union, Callable
+from typing import Any, List, Optional, Union
 
 from flet_core.charts.pie_chart_section import PieChartSection
 from flet_core.constrained_control import ConstrainedControl
@@ -26,7 +26,7 @@ class PieChart(ConstrainedControl):
         sections_space: OptionalNumber = None,
         start_degree_offset: OptionalNumber = None,
         animate: AnimationValue = None,
-        on_chart_event: Optional[Callable[["PieChartEvent"], None]] = None,
+        on_chart_event: OptionalEventCallable["PieChartEvent"] = None,
         #
         # ConstrainedControl
         #
@@ -171,7 +171,7 @@ class PieChart(ConstrainedControl):
         return self.__on_chart_event
 
     @on_chart_event.setter
-    def on_chart_event(self, handler: Optional[Callable[["PieChartEvent"], None]]):
+    def on_chart_event(self, handler: OptionalEventCallable["PieChartEvent"]):
         self.__on_chart_event.subscribe(handler)
         self._set_attr("onChartEvent", True if handler is not None else None)
 

--- a/sdk/python/packages/flet-core/src/flet_core/checkbox.py
+++ b/sdk/python/packages/flet-core/src/flet_core/checkbox.py
@@ -19,6 +19,7 @@ from flet_core.types import (
     OptionalEventCallable,
     ThemeVisualDensity,
     VisualDensity,
+    DefaultOptionalEventCallable,
 )
 
 
@@ -364,7 +365,7 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: OptionalEventCallable):
+    def on_change(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("change", handler)
 
     # on_focus
@@ -373,7 +374,7 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
         return self._get_event_handler("focus")
 
     @on_focus.setter
-    def on_focus(self, handler: OptionalEventCallable):
+    def on_focus(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("focus", handler)
 
     # on_blur
@@ -382,5 +383,5 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
         return self._get_event_handler("blur")
 
     @on_blur.setter
-    def on_blur(self, handler: OptionalEventCallable):
+    def on_blur(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("blur", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/checkbox.py
+++ b/sdk/python/packages/flet-core/src/flet_core/checkbox.py
@@ -19,7 +19,7 @@ from flet_core.types import (
     OptionalEventCallable,
     ThemeVisualDensity,
     VisualDensity,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -365,7 +365,7 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: DefaultOptionalEventCallable):
+    def on_change(self, handler: OptionalControlEventCallable):
         self._add_event_handler("change", handler)
 
     # on_focus
@@ -374,7 +374,7 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
         return self._get_event_handler("focus")
 
     @on_focus.setter
-    def on_focus(self, handler: DefaultOptionalEventCallable):
+    def on_focus(self, handler: OptionalControlEventCallable):
         self._add_event_handler("focus", handler)
 
     # on_blur
@@ -383,5 +383,5 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
         return self._get_event_handler("blur")
 
     @on_blur.setter
-    def on_blur(self, handler: DefaultOptionalEventCallable):
+    def on_blur(self, handler: OptionalControlEventCallable):
         self._add_event_handler("blur", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/chip.py
+++ b/sdk/python/packages/flet-core/src/flet_core/chip.py
@@ -18,7 +18,7 @@ from flet_core.types import (
     OptionalEventCallable,
     ThemeVisualDensity,
     VisualDensity,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -451,7 +451,7 @@ class Chip(ConstrainedControl):
         return self._get_event_handler("click")
 
     @on_click.setter
-    def on_click(self, handler: DefaultOptionalEventCallable):
+    def on_click(self, handler: OptionalControlEventCallable):
         self._add_event_handler("click", handler)
         self._set_attr("onclick", True if handler is not None else None)
 
@@ -461,7 +461,7 @@ class Chip(ConstrainedControl):
         return self._get_event_handler("delete")
 
     @on_delete.setter
-    def on_delete(self, handler: DefaultOptionalEventCallable):
+    def on_delete(self, handler: OptionalControlEventCallable):
         self._add_event_handler("delete", handler)
         self._set_attr("onDelete", True if handler is not None else None)
 
@@ -471,7 +471,7 @@ class Chip(ConstrainedControl):
         return self._get_event_handler("select")
 
     @on_select.setter
-    def on_select(self, handler: DefaultOptionalEventCallable):
+    def on_select(self, handler: OptionalControlEventCallable):
         self._add_event_handler("select", handler)
         self._set_attr("onSelect", True if handler is not None else None)
 
@@ -481,7 +481,7 @@ class Chip(ConstrainedControl):
         return self._get_event_handler("focus")
 
     @on_focus.setter
-    def on_focus(self, handler: DefaultOptionalEventCallable):
+    def on_focus(self, handler: OptionalControlEventCallable):
         self._add_event_handler("focus", handler)
 
     # on_blur
@@ -490,5 +490,5 @@ class Chip(ConstrainedControl):
         return self._get_event_handler("blur")
 
     @on_blur.setter
-    def on_blur(self, handler: DefaultOptionalEventCallable):
+    def on_blur(self, handler: OptionalControlEventCallable):
         self._add_event_handler("blur", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/chip.py
+++ b/sdk/python/packages/flet-core/src/flet_core/chip.py
@@ -18,6 +18,7 @@ from flet_core.types import (
     OptionalEventCallable,
     ThemeVisualDensity,
     VisualDensity,
+    DefaultOptionalEventCallable,
 )
 
 
@@ -450,7 +451,7 @@ class Chip(ConstrainedControl):
         return self._get_event_handler("click")
 
     @on_click.setter
-    def on_click(self, handler: OptionalEventCallable):
+    def on_click(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("click", handler)
         self._set_attr("onclick", True if handler is not None else None)
 
@@ -460,7 +461,7 @@ class Chip(ConstrainedControl):
         return self._get_event_handler("delete")
 
     @on_delete.setter
-    def on_delete(self, handler: OptionalEventCallable):
+    def on_delete(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("delete", handler)
         self._set_attr("onDelete", True if handler is not None else None)
 
@@ -470,7 +471,7 @@ class Chip(ConstrainedControl):
         return self._get_event_handler("select")
 
     @on_select.setter
-    def on_select(self, handler: OptionalEventCallable):
+    def on_select(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("select", handler)
         self._set_attr("onSelect", True if handler is not None else None)
 
@@ -480,7 +481,7 @@ class Chip(ConstrainedControl):
         return self._get_event_handler("focus")
 
     @on_focus.setter
-    def on_focus(self, handler: OptionalEventCallable):
+    def on_focus(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("focus", handler)
 
     # on_blur
@@ -489,5 +490,5 @@ class Chip(ConstrainedControl):
         return self._get_event_handler("blur")
 
     @on_blur.setter
-    def on_blur(self, handler: OptionalEventCallable):
+    def on_blur(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("blur", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/circle_avatar.py
+++ b/sdk/python/packages/flet-core/src/flet_core/circle_avatar.py
@@ -11,7 +11,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -293,5 +293,5 @@ class CircleAvatar(ConstrainedControl):
         return self._get_event_handler("imageError")
 
     @on_image_error.setter
-    def on_image_error(self, handler: DefaultOptionalEventCallable):
+    def on_image_error(self, handler: OptionalControlEventCallable):
         self._add_event_handler("imageError", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/circle_avatar.py
+++ b/sdk/python/packages/flet-core/src/flet_core/circle_avatar.py
@@ -11,6 +11,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 
 
@@ -292,5 +293,5 @@ class CircleAvatar(ConstrainedControl):
         return self._get_event_handler("imageError")
 
     @on_image_error.setter
-    def on_image_error(self, handler: OptionalEventCallable):
+    def on_image_error(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("imageError", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/constrained_control.py
+++ b/sdk/python/packages/flet-core/src/flet_core/constrained_control.py
@@ -9,6 +9,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 
 
@@ -250,10 +251,10 @@ class ConstrainedControl(Control):
 
     # on_animation_end
     @property
-    def on_animation_end(self) -> OptionalEventCallable:
+    def on_animation_end(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("animation_end")
 
     @on_animation_end.setter
-    def on_animation_end(self, handler: OptionalEventCallable):
+    def on_animation_end(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("animation_end", handler)
         self._set_attr("onAnimationEnd", True if handler is not None else None)

--- a/sdk/python/packages/flet-core/src/flet_core/constrained_control.py
+++ b/sdk/python/packages/flet-core/src/flet_core/constrained_control.py
@@ -9,7 +9,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -251,10 +251,10 @@ class ConstrainedControl(Control):
 
     # on_animation_end
     @property
-    def on_animation_end(self) -> DefaultOptionalEventCallable:
+    def on_animation_end(self) -> OptionalControlEventCallable:
         return self._get_event_handler("animation_end")
 
     @on_animation_end.setter
-    def on_animation_end(self, handler: DefaultOptionalEventCallable):
+    def on_animation_end(self, handler: OptionalControlEventCallable):
         self._add_event_handler("animation_end", handler)
         self._set_attr("onAnimationEnd", True if handler is not None else None)

--- a/sdk/python/packages/flet-core/src/flet_core/container.py
+++ b/sdk/python/packages/flet-core/src/flet_core/container.py
@@ -1,6 +1,6 @@
 import json
 from dataclasses import dataclass, field
-from typing import Any, List, Optional, Tuple, Union, Callable
+from typing import Any, List, Optional, Tuple, Union
 
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.alignment import Alignment
@@ -31,6 +31,7 @@ from flet_core.types import (
     ThemeMode,
     UrlTarget,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 
 
@@ -97,10 +98,10 @@ class Container(ConstrainedControl, AdaptiveControl):
         theme: Optional[Theme] = None,
         theme_mode: Optional[ThemeMode] = None,
         color_filter: Optional[ColorFilter] = None,
-        on_click: OptionalEventCallable = None,
-        on_tap_down: Optional[Callable[["ContainerTapEvent"], None]] = None,
-        on_long_press: OptionalEventCallable = None,
-        on_hover: OptionalEventCallable = None,
+        on_click: DefaultOptionalEventCallable = None,
+        on_tap_down: OptionalEventCallable["ContainerTapEvent"] = None,
+        on_long_press: DefaultOptionalEventCallable = None,
+        on_hover: DefaultOptionalEventCallable = None,
         #
         # ConstrainedControl and AdaptiveControl
         #
@@ -126,7 +127,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         animate_rotation: AnimationValue = None,
         animate_scale: AnimationValue = None,
         animate_offset: AnimationValue = None,
-        on_animation_end: OptionalEventCallable = None,
+        on_animation_end: DefaultOptionalEventCallable = None,
         tooltip: Optional[str] = None,
         visible: Optional[bool] = None,
         disabled: Optional[bool] = None,
@@ -487,7 +488,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         return self._get_event_handler("click")
 
     @on_click.setter
-    def on_click(self, handler: OptionalEventCallable):
+    def on_click(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("click", handler)
         self._set_attr("onClick", True if handler is not None else None)
 
@@ -497,7 +498,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         return self.__on_tap_down
 
     @on_tap_down.setter
-    def on_tap_down(self, handler: Optional[Callable[["ContainerTapEvent"], None]]):
+    def on_tap_down(self, handler: OptionalEventCallable["ContainerTapEvent"]):
         self.__on_tap_down.subscribe(handler)
         self._set_attr("onTapDown", True if handler is not None else None)
 
@@ -507,7 +508,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         return self._get_event_handler("long_press")
 
     @on_long_press.setter
-    def on_long_press(self, handler: OptionalEventCallable):
+    def on_long_press(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("long_press", handler)
         self._set_attr("onLongPress", True if handler is not None else None)
 
@@ -517,7 +518,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         return self._get_event_handler("hover")
 
     @on_hover.setter
-    def on_hover(self, handler: OptionalEventCallable):
+    def on_hover(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("hover", handler)
         self._set_attr("onHover", True if handler is not None else None)
 

--- a/sdk/python/packages/flet-core/src/flet_core/container.py
+++ b/sdk/python/packages/flet-core/src/flet_core/container.py
@@ -31,7 +31,7 @@ from flet_core.types import (
     ThemeMode,
     UrlTarget,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -98,10 +98,10 @@ class Container(ConstrainedControl, AdaptiveControl):
         theme: Optional[Theme] = None,
         theme_mode: Optional[ThemeMode] = None,
         color_filter: Optional[ColorFilter] = None,
-        on_click: DefaultOptionalEventCallable = None,
+        on_click: OptionalControlEventCallable = None,
         on_tap_down: OptionalEventCallable["ContainerTapEvent"] = None,
-        on_long_press: DefaultOptionalEventCallable = None,
-        on_hover: DefaultOptionalEventCallable = None,
+        on_long_press: OptionalControlEventCallable = None,
+        on_hover: OptionalControlEventCallable = None,
         #
         # ConstrainedControl and AdaptiveControl
         #
@@ -127,7 +127,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         animate_rotation: AnimationValue = None,
         animate_scale: AnimationValue = None,
         animate_offset: AnimationValue = None,
-        on_animation_end: DefaultOptionalEventCallable = None,
+        on_animation_end: OptionalControlEventCallable = None,
         tooltip: Optional[str] = None,
         visible: Optional[bool] = None,
         disabled: Optional[bool] = None,
@@ -488,7 +488,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         return self._get_event_handler("click")
 
     @on_click.setter
-    def on_click(self, handler: DefaultOptionalEventCallable):
+    def on_click(self, handler: OptionalControlEventCallable):
         self._add_event_handler("click", handler)
         self._set_attr("onClick", True if handler is not None else None)
 
@@ -508,7 +508,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         return self._get_event_handler("long_press")
 
     @on_long_press.setter
-    def on_long_press(self, handler: DefaultOptionalEventCallable):
+    def on_long_press(self, handler: OptionalControlEventCallable):
         self._add_event_handler("long_press", handler)
         self._set_attr("onLongPress", True if handler is not None else None)
 
@@ -518,7 +518,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         return self._get_event_handler("hover")
 
     @on_hover.setter
-    def on_hover(self, handler: DefaultOptionalEventCallable):
+    def on_hover(self, handler: OptionalControlEventCallable):
         self._add_event_handler("hover", handler)
         self._set_attr("onHover", True if handler is not None else None)
 

--- a/sdk/python/packages/flet-core/src/flet_core/control.py
+++ b/sdk/python/packages/flet-core/src/flet_core/control.py
@@ -22,6 +22,7 @@ from flet_core.types import (
     ResponsiveNumber,
     SupportsStr,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 from flet_core.utils import deprecated
 
@@ -106,7 +107,7 @@ class Control:
     ) -> None:
         self.__event_handlers[event_name] = handler
 
-    def _get_event_handler(self, event_name: str) -> OptionalEventCallable:
+    def _get_event_handler(self, event_name: str) -> DefaultOptionalEventCallable:
         return self.__event_handlers.get(event_name)
 
     def _get_attr(

--- a/sdk/python/packages/flet-core/src/flet_core/control.py
+++ b/sdk/python/packages/flet-core/src/flet_core/control.py
@@ -22,7 +22,7 @@ from flet_core.types import (
     ResponsiveNumber,
     SupportsStr,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 from flet_core.utils import deprecated
 
@@ -107,7 +107,7 @@ class Control:
     ) -> None:
         self.__event_handlers[event_name] = handler
 
-    def _get_event_handler(self, event_name: str) -> DefaultOptionalEventCallable:
+    def _get_event_handler(self, event_name: str) -> OptionalControlEventCallable:
         return self.__event_handlers.get(event_name)
 
     def _get_attr(

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_action_sheet_action.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_action_sheet_action.py
@@ -10,7 +10,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -151,9 +151,9 @@ class CupertinoActionSheetAction(ConstrainedControl):
 
     # on_click
     @property
-    def on_click(self) -> DefaultOptionalEventCallable:
+    def on_click(self) -> OptionalControlEventCallable:
         return self._get_event_handler("click")
 
     @on_click.setter
-    def on_click(self, handler: DefaultOptionalEventCallable):
+    def on_click(self, handler: OptionalControlEventCallable):
         self._add_event_handler("click", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_action_sheet_action.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_action_sheet_action.py
@@ -10,6 +10,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 
 
@@ -150,9 +151,9 @@ class CupertinoActionSheetAction(ConstrainedControl):
 
     # on_click
     @property
-    def on_click(self) -> OptionalEventCallable:
+    def on_click(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("click")
 
     @on_click.setter
-    def on_click(self, handler: OptionalEventCallable):
+    def on_click(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("click", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_alert_dialog.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_alert_dialog.py
@@ -2,7 +2,7 @@ from typing import Any, List, Optional
 
 from flet_core.control import Control
 from flet_core.ref import Ref
-from flet_core.types import OptionalEventCallable, DefaultOptionalEventCallable
+from flet_core.types import OptionalEventCallable, OptionalControlEventCallable
 
 
 class CupertinoAlertDialog(Control):
@@ -179,9 +179,9 @@ class CupertinoAlertDialog(Control):
 
     # on_dismiss
     @property
-    def on_dismiss(self) -> DefaultOptionalEventCallable:
+    def on_dismiss(self) -> OptionalControlEventCallable:
         return self._get_event_handler("dismiss")
 
     @on_dismiss.setter
-    def on_dismiss(self, handler: DefaultOptionalEventCallable):
+    def on_dismiss(self, handler: OptionalControlEventCallable):
         self._add_event_handler("dismiss", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_alert_dialog.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_alert_dialog.py
@@ -1,8 +1,8 @@
 from typing import Any, List, Optional
 
-from flet_core.types import OptionalEventCallable
 from flet_core.control import Control
 from flet_core.ref import Ref
+from flet_core.types import OptionalEventCallable, DefaultOptionalEventCallable
 
 
 class CupertinoAlertDialog(Control):
@@ -179,9 +179,9 @@ class CupertinoAlertDialog(Control):
 
     # on_dismiss
     @property
-    def on_dismiss(self) -> OptionalEventCallable:
+    def on_dismiss(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("dismiss")
 
     @on_dismiss.setter
-    def on_dismiss(self, handler: OptionalEventCallable):
+    def on_dismiss(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("dismiss", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_bottom_sheet.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_bottom_sheet.py
@@ -2,7 +2,11 @@ from typing import Any, Optional
 
 from flet_core.control import Control, OptionalNumber
 from flet_core.ref import Ref
-from flet_core.types import PaddingValue, OptionalEventCallable
+from flet_core.types import (
+    PaddingValue,
+    OptionalEventCallable,
+    DefaultOptionalEventCallable,
+)
 
 
 class CupertinoBottomSheet(Control):
@@ -119,9 +123,9 @@ class CupertinoBottomSheet(Control):
 
     # on_dismiss
     @property
-    def on_dismiss(self) -> OptionalEventCallable:
+    def on_dismiss(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("dismiss")
 
     @on_dismiss.setter
-    def on_dismiss(self, handler: OptionalEventCallable):
+    def on_dismiss(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("dismiss", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_bottom_sheet.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_bottom_sheet.py
@@ -5,7 +5,7 @@ from flet_core.ref import Ref
 from flet_core.types import (
     PaddingValue,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -123,9 +123,9 @@ class CupertinoBottomSheet(Control):
 
     # on_dismiss
     @property
-    def on_dismiss(self) -> DefaultOptionalEventCallable:
+    def on_dismiss(self) -> OptionalControlEventCallable:
         return self._get_event_handler("dismiss")
 
     @on_dismiss.setter
-    def on_dismiss(self, handler: DefaultOptionalEventCallable):
+    def on_dismiss(self, handler: OptionalControlEventCallable):
         self._add_event_handler("dismiss", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_button.py
@@ -15,7 +15,7 @@ from flet_core.types import (
     ScaleValue,
     UrlTarget,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -287,11 +287,11 @@ class CupertinoButton(ConstrainedControl):
 
     # on_click
     @property
-    def on_click(self) -> DefaultOptionalEventCallable:
+    def on_click(self) -> OptionalControlEventCallable:
         return self._get_event_handler("click")
 
     @on_click.setter
-    def on_click(self, handler: DefaultOptionalEventCallable):
+    def on_click(self, handler: OptionalControlEventCallable):
         self._add_event_handler("click", handler)
 
     # content

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_button.py
@@ -15,6 +15,7 @@ from flet_core.types import (
     ScaleValue,
     UrlTarget,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 
 
@@ -286,11 +287,11 @@ class CupertinoButton(ConstrainedControl):
 
     # on_click
     @property
-    def on_click(self) -> OptionalEventCallable:
+    def on_click(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("click")
 
     @on_click.setter
-    def on_click(self, handler: OptionalEventCallable):
+    def on_click(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("click", handler)
 
     # content

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_checkbox.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_checkbox.py
@@ -11,6 +11,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 
 
@@ -215,27 +216,27 @@ class CupertinoCheckbox(ConstrainedControl):
 
     # on_change
     @property
-    def on_change(self) -> OptionalEventCallable:
+    def on_change(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: OptionalEventCallable):
+    def on_change(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("change", handler)
 
     # on_focus
     @property
-    def on_focus(self) -> OptionalEventCallable:
+    def on_focus(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("focus")
 
     @on_focus.setter
-    def on_focus(self, handler: OptionalEventCallable):
+    def on_focus(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("focus", handler)
 
     # on_blur
     @property
-    def on_blur(self) -> OptionalEventCallable:
+    def on_blur(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("blur")
 
     @on_blur.setter
-    def on_blur(self, handler: OptionalEventCallable):
+    def on_blur(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("blur", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_checkbox.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_checkbox.py
@@ -11,7 +11,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -216,27 +216,27 @@ class CupertinoCheckbox(ConstrainedControl):
 
     # on_change
     @property
-    def on_change(self) -> DefaultOptionalEventCallable:
+    def on_change(self) -> OptionalControlEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: DefaultOptionalEventCallable):
+    def on_change(self, handler: OptionalControlEventCallable):
         self._add_event_handler("change", handler)
 
     # on_focus
     @property
-    def on_focus(self) -> DefaultOptionalEventCallable:
+    def on_focus(self) -> OptionalControlEventCallable:
         return self._get_event_handler("focus")
 
     @on_focus.setter
-    def on_focus(self, handler: DefaultOptionalEventCallable):
+    def on_focus(self, handler: OptionalControlEventCallable):
         self._add_event_handler("focus", handler)
 
     # on_blur
     @property
-    def on_blur(self) -> DefaultOptionalEventCallable:
+    def on_blur(self) -> OptionalControlEventCallable:
         return self._get_event_handler("blur")
 
     @on_blur.setter
-    def on_blur(self, handler: DefaultOptionalEventCallable):
+    def on_blur(self, handler: OptionalControlEventCallable):
         self._add_event_handler("blur", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_context_menu_action.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_context_menu_action.py
@@ -1,9 +1,9 @@
 from typing import Any, Optional
 
-from flet_core.types import OptionalEventCallable
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.control import Control
 from flet_core.ref import Ref
+from flet_core.types import OptionalEventCallable, DefaultOptionalEventCallable
 
 
 class CupertinoContextMenuAction(AdaptiveControl):
@@ -102,9 +102,9 @@ class CupertinoContextMenuAction(AdaptiveControl):
 
     # on_click
     @property
-    def on_click(self) -> OptionalEventCallable:
+    def on_click(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("click")
 
     @on_click.setter
-    def on_click(self, handler: OptionalEventCallable):
+    def on_click(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("click", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_context_menu_action.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_context_menu_action.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.control import Control
 from flet_core.ref import Ref
-from flet_core.types import OptionalEventCallable, DefaultOptionalEventCallable
+from flet_core.types import OptionalEventCallable, OptionalControlEventCallable
 
 
 class CupertinoContextMenuAction(AdaptiveControl):
@@ -102,9 +102,9 @@ class CupertinoContextMenuAction(AdaptiveControl):
 
     # on_click
     @property
-    def on_click(self) -> DefaultOptionalEventCallable:
+    def on_click(self) -> OptionalControlEventCallable:
         return self._get_event_handler("click")
 
     @on_click.setter
-    def on_click(self, handler: DefaultOptionalEventCallable):
+    def on_click(self, handler: OptionalControlEventCallable):
         self._add_event_handler("click", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_date_picker.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_date_picker.py
@@ -12,6 +12,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 
 
@@ -249,9 +250,9 @@ class CupertinoDatePicker(ConstrainedControl):
 
     # on_change
     @property
-    def on_change(self) -> OptionalEventCallable:
+    def on_change(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: OptionalEventCallable):
+    def on_change(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("change", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_date_picker.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_date_picker.py
@@ -12,7 +12,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -250,9 +250,9 @@ class CupertinoDatePicker(ConstrainedControl):
 
     # on_change
     @property
-    def on_change(self) -> DefaultOptionalEventCallable:
+    def on_change(self) -> OptionalControlEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: DefaultOptionalEventCallable):
+    def on_change(self, handler: OptionalControlEventCallable):
         self._add_event_handler("change", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_dialog_action.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_dialog_action.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 from flet_core.control import Control, OptionalNumber
 from flet_core.ref import Ref
 from flet_core.text_style import TextStyle
-from flet_core.types import OptionalEventCallable, DefaultOptionalEventCallable
+from flet_core.types import OptionalEventCallable, OptionalControlEventCallable
 
 
 class CupertinoDialogAction(Control):
@@ -132,11 +132,11 @@ class CupertinoDialogAction(Control):
 
     # on_click
     @property
-    def on_click(self) -> DefaultOptionalEventCallable:
+    def on_click(self) -> OptionalControlEventCallable:
         return self._get_event_handler("click")
 
     @on_click.setter
-    def on_click(self, handler: DefaultOptionalEventCallable):
+    def on_click(self, handler: OptionalControlEventCallable):
         self._add_event_handler("click", handler)
 
     # content

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_dialog_action.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_dialog_action.py
@@ -1,9 +1,9 @@
 from typing import Any, Optional
 
-from flet_core.types import OptionalEventCallable
 from flet_core.control import Control, OptionalNumber
 from flet_core.ref import Ref
 from flet_core.text_style import TextStyle
+from flet_core.types import OptionalEventCallable, DefaultOptionalEventCallable
 
 
 class CupertinoDialogAction(Control):
@@ -132,11 +132,11 @@ class CupertinoDialogAction(Control):
 
     # on_click
     @property
-    def on_click(self) -> OptionalEventCallable:
+    def on_click(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("click")
 
     @on_click.setter
-    def on_click(self, handler: OptionalEventCallable):
+    def on_click(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("click", handler)
 
     # content

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_list_tile.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_list_tile.py
@@ -12,6 +12,7 @@ from flet_core.types import (
     ScaleValue,
     UrlTarget,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 
 
@@ -301,10 +302,10 @@ class CupertinoListTile(ConstrainedControl):
 
     # on_click
     @property
-    def on_click(self) -> OptionalEventCallable:
+    def on_click(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("click")
 
     @on_click.setter
-    def on_click(self, handler: OptionalEventCallable):
+    def on_click(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("click", handler)
         self._set_attr("onclick", True if handler is not None else None)

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_list_tile.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_list_tile.py
@@ -12,7 +12,7 @@ from flet_core.types import (
     ScaleValue,
     UrlTarget,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -302,10 +302,10 @@ class CupertinoListTile(ConstrainedControl):
 
     # on_click
     @property
-    def on_click(self) -> DefaultOptionalEventCallable:
+    def on_click(self) -> OptionalControlEventCallable:
         return self._get_event_handler("click")
 
     @on_click.setter
-    def on_click(self, handler: DefaultOptionalEventCallable):
+    def on_click(self, handler: OptionalControlEventCallable):
         self._add_event_handler("click", handler)
         self._set_attr("onclick", True if handler is not None else None)

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_navigation_bar.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_navigation_bar.py
@@ -12,6 +12,7 @@ from flet_core.types import (
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
+    DefaultOptionalEventCallable,
 )
 
 
@@ -206,9 +207,9 @@ class CupertinoNavigationBar(ConstrainedControl):
 
     # on_change
     @property
-    def on_change(self) -> OptionalEventCallable:
+    def on_change(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: OptionalEventCallable):
+    def on_change(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("change", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_navigation_bar.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_navigation_bar.py
@@ -12,7 +12,7 @@ from flet_core.types import (
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -207,9 +207,9 @@ class CupertinoNavigationBar(ConstrainedControl):
 
     # on_change
     @property
-    def on_change(self) -> DefaultOptionalEventCallable:
+    def on_change(self) -> OptionalControlEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: DefaultOptionalEventCallable):
+    def on_change(self, handler: OptionalControlEventCallable):
         self._add_event_handler("change", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_picker.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_picker.py
@@ -10,7 +10,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -215,9 +215,9 @@ class CupertinoPicker(ConstrainedControl):
 
     # on_change
     @property
-    def on_change(self) -> DefaultOptionalEventCallable:
+    def on_change(self) -> OptionalControlEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: DefaultOptionalEventCallable):
+    def on_change(self, handler: OptionalControlEventCallable):
         self._add_event_handler("change", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_picker.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_picker.py
@@ -10,6 +10,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 
 
@@ -214,9 +215,9 @@ class CupertinoPicker(ConstrainedControl):
 
     # on_change
     @property
-    def on_change(self) -> OptionalEventCallable:
+    def on_change(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: OptionalEventCallable):
+    def on_change(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("change", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_radio.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_radio.py
@@ -11,7 +11,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 try:
@@ -177,20 +177,20 @@ class CupertinoRadio(ConstrainedControl):
 
     # on_focus
     @property
-    def on_focus(self) -> DefaultOptionalEventCallable:
+    def on_focus(self) -> OptionalControlEventCallable:
         return self._get_event_handler("focus")
 
     @on_focus.setter
-    def on_focus(self, handler: DefaultOptionalEventCallable):
+    def on_focus(self, handler: OptionalControlEventCallable):
         self._add_event_handler("focus", handler)
 
     # on_blur
     @property
-    def on_blur(self) -> DefaultOptionalEventCallable:
+    def on_blur(self) -> OptionalControlEventCallable:
         return self._get_event_handler("blur")
 
     @on_blur.setter
-    def on_blur(self, handler: DefaultOptionalEventCallable):
+    def on_blur(self, handler: OptionalControlEventCallable):
         self._add_event_handler("blur", handler)
 
     # autofocus

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_radio.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_radio.py
@@ -11,6 +11,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 
 try:
@@ -176,20 +177,20 @@ class CupertinoRadio(ConstrainedControl):
 
     # on_focus
     @property
-    def on_focus(self) -> OptionalEventCallable:
+    def on_focus(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("focus")
 
     @on_focus.setter
-    def on_focus(self, handler: OptionalEventCallable):
+    def on_focus(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("focus", handler)
 
     # on_blur
     @property
-    def on_blur(self) -> OptionalEventCallable:
+    def on_blur(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("blur")
 
     @on_blur.setter
-    def on_blur(self, handler: OptionalEventCallable):
+    def on_blur(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("blur", handler)
 
     # autofocus

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_segmented_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_segmented_button.py
@@ -11,6 +11,7 @@ from flet_core.types import (
     ScaleValue,
     PaddingValue,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 
 
@@ -186,9 +187,9 @@ class CupertinoSegmentedButton(ConstrainedControl):
 
     # on_change
     @property
-    def on_change(self) -> OptionalEventCallable:
+    def on_change(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: OptionalEventCallable):
+    def on_change(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("change", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_segmented_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_segmented_button.py
@@ -11,7 +11,7 @@ from flet_core.types import (
     ScaleValue,
     PaddingValue,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -187,9 +187,9 @@ class CupertinoSegmentedButton(ConstrainedControl):
 
     # on_change
     @property
-    def on_change(self) -> DefaultOptionalEventCallable:
+    def on_change(self) -> OptionalControlEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: DefaultOptionalEventCallable):
+    def on_change(self, handler: OptionalControlEventCallable):
         self._add_event_handler("change", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_slider.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_slider.py
@@ -10,7 +10,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -193,45 +193,45 @@ class CupertinoSlider(ConstrainedControl):
 
     # on_change
     @property
-    def on_change(self) -> DefaultOptionalEventCallable:
+    def on_change(self) -> OptionalControlEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: DefaultOptionalEventCallable):
+    def on_change(self, handler: OptionalControlEventCallable):
         self._add_event_handler("change", handler)
 
     # on_change_start
     @property
-    def on_change_start(self) -> DefaultOptionalEventCallable:
+    def on_change_start(self) -> OptionalControlEventCallable:
         return self._get_event_handler("change_start")
 
     @on_change_start.setter
-    def on_change_start(self, handler: DefaultOptionalEventCallable):
+    def on_change_start(self, handler: OptionalControlEventCallable):
         self._add_event_handler("change_start", handler)
 
     # on_change_end
     @property
-    def on_change_end(self) -> DefaultOptionalEventCallable:
+    def on_change_end(self) -> OptionalControlEventCallable:
         return self._get_event_handler("change_end")
 
     @on_change_end.setter
-    def on_change_end(self, handler: DefaultOptionalEventCallable):
+    def on_change_end(self, handler: OptionalControlEventCallable):
         self._add_event_handler("change_end", handler)
 
     # on_focus
     @property
-    def on_focus(self) -> DefaultOptionalEventCallable:
+    def on_focus(self) -> OptionalControlEventCallable:
         return self._get_event_handler("focus")
 
     @on_focus.setter
-    def on_focus(self, handler: DefaultOptionalEventCallable):
+    def on_focus(self, handler: OptionalControlEventCallable):
         self._add_event_handler("focus", handler)
 
     # on_blur
     @property
-    def on_blur(self) -> DefaultOptionalEventCallable:
+    def on_blur(self) -> OptionalControlEventCallable:
         return self._get_event_handler("blur")
 
     @on_blur.setter
-    def on_blur(self, handler: DefaultOptionalEventCallable):
+    def on_blur(self, handler: OptionalControlEventCallable):
         self._add_event_handler("blur", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_slider.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_slider.py
@@ -10,6 +10,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 
 
@@ -192,45 +193,45 @@ class CupertinoSlider(ConstrainedControl):
 
     # on_change
     @property
-    def on_change(self) -> OptionalEventCallable:
+    def on_change(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: OptionalEventCallable):
+    def on_change(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("change", handler)
 
     # on_change_start
     @property
-    def on_change_start(self) -> OptionalEventCallable:
+    def on_change_start(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("change_start")
 
     @on_change_start.setter
-    def on_change_start(self, handler: OptionalEventCallable):
+    def on_change_start(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("change_start", handler)
 
     # on_change_end
     @property
-    def on_change_end(self) -> OptionalEventCallable:
+    def on_change_end(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("change_end")
 
     @on_change_end.setter
-    def on_change_end(self, handler: OptionalEventCallable):
+    def on_change_end(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("change_end", handler)
 
     # on_focus
     @property
-    def on_focus(self) -> OptionalEventCallable:
+    def on_focus(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("focus")
 
     @on_focus.setter
-    def on_focus(self, handler: OptionalEventCallable):
+    def on_focus(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("focus", handler)
 
     # on_blur
     @property
-    def on_blur(self) -> OptionalEventCallable:
+    def on_blur(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("blur")
 
     @on_blur.setter
-    def on_blur(self, handler: OptionalEventCallable):
+    def on_blur(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("blur", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_sliding_segmented_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_sliding_segmented_button.py
@@ -11,7 +11,7 @@ from flet_core.types import (
     ScaleValue,
     PaddingValue,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -162,9 +162,9 @@ class CupertinoSlidingSegmentedButton(ConstrainedControl):
 
     # on_change
     @property
-    def on_change(self) -> DefaultOptionalEventCallable:
+    def on_change(self) -> OptionalControlEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: DefaultOptionalEventCallable):
+    def on_change(self, handler: OptionalControlEventCallable):
         self._add_event_handler("change", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_sliding_segmented_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_sliding_segmented_button.py
@@ -11,6 +11,7 @@ from flet_core.types import (
     ScaleValue,
     PaddingValue,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 
 
@@ -161,9 +162,9 @@ class CupertinoSlidingSegmentedButton(ConstrainedControl):
 
     # on_change
     @property
-    def on_change(self) -> OptionalEventCallable:
+    def on_change(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: OptionalEventCallable):
+    def on_change(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("change", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_switch.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_switch.py
@@ -11,6 +11,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 
 
@@ -231,27 +232,27 @@ class CupertinoSwitch(ConstrainedControl):
 
     # on_change
     @property
-    def on_change(self) -> OptionalEventCallable:
+    def on_change(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: OptionalEventCallable):
+    def on_change(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("change", handler)
 
     # on_focus
     @property
-    def on_focus(self) -> OptionalEventCallable:
+    def on_focus(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("focus")
 
     @on_focus.setter
-    def on_focus(self, handler: OptionalEventCallable):
+    def on_focus(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("focus", handler)
 
     # on_blur
     @property
-    def on_blur(self) -> OptionalEventCallable:
+    def on_blur(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("blur")
 
     @on_blur.setter
-    def on_blur(self, handler: OptionalEventCallable):
+    def on_blur(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("blur", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_switch.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_switch.py
@@ -11,7 +11,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -232,27 +232,27 @@ class CupertinoSwitch(ConstrainedControl):
 
     # on_change
     @property
-    def on_change(self) -> DefaultOptionalEventCallable:
+    def on_change(self) -> OptionalControlEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: DefaultOptionalEventCallable):
+    def on_change(self, handler: OptionalControlEventCallable):
         self._add_event_handler("change", handler)
 
     # on_focus
     @property
-    def on_focus(self) -> DefaultOptionalEventCallable:
+    def on_focus(self) -> OptionalControlEventCallable:
         return self._get_event_handler("focus")
 
     @on_focus.setter
-    def on_focus(self, handler: DefaultOptionalEventCallable):
+    def on_focus(self, handler: OptionalControlEventCallable):
         self._add_event_handler("focus", handler)
 
     # on_blur
     @property
-    def on_blur(self) -> DefaultOptionalEventCallable:
+    def on_blur(self) -> OptionalControlEventCallable:
         return self._get_event_handler("blur")
 
     @on_blur.setter
-    def on_blur(self, handler: DefaultOptionalEventCallable):
+    def on_blur(self, handler: OptionalControlEventCallable):
         self._add_event_handler("blur", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_timer_picker.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_timer_picker.py
@@ -12,7 +12,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -187,9 +187,9 @@ class CupertinoTimerPicker(ConstrainedControl):
 
     # on_change
     @property
-    def on_change(self) -> DefaultOptionalEventCallable:
+    def on_change(self) -> OptionalControlEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: DefaultOptionalEventCallable):
+    def on_change(self, handler: OptionalControlEventCallable):
         self._add_event_handler("change", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_timer_picker.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_timer_picker.py
@@ -12,6 +12,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 
 
@@ -186,9 +187,9 @@ class CupertinoTimerPicker(ConstrainedControl):
 
     # on_change
     @property
-    def on_change(self) -> OptionalEventCallable:
+    def on_change(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: OptionalEventCallable):
+    def on_change(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("change", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/datatable.py
+++ b/sdk/python/packages/flet-core/src/flet_core/datatable.py
@@ -20,6 +20,7 @@ from flet_core.types import (
     ScaleValue,
     ClipBehavior,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 
 
@@ -177,41 +178,41 @@ class DataCell(Control):
 
     # on_double_tap
     @property
-    def on_double_tap(self) -> OptionalEventCallable:
+    def on_double_tap(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("double_tap")
 
     @on_double_tap.setter
-    def on_double_tap(self, handler: OptionalEventCallable):
+    def on_double_tap(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("double_tap", handler)
         self._set_attr("onDoubleTap", True if handler is not None else None)
 
     # on_long_press
     @property
-    def on_long_press(self) -> OptionalEventCallable:
+    def on_long_press(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("long_press")
 
     @on_long_press.setter
-    def on_long_press(self, handler: OptionalEventCallable):
+    def on_long_press(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("long_press", handler)
         self._set_attr("onLongPress", True if handler is not None else None)
 
     # on_tap
     @property
-    def on_tap(self) -> OptionalEventCallable:
+    def on_tap(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("tap")
 
     @on_tap.setter
-    def on_tap(self, handler: OptionalEventCallable):
+    def on_tap(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("tap", handler)
         self._set_attr("onTap", True if handler is not None else None)
 
     # on_tap_cancel
     @property
-    def on_tap_cancel(self) -> OptionalEventCallable:
+    def on_tap_cancel(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("tap_cancel")
 
     @on_tap_cancel.setter
-    def on_tap_cancel(self, handler: OptionalEventCallable):
+    def on_tap_cancel(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("tap_cancel", handler)
         self._set_attr("onTapCancel", True if handler is not None else None)
 
@@ -295,21 +296,21 @@ class DataRow(Control):
 
     # on_long_press
     @property
-    def on_long_press(self) -> OptionalEventCallable:
+    def on_long_press(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("long_press")
 
     @on_long_press.setter
-    def on_long_press(self, handler: OptionalEventCallable):
+    def on_long_press(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("long_press", handler)
         self._set_attr("onLongPress", True if handler is not None else None)
 
     # on_select_changed
     @property
-    def on_select_changed(self) -> OptionalEventCallable:
+    def on_select_changed(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("select_changed")
 
     @on_select_changed.setter
-    def on_select_changed(self, handler: OptionalEventCallable):
+    def on_select_changed(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("select_changed", handler)
         self._set_attr("onSelectChanged", True if handler is not None else None)
 
@@ -693,11 +694,11 @@ class DataTable(ConstrainedControl):
 
     # on_select_all
     @property
-    def on_select_all(self) -> OptionalEventCallable:
+    def on_select_all(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("select_all")
 
     @on_select_all.setter
-    def on_select_all(self, handler: OptionalEventCallable):
+    def on_select_all(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("select_all", handler)
         self._set_attr("onSelectAll", True if handler is not None else None)
 

--- a/sdk/python/packages/flet-core/src/flet_core/datatable.py
+++ b/sdk/python/packages/flet-core/src/flet_core/datatable.py
@@ -20,7 +20,7 @@ from flet_core.types import (
     ScaleValue,
     ClipBehavior,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -178,41 +178,41 @@ class DataCell(Control):
 
     # on_double_tap
     @property
-    def on_double_tap(self) -> DefaultOptionalEventCallable:
+    def on_double_tap(self) -> OptionalControlEventCallable:
         return self._get_event_handler("double_tap")
 
     @on_double_tap.setter
-    def on_double_tap(self, handler: DefaultOptionalEventCallable):
+    def on_double_tap(self, handler: OptionalControlEventCallable):
         self._add_event_handler("double_tap", handler)
         self._set_attr("onDoubleTap", True if handler is not None else None)
 
     # on_long_press
     @property
-    def on_long_press(self) -> DefaultOptionalEventCallable:
+    def on_long_press(self) -> OptionalControlEventCallable:
         return self._get_event_handler("long_press")
 
     @on_long_press.setter
-    def on_long_press(self, handler: DefaultOptionalEventCallable):
+    def on_long_press(self, handler: OptionalControlEventCallable):
         self._add_event_handler("long_press", handler)
         self._set_attr("onLongPress", True if handler is not None else None)
 
     # on_tap
     @property
-    def on_tap(self) -> DefaultOptionalEventCallable:
+    def on_tap(self) -> OptionalControlEventCallable:
         return self._get_event_handler("tap")
 
     @on_tap.setter
-    def on_tap(self, handler: DefaultOptionalEventCallable):
+    def on_tap(self, handler: OptionalControlEventCallable):
         self._add_event_handler("tap", handler)
         self._set_attr("onTap", True if handler is not None else None)
 
     # on_tap_cancel
     @property
-    def on_tap_cancel(self) -> DefaultOptionalEventCallable:
+    def on_tap_cancel(self) -> OptionalControlEventCallable:
         return self._get_event_handler("tap_cancel")
 
     @on_tap_cancel.setter
-    def on_tap_cancel(self, handler: DefaultOptionalEventCallable):
+    def on_tap_cancel(self, handler: OptionalControlEventCallable):
         self._add_event_handler("tap_cancel", handler)
         self._set_attr("onTapCancel", True if handler is not None else None)
 
@@ -296,21 +296,21 @@ class DataRow(Control):
 
     # on_long_press
     @property
-    def on_long_press(self) -> DefaultOptionalEventCallable:
+    def on_long_press(self) -> OptionalControlEventCallable:
         return self._get_event_handler("long_press")
 
     @on_long_press.setter
-    def on_long_press(self, handler: DefaultOptionalEventCallable):
+    def on_long_press(self, handler: OptionalControlEventCallable):
         self._add_event_handler("long_press", handler)
         self._set_attr("onLongPress", True if handler is not None else None)
 
     # on_select_changed
     @property
-    def on_select_changed(self) -> DefaultOptionalEventCallable:
+    def on_select_changed(self) -> OptionalControlEventCallable:
         return self._get_event_handler("select_changed")
 
     @on_select_changed.setter
-    def on_select_changed(self, handler: DefaultOptionalEventCallable):
+    def on_select_changed(self, handler: OptionalControlEventCallable):
         self._add_event_handler("select_changed", handler)
         self._set_attr("onSelectChanged", True if handler is not None else None)
 
@@ -694,11 +694,11 @@ class DataTable(ConstrainedControl):
 
     # on_select_all
     @property
-    def on_select_all(self) -> DefaultOptionalEventCallable:
+    def on_select_all(self) -> OptionalControlEventCallable:
         return self._get_event_handler("select_all")
 
     @on_select_all.setter
-    def on_select_all(self, handler: DefaultOptionalEventCallable):
+    def on_select_all(self, handler: OptionalControlEventCallable):
         self._add_event_handler("select_all", handler)
         self._set_attr("onSelectAll", True if handler is not None else None)
 

--- a/sdk/python/packages/flet-core/src/flet_core/date_picker.py
+++ b/sdk/python/packages/flet-core/src/flet_core/date_picker.py
@@ -7,7 +7,11 @@ from flet_core.control import Control, OptionalNumber
 from flet_core.event_handler import EventHandler
 from flet_core.ref import Ref
 from flet_core.textfield import KeyboardType
-from flet_core.types import ResponsiveNumber, OptionalEventCallable
+from flet_core.types import (
+    ResponsiveNumber,
+    OptionalEventCallable,
+    DefaultOptionalEventCallable,
+)
 from flet_core.utils import deprecated
 
 try:
@@ -356,20 +360,20 @@ class DatePicker(Control):
 
     # on_change
     @property
-    def on_change(self) -> OptionalEventCallable:
+    def on_change(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: OptionalEventCallable):
+    def on_change(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("change", handler)
 
     # on_dismiss
     @property
-    def on_dismiss(self) -> OptionalEventCallable:
+    def on_dismiss(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("dismiss")
 
     @on_dismiss.setter
-    def on_dismiss(self, handler: OptionalEventCallable):
+    def on_dismiss(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("dismiss", handler)
 
     # on_entry_mode_change

--- a/sdk/python/packages/flet-core/src/flet_core/date_picker.py
+++ b/sdk/python/packages/flet-core/src/flet_core/date_picker.py
@@ -10,7 +10,7 @@ from flet_core.textfield import KeyboardType
 from flet_core.types import (
     ResponsiveNumber,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 from flet_core.utils import deprecated
 
@@ -360,20 +360,20 @@ class DatePicker(Control):
 
     # on_change
     @property
-    def on_change(self) -> DefaultOptionalEventCallable:
+    def on_change(self) -> OptionalControlEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: DefaultOptionalEventCallable):
+    def on_change(self, handler: OptionalControlEventCallable):
         self._add_event_handler("change", handler)
 
     # on_dismiss
     @property
-    def on_dismiss(self) -> DefaultOptionalEventCallable:
+    def on_dismiss(self) -> OptionalControlEventCallable:
         return self._get_event_handler("dismiss")
 
     @on_dismiss.setter
-    def on_dismiss(self, handler: DefaultOptionalEventCallable):
+    def on_dismiss(self, handler: OptionalControlEventCallable):
         self._add_event_handler("dismiss", handler)
 
     # on_entry_mode_change

--- a/sdk/python/packages/flet-core/src/flet_core/dismissible.py
+++ b/sdk/python/packages/flet-core/src/flet_core/dismissible.py
@@ -15,7 +15,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 from flet_core.utils import deprecated
 
@@ -283,7 +283,7 @@ class Dismissible(ConstrainedControl, AdaptiveControl):
         return self._get_event_handler("resize")
 
     @on_resize.setter
-    def on_resize(self, handler: DefaultOptionalEventCallable):
+    def on_resize(self, handler: OptionalControlEventCallable):
         self._add_event_handler("resize", handler)
         self._set_attr("onResize", True if handler is not None else None)
 

--- a/sdk/python/packages/flet-core/src/flet_core/dismissible.py
+++ b/sdk/python/packages/flet-core/src/flet_core/dismissible.py
@@ -15,6 +15,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 from flet_core.utils import deprecated
 
@@ -43,8 +44,8 @@ class Dismissible(ConstrainedControl, AdaptiveControl):
         movement_duration: Optional[int] = None,
         resize_duration: Optional[int] = None,
         cross_axis_end_offset: OptionalNumber = None,
-        on_update: Optional[Callable[["DismissibleUpdateEvent"], None]] = None,
-        on_dismiss: Optional[Callable[["DismissibleDismissEvent"], None]] = None,
+        on_update: OptionalEventCallable["DismissibleUpdateEvent"] = None,
+        on_dismiss: OptionalEventCallable["DismissibleDismissEvent"] = None,
         on_confirm_dismiss: Optional[
             Callable[["DismissibleDismissEvent"], None]
         ] = None,
@@ -250,9 +251,7 @@ class Dismissible(ConstrainedControl, AdaptiveControl):
         return self._get_event_handler("dismiss")
 
     @on_dismiss.setter
-    def on_dismiss(
-        self, handler: Optional[Callable[["DismissibleDismissEvent"], None]]
-    ):
+    def on_dismiss(self, handler: OptionalEventCallable["DismissibleDismissEvent"]):
         self.__on_dismiss.subscribe(handler)
         self._set_attr("onDismiss", True if handler is not None else None)
 
@@ -263,7 +262,7 @@ class Dismissible(ConstrainedControl, AdaptiveControl):
 
     @on_confirm_dismiss.setter
     def on_confirm_dismiss(
-        self, handler: Optional[Callable[["DismissibleDismissEvent"], None]]
+        self, handler: OptionalEventCallable["DismissibleDismissEvent"]
     ):
         self.__on_confirm_dismiss.subscribe(handler)
         self._set_attr("onConfirmDismiss", True if handler is not None else None)
@@ -274,7 +273,7 @@ class Dismissible(ConstrainedControl, AdaptiveControl):
         return self._get_event_handler("update")
 
     @on_update.setter
-    def on_update(self, handler: Optional[Callable[["DismissibleUpdateEvent"], None]]):
+    def on_update(self, handler: OptionalEventCallable["DismissibleUpdateEvent"]):
         self.__on_update.subscribe(handler)
         self._set_attr("onUpdate", True if handler is not None else None)
 
@@ -284,7 +283,7 @@ class Dismissible(ConstrainedControl, AdaptiveControl):
         return self._get_event_handler("resize")
 
     @on_resize.setter
-    def on_resize(self, handler: OptionalEventCallable):
+    def on_resize(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("resize", handler)
         self._set_attr("onResize", True if handler is not None else None)
 

--- a/sdk/python/packages/flet-core/src/flet_core/draggable.py
+++ b/sdk/python/packages/flet-core/src/flet_core/draggable.py
@@ -2,7 +2,7 @@ from typing import Any, Optional
 
 from flet_core.control import Control
 from flet_core.ref import Ref
-from flet_core.types import OptionalEventCallable, DefaultOptionalEventCallable
+from flet_core.types import OptionalEventCallable, OptionalControlEventCallable
 
 
 class Draggable(Control):
@@ -202,18 +202,18 @@ class Draggable(Control):
 
     # on_drag_start
     @property
-    def on_drag_start(self) -> DefaultOptionalEventCallable:
+    def on_drag_start(self) -> OptionalControlEventCallable:
         return self._get_event_handler("dragStart")
 
     @on_drag_start.setter
-    def on_drag_start(self, handler: DefaultOptionalEventCallable):
+    def on_drag_start(self, handler: OptionalControlEventCallable):
         self._add_event_handler("dragStart", handler)
 
     # on_drag_complete
     @property
-    def on_drag_complete(self) -> DefaultOptionalEventCallable:
+    def on_drag_complete(self) -> OptionalControlEventCallable:
         return self._get_event_handler("dragComplete")
 
     @on_drag_complete.setter
-    def on_drag_complete(self, handler: DefaultOptionalEventCallable):
+    def on_drag_complete(self, handler: OptionalControlEventCallable):
         self._add_event_handler("dragComplete", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/draggable.py
+++ b/sdk/python/packages/flet-core/src/flet_core/draggable.py
@@ -2,7 +2,7 @@ from typing import Any, Optional
 
 from flet_core.control import Control
 from flet_core.ref import Ref
-from flet_core.types import OptionalEventCallable
+from flet_core.types import OptionalEventCallable, DefaultOptionalEventCallable
 
 
 class Draggable(Control):
@@ -202,18 +202,18 @@ class Draggable(Control):
 
     # on_drag_start
     @property
-    def on_drag_start(self) -> OptionalEventCallable:
+    def on_drag_start(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("dragStart")
 
     @on_drag_start.setter
-    def on_drag_start(self, handler: OptionalEventCallable):
+    def on_drag_start(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("dragStart", handler)
 
     # on_drag_complete
     @property
-    def on_drag_complete(self) -> OptionalEventCallable:
+    def on_drag_complete(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("dragComplete")
 
     @on_drag_complete.setter
-    def on_drag_complete(self, handler: OptionalEventCallable):
+    def on_drag_complete(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("dragComplete", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/dropdown.py
+++ b/sdk/python/packages/flet-core/src/flet_core/dropdown.py
@@ -15,6 +15,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 from flet_core.utils import deprecated
 
@@ -110,11 +111,11 @@ class Option(Control):
 
     # on_click
     @property
-    def on_click(self) -> OptionalEventCallable:
+    def on_click(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("click")
 
     @on_click.setter
-    def on_click(self, handler: OptionalEventCallable):
+    def on_click(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("click", handler)
 
 
@@ -490,36 +491,36 @@ class Dropdown(FormFieldControl):
 
     # on_change
     @property
-    def on_change(self) -> OptionalEventCallable:
+    def on_change(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: OptionalEventCallable):
+    def on_change(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("change", handler)
 
     # on_focus
     @property
-    def on_focus(self) -> OptionalEventCallable:
+    def on_focus(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("focus")
 
     @on_focus.setter
-    def on_focus(self, handler: OptionalEventCallable):
+    def on_focus(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("focus", handler)
 
     # on_blur
     @property
-    def on_blur(self) -> OptionalEventCallable:
+    def on_blur(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("blur")
 
     @on_blur.setter
-    def on_blur(self, handler: OptionalEventCallable):
+    def on_blur(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("blur", handler)
 
     # on_click
     @property
-    def on_click(self) -> OptionalEventCallable:
+    def on_click(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("click")
 
     @on_click.setter
-    def on_click(self, handler: OptionalEventCallable):
+    def on_click(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("click", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/dropdown.py
+++ b/sdk/python/packages/flet-core/src/flet_core/dropdown.py
@@ -15,7 +15,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 from flet_core.utils import deprecated
 
@@ -111,11 +111,11 @@ class Option(Control):
 
     # on_click
     @property
-    def on_click(self) -> DefaultOptionalEventCallable:
+    def on_click(self) -> OptionalControlEventCallable:
         return self._get_event_handler("click")
 
     @on_click.setter
-    def on_click(self, handler: DefaultOptionalEventCallable):
+    def on_click(self, handler: OptionalControlEventCallable):
         self._add_event_handler("click", handler)
 
 
@@ -491,36 +491,36 @@ class Dropdown(FormFieldControl):
 
     # on_change
     @property
-    def on_change(self) -> DefaultOptionalEventCallable:
+    def on_change(self) -> OptionalControlEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: DefaultOptionalEventCallable):
+    def on_change(self, handler: OptionalControlEventCallable):
         self._add_event_handler("change", handler)
 
     # on_focus
     @property
-    def on_focus(self) -> DefaultOptionalEventCallable:
+    def on_focus(self) -> OptionalControlEventCallable:
         return self._get_event_handler("focus")
 
     @on_focus.setter
-    def on_focus(self, handler: DefaultOptionalEventCallable):
+    def on_focus(self, handler: OptionalControlEventCallable):
         self._add_event_handler("focus", handler)
 
     # on_blur
     @property
-    def on_blur(self) -> DefaultOptionalEventCallable:
+    def on_blur(self) -> OptionalControlEventCallable:
         return self._get_event_handler("blur")
 
     @on_blur.setter
-    def on_blur(self, handler: DefaultOptionalEventCallable):
+    def on_blur(self, handler: OptionalControlEventCallable):
         self._add_event_handler("blur", handler)
 
     # on_click
     @property
-    def on_click(self) -> DefaultOptionalEventCallable:
+    def on_click(self) -> OptionalControlEventCallable:
         return self._get_event_handler("click")
 
     @on_click.setter
-    def on_click(self, handler: DefaultOptionalEventCallable):
+    def on_click(self, handler: OptionalControlEventCallable):
         self._add_event_handler("click", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/elevated_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/elevated_button.py
@@ -15,7 +15,7 @@ from flet_core.types import (
     ClipBehavior,
     UrlTarget,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 from flet_core.utils import deprecated
 
@@ -329,28 +329,28 @@ class ElevatedButton(ConstrainedControl, AdaptiveControl):
 
     # on_hover
     @property
-    def on_hover(self) -> DefaultOptionalEventCallable:
+    def on_hover(self) -> OptionalControlEventCallable:
         return self._get_event_handler("hover")
 
     @on_hover.setter
-    def on_hover(self, handler: DefaultOptionalEventCallable):
+    def on_hover(self, handler: OptionalControlEventCallable):
         self._add_event_handler("hover", handler)
         self._set_attr("onHover", True if handler is not None else None)
 
     # on_focus
     @property
-    def on_focus(self) -> DefaultOptionalEventCallable:
+    def on_focus(self) -> OptionalControlEventCallable:
         return self._get_event_handler("focus")
 
     @on_focus.setter
-    def on_focus(self, handler: DefaultOptionalEventCallable):
+    def on_focus(self, handler: OptionalControlEventCallable):
         self._add_event_handler("focus", handler)
 
     # on_blur
     @property
-    def on_blur(self) -> DefaultOptionalEventCallable:
+    def on_blur(self) -> OptionalControlEventCallable:
         return self._get_event_handler("blur")
 
     @on_blur.setter
-    def on_blur(self, handler: DefaultOptionalEventCallable):
+    def on_blur(self, handler: OptionalControlEventCallable):
         self._add_event_handler("blur", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/elevated_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/elevated_button.py
@@ -15,6 +15,7 @@ from flet_core.types import (
     ClipBehavior,
     UrlTarget,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 from flet_core.utils import deprecated
 
@@ -328,28 +329,28 @@ class ElevatedButton(ConstrainedControl, AdaptiveControl):
 
     # on_hover
     @property
-    def on_hover(self) -> OptionalEventCallable:
+    def on_hover(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("hover")
 
     @on_hover.setter
-    def on_hover(self, handler: OptionalEventCallable):
+    def on_hover(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("hover", handler)
         self._set_attr("onHover", True if handler is not None else None)
 
     # on_focus
     @property
-    def on_focus(self) -> OptionalEventCallable:
+    def on_focus(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("focus")
 
     @on_focus.setter
-    def on_focus(self, handler: OptionalEventCallable):
+    def on_focus(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("focus", handler)
 
     # on_blur
     @property
-    def on_blur(self) -> OptionalEventCallable:
+    def on_blur(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("blur")
 
     @on_blur.setter
-    def on_blur(self, handler: OptionalEventCallable):
+    def on_blur(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("blur", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/event_handler.py
+++ b/sdk/python/packages/flet-core/src/flet_core/event_handler.py
@@ -2,7 +2,7 @@ import asyncio
 from typing import Callable
 
 from flet_core.control_event import ControlEvent
-from flet_core.types import OptionalEventCallable
+from flet_core.types import DefaultOptionalEventCallable
 
 
 class EventHandler:
@@ -31,7 +31,7 @@ class EventHandler:
 
         return fn
 
-    def subscribe(self, handler: OptionalEventCallable):
+    def subscribe(self, handler: DefaultOptionalEventCallable):
         if handler is not None:
             self.__handlers[handler] = True
 

--- a/sdk/python/packages/flet-core/src/flet_core/event_handler.py
+++ b/sdk/python/packages/flet-core/src/flet_core/event_handler.py
@@ -2,7 +2,7 @@ import asyncio
 from typing import Callable
 
 from flet_core.control_event import ControlEvent
-from flet_core.types import DefaultOptionalEventCallable
+from flet_core.types import OptionalControlEventCallable
 
 
 class EventHandler:
@@ -31,7 +31,7 @@ class EventHandler:
 
         return fn
 
-    def subscribe(self, handler: DefaultOptionalEventCallable):
+    def subscribe(self, handler: OptionalControlEventCallable):
         if handler is not None:
             self.__handlers[handler] = True
 

--- a/sdk/python/packages/flet-core/src/flet_core/expansion_panel.py
+++ b/sdk/python/packages/flet-core/src/flet_core/expansion_panel.py
@@ -12,7 +12,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -323,10 +323,10 @@ class ExpansionPanelList(ConstrainedControl):
 
     # on_change
     @property
-    def on_change(self) -> DefaultOptionalEventCallable:
+    def on_change(self) -> OptionalControlEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: DefaultOptionalEventCallable):
+    def on_change(self, handler: OptionalControlEventCallable):
         self._add_event_handler("change", handler)
         self._set_attr("onChange", True if handler is not None else None)

--- a/sdk/python/packages/flet-core/src/flet_core/expansion_panel.py
+++ b/sdk/python/packages/flet-core/src/flet_core/expansion_panel.py
@@ -12,6 +12,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 
 
@@ -322,10 +323,10 @@ class ExpansionPanelList(ConstrainedControl):
 
     # on_change
     @property
-    def on_change(self) -> OptionalEventCallable:
+    def on_change(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: OptionalEventCallable):
+    def on_change(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("change", handler)
         self._set_attr("onChange", True if handler is not None else None)

--- a/sdk/python/packages/flet-core/src/flet_core/expansion_tile.py
+++ b/sdk/python/packages/flet-core/src/flet_core/expansion_tile.py
@@ -19,7 +19,7 @@ from flet_core.types import (
     OptionalEventCallable,
     ThemeVisualDensity,
     VisualDensity,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -414,6 +414,6 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: DefaultOptionalEventCallable):
+    def on_change(self, handler: OptionalControlEventCallable):
         self._add_event_handler("change", handler)
         self._set_attr("onChange", True if handler is not None else None)

--- a/sdk/python/packages/flet-core/src/flet_core/expansion_tile.py
+++ b/sdk/python/packages/flet-core/src/flet_core/expansion_tile.py
@@ -19,6 +19,7 @@ from flet_core.types import (
     OptionalEventCallable,
     ThemeVisualDensity,
     VisualDensity,
+    DefaultOptionalEventCallable,
 )
 
 
@@ -413,6 +414,6 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: OptionalEventCallable):
+    def on_change(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("change", handler)
         self._set_attr("onChange", True if handler is not None else None)

--- a/sdk/python/packages/flet-core/src/flet_core/flet_app.py
+++ b/sdk/python/packages/flet-core/src/flet_core/flet_app.py
@@ -9,7 +9,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -115,9 +115,9 @@ class FletApp(ConstrainedControl):
 
     # on_error
     @property
-    def on_error(self) -> DefaultOptionalEventCallable:
+    def on_error(self) -> OptionalControlEventCallable:
         return self._get_event_handler("error")
 
     @on_error.setter
-    def on_error(self, handler: DefaultOptionalEventCallable):
+    def on_error(self, handler: OptionalControlEventCallable):
         self._add_event_handler("error", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/flet_app.py
+++ b/sdk/python/packages/flet-core/src/flet_core/flet_app.py
@@ -9,6 +9,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 
 
@@ -114,9 +115,9 @@ class FletApp(ConstrainedControl):
 
     # on_error
     @property
-    def on_error(self) -> OptionalEventCallable:
+    def on_error(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("error")
 
     @on_error.setter
-    def on_error(self, handler: OptionalEventCallable):
+    def on_error(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("error", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/floating_action_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/floating_action_button.py
@@ -14,6 +14,7 @@ from flet_core.types import (
     ScaleValue,
     UrlTarget,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 
 
@@ -245,11 +246,11 @@ class FloatingActionButton(ConstrainedControl):
 
     # on_click
     @property
-    def on_click(self) -> OptionalEventCallable:
+    def on_click(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("click")
 
     @on_click.setter
-    def on_click(self, handler: OptionalEventCallable):
+    def on_click(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("click", handler)
 
     # content

--- a/sdk/python/packages/flet-core/src/flet_core/floating_action_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/floating_action_button.py
@@ -14,7 +14,7 @@ from flet_core.types import (
     ScaleValue,
     UrlTarget,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -246,11 +246,11 @@ class FloatingActionButton(ConstrainedControl):
 
     # on_click
     @property
-    def on_click(self) -> DefaultOptionalEventCallable:
+    def on_click(self) -> OptionalControlEventCallable:
         return self._get_event_handler("click")
 
     @on_click.setter
-    def on_click(self, handler: DefaultOptionalEventCallable):
+    def on_click(self, handler: OptionalControlEventCallable):
         self._add_event_handler("click", handler)
 
     # content

--- a/sdk/python/packages/flet-core/src/flet_core/gesture_detector.py
+++ b/sdk/python/packages/flet-core/src/flet_core/gesture_detector.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Optional, Union, Callable
+from typing import Any, Optional, Union
 
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.constrained_control import ConstrainedControl
@@ -15,6 +15,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 
 
@@ -366,11 +367,11 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
 
     # on_tap
     @property
-    def on_tap(self) -> OptionalEventCallable:
+    def on_tap(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("tap")
 
     @on_tap.setter
-    def on_tap(self, handler: OptionalEventCallable):
+    def on_tap(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("tap", handler)
         self._set_attr("onTap", True if handler is not None else None)
 
@@ -380,7 +381,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         return self.__on_tap_down
 
     @on_tap_down.setter
-    def on_tap_down(self, handler: Optional[Callable[["TapEvent"], None]]):
+    def on_tap_down(self, handler: OptionalEventCallable["TapEvent"]):
         self.__on_tap_down.subscribe(handler)
         self._set_attr("onTapDown", True if handler is not None else None)
 
@@ -390,7 +391,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         return self.__on_tap_up
 
     @on_tap_up.setter
-    def on_tap_up(self, handler: Optional[Callable[["TapEvent"], None]]):
+    def on_tap_up(self, handler: OptionalEventCallable["TapEvent"]):
         self.__on_tap_up.subscribe(handler)
         self._set_attr("onTapUp", True if handler is not None else None)
 
@@ -400,7 +401,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         return self.__on_multi_tap
 
     @on_multi_tap.setter
-    def on_multi_tap(self, handler: Optional[Callable[["MultiTapEvent"], None]]):
+    def on_multi_tap(self, handler: OptionalEventCallable["MultiTapEvent"]):
         self.__on_multi_tap.subscribe(handler)
         self._set_attr("onMultiTap", True if handler is not None else None)
 
@@ -415,21 +416,21 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
 
     # on_multi_long_press
     @property
-    def on_multi_long_press(self) -> OptionalEventCallable:
+    def on_multi_long_press(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("multi_long_press")
 
     @on_multi_long_press.setter
-    def on_multi_long_press(self, handler: OptionalEventCallable):
+    def on_multi_long_press(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("multi_long_press", handler)
         self._set_attr("onMultiLongPress", True if handler is not None else None)
 
     # on_secondary_tap
     @property
-    def on_secondary_tap(self) -> OptionalEventCallable:
+    def on_secondary_tap(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("secondary_tap")
 
     @on_secondary_tap.setter
-    def on_secondary_tap(self, handler: OptionalEventCallable):
+    def on_secondary_tap(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("secondary_tap", handler)
         self._set_attr("onSecondaryTap", True if handler is not None else None)
 
@@ -439,7 +440,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         return self.__on_secondary_tap_down
 
     @on_secondary_tap_down.setter
-    def on_secondary_tap_down(self, handler: Optional[Callable[["TapEvent"], None]]):
+    def on_secondary_tap_down(self, handler: OptionalEventCallable["TapEvent"]):
         self.__on_secondary_tap_down.subscribe(handler)
         self._set_attr("onSecondaryTapDown", True if handler is not None else None)
 
@@ -449,7 +450,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         return self.__on_secondary_tap_up
 
     @on_secondary_tap_up.setter
-    def on_secondary_tap_up(self, handler: Optional[Callable[["TapEvent"], None]]):
+    def on_secondary_tap_up(self, handler: OptionalEventCallable["TapEvent"]):
         self.__on_secondary_tap_up.subscribe(handler)
         self._set_attr("onSecondaryTapUp", True if handler is not None else None)
 
@@ -460,7 +461,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
 
     @on_long_press_start.setter
     def on_long_press_start(
-        self, handler: Optional[Callable[["LongPressStartEvent"], None]]
+        self, handler: OptionalEventCallable["LongPressStartEvent"]
     ):
         self.__on_long_press_start.subscribe(handler)
         self._set_attr("onLongPressStart", True if handler is not None else None)
@@ -471,9 +472,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         return self.__on_long_press_end
 
     @on_long_press_end.setter
-    def on_long_press_end(
-        self, handler: Optional[Callable[["LongPressEndEvent"], None]]
-    ):
+    def on_long_press_end(self, handler: OptionalEventCallable["LongPressEndEvent"]):
         self.__on_long_press_end.subscribe(handler)
         self._set_attr("onLongPressEnd", True if handler is not None else None)
 
@@ -484,7 +483,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
 
     @on_secondary_long_press_start.setter
     def on_secondary_long_press_start(
-        self, handler: Optional[Callable[["LongPressStartEvent"], None]]
+        self, handler: OptionalEventCallable["LongPressStartEvent"]
     ):
         self.__on_secondary_long_press_start.subscribe(handler)
         self._set_attr(
@@ -498,7 +497,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
 
     @on_secondary_long_press_end.setter
     def on_secondary_long_press_end(
-        self, handler: Optional[Callable[["LongPressEndEvent"], None]]
+        self, handler: OptionalEventCallable["LongPressEndEvent"]
     ):
         self.__on_secondary_long_press_end.subscribe(handler)
         self._set_attr("onSecondaryLongPressEnd", True if handler is not None else None)
@@ -509,7 +508,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         return self._get_event_handler("double_tap")
 
     @on_double_tap.setter
-    def on_double_tap(self, handler: Optional[Callable[["TapEvent"], None]]):
+    def on_double_tap(self, handler: OptionalEventCallable["TapEvent"]):
         self._add_event_handler("double_tap", handler)
         self._set_attr("onDoubleTap", True if handler is not None else None)
 
@@ -519,7 +518,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         return self.__on_double_tap_down
 
     @on_double_tap_down.setter
-    def on_double_tap_down(self, handler: Optional[Callable[["TapEvent"], None]]):
+    def on_double_tap_down(self, handler: OptionalEventCallable["TapEvent"]):
         self.__on_double_tap_down.subscribe(handler)
         self._set_attr("onDoubleTapDown", True if handler is not None else None)
 
@@ -530,7 +529,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
 
     @on_horizontal_drag_start.setter
     def on_horizontal_drag_start(
-        self, handler: Optional[Callable[["DragStartEvent"], None]]
+        self, handler: OptionalEventCallable["DragStartEvent"]
     ):
         self.__on_horizontal_drag_start.subscribe(handler)
         self._set_attr("onHorizontalDragStart", True if handler is not None else None)
@@ -542,7 +541,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
 
     @on_horizontal_drag_update.setter
     def on_horizontal_drag_update(
-        self, handler: Optional[Callable[["DragUpdateEvent"], None]]
+        self, handler: OptionalEventCallable["DragUpdateEvent"]
     ):
         self.__on_horizontal_drag_update.subscribe(handler)
         self._set_attr("onHorizontalDragUpdate", True if handler is not None else None)
@@ -553,9 +552,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         return self.__on_horizontal_drag_end
 
     @on_horizontal_drag_end.setter
-    def on_horizontal_drag_end(
-        self, handler: Optional[Callable[["DragEndEvent"], None]]
-    ):
+    def on_horizontal_drag_end(self, handler: OptionalEventCallable["DragEndEvent"]):
         self.__on_horizontal_drag_end.subscribe(handler)
         self._set_attr("onHorizontalDragEnd", True if handler is not None else None)
 
@@ -565,9 +562,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         return self.__on_vertical_drag_start
 
     @on_vertical_drag_start.setter
-    def on_vertical_drag_start(
-        self, handler: Optional[Callable[["DragStartEvent"], None]]
-    ):
+    def on_vertical_drag_start(self, handler: OptionalEventCallable["DragStartEvent"]):
         self.__on_vertical_drag_start.subscribe(handler)
         self._set_attr("onVerticalDragStart", True if handler is not None else None)
 
@@ -578,7 +573,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
 
     @on_vertical_drag_update.setter
     def on_vertical_drag_update(
-        self, handler: Optional[Callable[["DragUpdateEvent"], None]]
+        self, handler: OptionalEventCallable["DragUpdateEvent"]
     ):
         self.__on_vertical_drag_update.subscribe(handler)
         self._set_attr("onVerticalDragUpdate", True if handler is not None else None)
@@ -589,7 +584,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         return self.__on_vertical_drag_end
 
     @on_vertical_drag_end.setter
-    def on_vertical_drag_end(self, handler: Optional[Callable[["DragEndEvent"], None]]):
+    def on_vertical_drag_end(self, handler: OptionalEventCallable["DragEndEvent"]):
         self.__on_vertical_drag_end.subscribe(handler)
         self._set_attr("onVerticalDragEnd", True if handler is not None else None)
 
@@ -599,7 +594,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         return self.__on_pan_start
 
     @on_pan_start.setter
-    def on_pan_start(self, handler: Optional[Callable[["DragStartEvent"], None]]):
+    def on_pan_start(self, handler: OptionalEventCallable["DragStartEvent"]):
         self.__on_pan_start.subscribe(handler)
         self._set_attr("onPanStart", True if handler is not None else None)
 
@@ -609,7 +604,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         return self.__on_pan_update
 
     @on_pan_update.setter
-    def on_pan_update(self, handler: Optional[Callable[["DragUpdateEvent"], None]]):
+    def on_pan_update(self, handler: OptionalEventCallable["DragUpdateEvent"]):
         self.__on_pan_update.subscribe(handler)
         self._set_attr("onPanUpdate", True if handler is not None else None)
 
@@ -619,7 +614,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         return self.__on_pan_end
 
     @on_pan_end.setter
-    def on_pan_end(self, handler: Optional[Callable[["DragEndEvent"], None]]):
+    def on_pan_end(self, handler: OptionalEventCallable["DragEndEvent"]):
         self.__on_pan_end.subscribe(handler)
         self._set_attr("onPanEnd", True if handler is not None else None)
 
@@ -629,7 +624,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         return self.__on_scale_start
 
     @on_scale_start.setter
-    def on_scale_start(self, handler: Optional[Callable[["ScaleStartEvent"], None]]):
+    def on_scale_start(self, handler: OptionalEventCallable["ScaleStartEvent"]):
         self.__on_scale_start.subscribe(handler)
         self._set_attr("onScaleStart", True if handler is not None else None)
 
@@ -639,7 +634,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         return self.__on_scale_update
 
     @on_scale_update.setter
-    def on_scale_update(self, handler: Optional[Callable[["ScaleUpdateEvent"], None]]):
+    def on_scale_update(self, handler: OptionalEventCallable["ScaleUpdateEvent"]):
         self.__on_scale_update.subscribe(handler)
         self._set_attr("onScaleUpdate", True if handler is not None else None)
 
@@ -649,7 +644,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         return self.__on_scale_end
 
     @on_scale_end.setter
-    def on_scale_end(self, handler: Optional[Callable[["ScaleEndEvent"], None]]):
+    def on_scale_end(self, handler: OptionalEventCallable["ScaleEndEvent"]):
         self.__on_scale_end.subscribe(handler)
         self._set_attr("onScaleEnd", True if handler is not None else None)
 
@@ -659,7 +654,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         return self.__on_hover
 
     @on_hover.setter
-    def on_hover(self, handler: Optional[Callable[["HoverEvent"], None]]):
+    def on_hover(self, handler: OptionalEventCallable["HoverEvent"]):
         self.__on_hover.subscribe(handler)
         self._set_attr("onHover", True if handler is not None else None)
 
@@ -669,7 +664,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         return self.__on_enter
 
     @on_enter.setter
-    def on_enter(self, handler: Optional[Callable[["HoverEvent"], None]]):
+    def on_enter(self, handler: OptionalEventCallable["HoverEvent"]):
         self.__on_enter.subscribe(handler)
         self._set_attr("onEnter", True if handler is not None else None)
 
@@ -679,7 +674,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         return self.__on_exit
 
     @on_exit.setter
-    def on_exit(self, handler: Optional[Callable[["HoverEvent"], None]]):
+    def on_exit(self, handler: OptionalEventCallable["HoverEvent"]):
         self.__on_exit.subscribe(handler)
         self._set_attr("onExit", True if handler is not None else None)
 
@@ -689,7 +684,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
         return self.__on_scroll
 
     @on_scroll.setter
-    def on_scroll(self, handler: Optional[Callable[["ScrollEvent"], None]]):
+    def on_scroll(self, handler: OptionalEventCallable["ScrollEvent"]):
         self.__on_scroll.subscribe(handler)
         self._set_attr("onScroll", True if handler is not None else None)
 

--- a/sdk/python/packages/flet-core/src/flet_core/gesture_detector.py
+++ b/sdk/python/packages/flet-core/src/flet_core/gesture_detector.py
@@ -15,7 +15,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -367,11 +367,11 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
 
     # on_tap
     @property
-    def on_tap(self) -> DefaultOptionalEventCallable:
+    def on_tap(self) -> OptionalControlEventCallable:
         return self._get_event_handler("tap")
 
     @on_tap.setter
-    def on_tap(self, handler: DefaultOptionalEventCallable):
+    def on_tap(self, handler: OptionalControlEventCallable):
         self._add_event_handler("tap", handler)
         self._set_attr("onTap", True if handler is not None else None)
 
@@ -416,21 +416,21 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
 
     # on_multi_long_press
     @property
-    def on_multi_long_press(self) -> DefaultOptionalEventCallable:
+    def on_multi_long_press(self) -> OptionalControlEventCallable:
         return self._get_event_handler("multi_long_press")
 
     @on_multi_long_press.setter
-    def on_multi_long_press(self, handler: DefaultOptionalEventCallable):
+    def on_multi_long_press(self, handler: OptionalControlEventCallable):
         self._add_event_handler("multi_long_press", handler)
         self._set_attr("onMultiLongPress", True if handler is not None else None)
 
     # on_secondary_tap
     @property
-    def on_secondary_tap(self) -> DefaultOptionalEventCallable:
+    def on_secondary_tap(self) -> OptionalControlEventCallable:
         return self._get_event_handler("secondary_tap")
 
     @on_secondary_tap.setter
-    def on_secondary_tap(self, handler: DefaultOptionalEventCallable):
+    def on_secondary_tap(self, handler: OptionalControlEventCallable):
         self._add_event_handler("secondary_tap", handler)
         self._set_attr("onSecondaryTap", True if handler is not None else None)
 

--- a/sdk/python/packages/flet-core/src/flet_core/icon_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/icon_button.py
@@ -19,7 +19,7 @@ from flet_core.types import (
     OptionalEventCallable,
     ThemeVisualDensity,
     VisualDensity,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 from flet_core.utils import deprecated
 
@@ -398,11 +398,11 @@ class IconButton(ConstrainedControl, AdaptiveControl):
 
     # on_click
     @property
-    def on_click(self) -> DefaultOptionalEventCallable:
+    def on_click(self) -> OptionalControlEventCallable:
         return self._get_event_handler("click")
 
     @on_click.setter
-    def on_click(self, handler: DefaultOptionalEventCallable):
+    def on_click(self, handler: OptionalControlEventCallable):
         self._add_event_handler("click", handler)
 
     # content
@@ -425,20 +425,20 @@ class IconButton(ConstrainedControl, AdaptiveControl):
 
     # on_focus
     @property
-    def on_focus(self) -> DefaultOptionalEventCallable:
+    def on_focus(self) -> OptionalControlEventCallable:
         return self._get_event_handler("focus")
 
     @on_focus.setter
-    def on_focus(self, handler: DefaultOptionalEventCallable):
+    def on_focus(self, handler: OptionalControlEventCallable):
         self._add_event_handler("focus", handler)
 
     # on_blur
     @property
-    def on_blur(self) -> DefaultOptionalEventCallable:
+    def on_blur(self) -> OptionalControlEventCallable:
         return self._get_event_handler("blur")
 
     @on_blur.setter
-    def on_blur(self, handler: DefaultOptionalEventCallable):
+    def on_blur(self, handler: OptionalControlEventCallable):
         self._add_event_handler("blur", handler)
 
     # alignment

--- a/sdk/python/packages/flet-core/src/flet_core/icon_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/icon_button.py
@@ -19,6 +19,7 @@ from flet_core.types import (
     OptionalEventCallable,
     ThemeVisualDensity,
     VisualDensity,
+    DefaultOptionalEventCallable,
 )
 from flet_core.utils import deprecated
 
@@ -397,11 +398,11 @@ class IconButton(ConstrainedControl, AdaptiveControl):
 
     # on_click
     @property
-    def on_click(self) -> OptionalEventCallable:
+    def on_click(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("click")
 
     @on_click.setter
-    def on_click(self, handler: OptionalEventCallable):
+    def on_click(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("click", handler)
 
     # content
@@ -424,20 +425,20 @@ class IconButton(ConstrainedControl, AdaptiveControl):
 
     # on_focus
     @property
-    def on_focus(self) -> OptionalEventCallable:
+    def on_focus(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("focus")
 
     @on_focus.setter
-    def on_focus(self, handler: OptionalEventCallable):
+    def on_focus(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("focus", handler)
 
     # on_blur
     @property
-    def on_blur(self) -> OptionalEventCallable:
+    def on_blur(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("blur")
 
     @on_blur.setter
-    def on_blur(self, handler: OptionalEventCallable):
+    def on_blur(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("blur", handler)
 
     # alignment

--- a/sdk/python/packages/flet-core/src/flet_core/list_tile.py
+++ b/sdk/python/packages/flet-core/src/flet_core/list_tile.py
@@ -19,7 +19,7 @@ from flet_core.types import (
     OptionalEventCallable,
     ThemeVisualDensity,
     VisualDensity,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -541,38 +541,38 @@ class ListTile(ConstrainedControl, AdaptiveControl):
 
     # on_click
     @property
-    def on_click(self) -> DefaultOptionalEventCallable:
+    def on_click(self) -> OptionalControlEventCallable:
         return self._get_event_handler("click")
 
     @on_click.setter
-    def on_click(self, handler: DefaultOptionalEventCallable):
+    def on_click(self, handler: OptionalControlEventCallable):
         self._add_event_handler("click", handler)
         self._set_attr("onclick", True if handler is not None else None)
 
     # on_long_press
     @property
-    def on_long_press(self) -> DefaultOptionalEventCallable:
+    def on_long_press(self) -> OptionalControlEventCallable:
         return self._get_event_handler("long_press")
 
     @on_long_press.setter
-    def on_long_press(self, handler: DefaultOptionalEventCallable):
+    def on_long_press(self, handler: OptionalControlEventCallable):
         self._add_event_handler("long_press", handler)
         self._set_attr("onLongPress", True if handler is not None else None)
 
     # on_focus
     @property
-    def on_focus(self) -> DefaultOptionalEventCallable:
+    def on_focus(self) -> OptionalControlEventCallable:
         return self._get_event_handler("focus")
 
     @on_focus.setter
-    def on_focus(self, handler: DefaultOptionalEventCallable):
+    def on_focus(self, handler: OptionalControlEventCallable):
         self._add_event_handler("focus", handler)
 
     # on_blur
     @property
-    def on_blur(self) -> DefaultOptionalEventCallable:
+    def on_blur(self) -> OptionalControlEventCallable:
         return self._get_event_handler("blur")
 
     @on_blur.setter
-    def on_blur(self, handler: DefaultOptionalEventCallable):
+    def on_blur(self, handler: OptionalControlEventCallable):
         self._add_event_handler("blur", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/list_tile.py
+++ b/sdk/python/packages/flet-core/src/flet_core/list_tile.py
@@ -19,6 +19,7 @@ from flet_core.types import (
     OptionalEventCallable,
     ThemeVisualDensity,
     VisualDensity,
+    DefaultOptionalEventCallable,
 )
 
 
@@ -540,38 +541,38 @@ class ListTile(ConstrainedControl, AdaptiveControl):
 
     # on_click
     @property
-    def on_click(self) -> OptionalEventCallable:
+    def on_click(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("click")
 
     @on_click.setter
-    def on_click(self, handler: OptionalEventCallable):
+    def on_click(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("click", handler)
         self._set_attr("onclick", True if handler is not None else None)
 
     # on_long_press
     @property
-    def on_long_press(self) -> OptionalEventCallable:
+    def on_long_press(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("long_press")
 
     @on_long_press.setter
-    def on_long_press(self, handler: OptionalEventCallable):
+    def on_long_press(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("long_press", handler)
         self._set_attr("onLongPress", True if handler is not None else None)
 
     # on_focus
     @property
-    def on_focus(self) -> OptionalEventCallable:
+    def on_focus(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("focus")
 
     @on_focus.setter
-    def on_focus(self, handler: OptionalEventCallable):
+    def on_focus(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("focus", handler)
 
     # on_blur
     @property
-    def on_blur(self) -> OptionalEventCallable:
+    def on_blur(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("blur")
 
     @on_blur.setter
-    def on_blur(self, handler: OptionalEventCallable):
+    def on_blur(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("blur", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/lottie.py
+++ b/sdk/python/packages/flet-core/src/flet_core/lottie.py
@@ -11,7 +11,7 @@ from flet_core.types import (
     ScaleValue,
     ImageFit,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 from flet_core.video import FilterQuality
 
@@ -189,10 +189,10 @@ class Lottie(ConstrainedControl):
 
     # on_error
     @property
-    def on_error(self) -> DefaultOptionalEventCallable:
+    def on_error(self) -> OptionalControlEventCallable:
         return self._get_event_handler("error")
 
     @on_error.setter
-    def on_error(self, handler: DefaultOptionalEventCallable):
+    def on_error(self, handler: OptionalControlEventCallable):
         self._add_event_handler("error", handler)
         self._set_attr("onError", True if handler is not None else None)

--- a/sdk/python/packages/flet-core/src/flet_core/lottie.py
+++ b/sdk/python/packages/flet-core/src/flet_core/lottie.py
@@ -11,6 +11,7 @@ from flet_core.types import (
     ScaleValue,
     ImageFit,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 from flet_core.video import FilterQuality
 
@@ -60,7 +61,7 @@ class Lottie(ConstrainedControl):
         animate_rotation: AnimationValue = None,
         animate_scale: AnimationValue = None,
         animate_offset: AnimationValue = None,
-            on_animation_end: OptionalEventCallable = None,
+        on_animation_end: OptionalEventCallable = None,
         tooltip: Optional[str] = None,
         visible: Optional[bool] = None,
         disabled: Optional[bool] = None,
@@ -188,10 +189,10 @@ class Lottie(ConstrainedControl):
 
     # on_error
     @property
-    def on_error(self) -> OptionalEventCallable:
+    def on_error(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("error")
 
     @on_error.setter
-    def on_error(self, handler: OptionalEventCallable):
+    def on_error(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("error", handler)
         self._set_attr("onError", True if handler is not None else None)

--- a/sdk/python/packages/flet-core/src/flet_core/map/map_configuration.py
+++ b/sdk/python/packages/flet-core/src/flet_core/map/map_configuration.py
@@ -1,11 +1,15 @@
 import json
 from dataclasses import dataclass, field
 from enum import Enum, IntFlag
-from typing import Optional, Union, Callable
+from typing import Optional, Union
 
 from flet_core.control import OptionalNumber, Control
 from flet_core.event_handler import EventHandler
-from flet_core.types import ControlEvent, OptionalEventCallable
+from flet_core.types import (
+    ControlEvent,
+    OptionalEventCallable,
+    DefaultOptionalEventCallable,
+)
 
 
 @dataclass
@@ -84,14 +88,14 @@ class MapConfiguration(Control):
         max_zoom: OptionalNumber = None,
         min_zoom: OptionalNumber = None,
         on_init: OptionalEventCallable = None,
-        on_tap: Optional[Callable[["MapTapEvent"], None]] = None,
-        on_secondary_tap: Optional[Callable[["MapTapEvent"], None]] = None,
-        on_long_press: Optional[Callable[["MapTapEvent"], None]] = None,
-        on_event: Optional[Callable[["MapEvent"], None]] = None,
-        on_position_change: Optional[Callable[["MapPositionChangeEvent"], None]] = None,
-        on_pointer_down: Optional[Callable[["MapPointerEvent"], None]] = None,
-        on_pointer_cancel: Optional[Callable[["MapPointerEvent"], None]] = None,
-        on_pointer_up: Optional[Callable[["MapPointerEvent"], None]] = None,
+        on_tap: OptionalEventCallable["MapTapEvent"] = None,
+        on_secondary_tap: OptionalEventCallable["MapTapEvent"] = None,
+        on_long_press: OptionalEventCallable["MapTapEvent"] = None,
+        on_event: OptionalEventCallable["MapEvent"] = None,
+        on_position_change: OptionalEventCallable["MapPositionChangeEvent"] = None,
+        on_pointer_down: OptionalEventCallable["MapPointerEvent"] = None,
+        on_pointer_cancel: OptionalEventCallable["MapPointerEvent"] = None,
+        on_pointer_up: OptionalEventCallable["MapPointerEvent"] = None,
     ):
         Control.__init__(self)
         self.__on_tap = EventHandler(lambda e: MapTapEvent(e))
@@ -230,7 +234,7 @@ class MapConfiguration(Control):
         return self.__on_tap
 
     @on_tap.setter
-    def on_tap(self, handler: Optional[Callable[["MapTapEvent"], None]]):
+    def on_tap(self, handler: OptionalEventCallable["MapTapEvent"]):
         self.__on_tap.subscribe(handler)
         self._set_attr("onTap", True if handler is not None else None)
 
@@ -240,7 +244,7 @@ class MapConfiguration(Control):
         return self.__on_secondary_tap
 
     @on_secondary_tap.setter
-    def on_secondary_tap(self, handler: Optional[Callable[["MapTapEvent"], None]]):
+    def on_secondary_tap(self, handler: OptionalEventCallable["MapTapEvent"]):
         self.__on_secondary_tap.subscribe(handler)
         self._set_attr("onSecondaryTap", True if handler is not None else None)
 
@@ -250,7 +254,7 @@ class MapConfiguration(Control):
         return self.__on_long_press
 
     @on_long_press.setter
-    def on_long_press(self, handler: Optional[Callable[["MapTapEvent"], None]]):
+    def on_long_press(self, handler: OptionalEventCallable["MapTapEvent"]):
         self.__on_long_press.subscribe(handler)
         self._set_attr("onLongPress", True if handler is not None else None)
 
@@ -260,17 +264,17 @@ class MapConfiguration(Control):
         return self.__on_event
 
     @on_event.setter
-    def on_event(self, handler: Optional[Callable[["MapEvent"], None]]):
+    def on_event(self, handler: OptionalEventCallable["MapEvent"]):
         self.__on_event.subscribe(handler)
         self._set_attr("onEvent", True if handler is not None else None)
 
     # on_init
     @property
-    def on_init(self) -> OptionalEventCallable:
+    def on_init(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("init")
 
     @on_init.setter
-    def on_init(self, handler: OptionalEventCallable):
+    def on_init(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("init", handler)
         self._set_attr("onInit", True if handler is not None else None)
 
@@ -281,7 +285,7 @@ class MapConfiguration(Control):
 
     @on_position_change.setter
     def on_position_change(
-        self, handler: Optional[Callable[["MapPositionChangeEvent"], None]]
+        self, handler: OptionalEventCallable["MapPositionChangeEvent"]
     ):
         self.__on_position_change.subscribe(handler)
         self._set_attr("onPositionChange", True if handler is not None else None)
@@ -292,7 +296,7 @@ class MapConfiguration(Control):
         return self.__on_pointer_down
 
     @on_pointer_down.setter
-    def on_pointer_down(self, handler: Optional[Callable[["MapPointerEvent"], None]]):
+    def on_pointer_down(self, handler: OptionalEventCallable["MapPointerEvent"]):
         self.__on_pointer_down.subscribe(handler)
         self._set_attr("onPointerDown", True if handler is not None else None)
 
@@ -302,7 +306,7 @@ class MapConfiguration(Control):
         return self.__on_pointer_cancel
 
     @on_pointer_cancel.setter
-    def on_pointer_cancel(self, handler: Optional[Callable[["MapPointerEvent"], None]]):
+    def on_pointer_cancel(self, handler: OptionalEventCallable["MapPointerEvent"]):
         self.__on_pointer_cancel.subscribe(handler)
         self._set_attr("onPointerCancel", True if handler is not None else None)
 
@@ -312,7 +316,7 @@ class MapConfiguration(Control):
         return self.__on_pointer_up
 
     @on_pointer_up.setter
-    def on_pointer_up(self, handler: Optional[Callable[["MapPointerEvent"], None]]):
+    def on_pointer_up(self, handler: OptionalEventCallable["MapPointerEvent"]):
         self.__on_pointer_up.subscribe(handler)
         self._set_attr("onPointerUp", True if handler is not None else None)
 

--- a/sdk/python/packages/flet-core/src/flet_core/map/map_configuration.py
+++ b/sdk/python/packages/flet-core/src/flet_core/map/map_configuration.py
@@ -8,7 +8,7 @@ from flet_core.event_handler import EventHandler
 from flet_core.types import (
     ControlEvent,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -270,11 +270,11 @@ class MapConfiguration(Control):
 
     # on_init
     @property
-    def on_init(self) -> DefaultOptionalEventCallable:
+    def on_init(self) -> OptionalControlEventCallable:
         return self._get_event_handler("init")
 
     @on_init.setter
-    def on_init(self, handler: DefaultOptionalEventCallable):
+    def on_init(self, handler: OptionalControlEventCallable):
         self._add_event_handler("init", handler)
         self._set_attr("onInit", True if handler is not None else None)
 

--- a/sdk/python/packages/flet-core/src/flet_core/map/simple_attribution.py
+++ b/sdk/python/packages/flet-core/src/flet_core/map/simple_attribution.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 from flet_core.alignment import Alignment
 from flet_core.map.map_layer import MapLayer
 from flet_core.ref import Ref
-from flet_core.types import OptionalEventCallable
+from flet_core.types import OptionalEventCallable, DefaultOptionalEventCallable
 
 
 class SimpleAttribution(MapLayer):
@@ -77,9 +77,9 @@ class SimpleAttribution(MapLayer):
 
     # on_click
     @property
-    def on_change(self) -> OptionalEventCallable:
+    def on_change(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("click")
 
     @on_change.setter
-    def on_change(self, handler: OptionalEventCallable):
+    def on_change(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("click", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/map/simple_attribution.py
+++ b/sdk/python/packages/flet-core/src/flet_core/map/simple_attribution.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 from flet_core.alignment import Alignment
 from flet_core.map.map_layer import MapLayer
 from flet_core.ref import Ref
-from flet_core.types import OptionalEventCallable, DefaultOptionalEventCallable
+from flet_core.types import OptionalEventCallable, OptionalControlEventCallable
 
 
 class SimpleAttribution(MapLayer):
@@ -77,9 +77,9 @@ class SimpleAttribution(MapLayer):
 
     # on_click
     @property
-    def on_change(self) -> DefaultOptionalEventCallable:
+    def on_change(self) -> OptionalControlEventCallable:
         return self._get_event_handler("click")
 
     @on_change.setter
-    def on_change(self, handler: DefaultOptionalEventCallable):
+    def on_change(self, handler: OptionalControlEventCallable):
         self._add_event_handler("click", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/map/text_source_attribution.py
+++ b/sdk/python/packages/flet-core/src/flet_core/map/text_source_attribution.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.text_style import TextStyle
-from flet_core.types import OptionalEventCallable, DefaultOptionalEventCallable
+from flet_core.types import OptionalEventCallable, OptionalControlEventCallable
 
 
 class TextSourceAttribution(Control):
@@ -79,9 +79,9 @@ class TextSourceAttribution(Control):
 
     # on_click
     @property
-    def on_click(self) -> DefaultOptionalEventCallable:
+    def on_click(self) -> OptionalControlEventCallable:
         return self._get_event_handler("click")
 
     @on_click.setter
-    def on_click(self, handler: DefaultOptionalEventCallable):
+    def on_click(self, handler: OptionalControlEventCallable):
         self._add_event_handler("click", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/map/text_source_attribution.py
+++ b/sdk/python/packages/flet-core/src/flet_core/map/text_source_attribution.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 from flet_core.control import Control
 from flet_core.ref import Ref
 from flet_core.text_style import TextStyle
-from flet_core.types import OptionalEventCallable
+from flet_core.types import OptionalEventCallable, DefaultOptionalEventCallable
 
 
 class TextSourceAttribution(Control):
@@ -79,9 +79,9 @@ class TextSourceAttribution(Control):
 
     # on_click
     @property
-    def on_click(self) -> OptionalEventCallable:
+    def on_click(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("click")
 
     @on_click.setter
-    def on_click(self, handler: OptionalEventCallable):
+    def on_click(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("click", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/map/tile_layer.py
+++ b/sdk/python/packages/flet-core/src/flet_core/map/tile_layer.py
@@ -5,7 +5,7 @@ from flet_core.control import OptionalNumber
 from flet_core.map.map_configuration import MapLatitudeLongitudeBounds
 from flet_core.map.map_layer import MapLayer
 from flet_core.ref import Ref
-from flet_core.types import OptionalEventCallable
+from flet_core.types import OptionalEventCallable, DefaultOptionalEventCallable
 
 
 class MapTileLayerEvictErrorTileStrategy(Enum):
@@ -270,9 +270,9 @@ class TileLayer(MapLayer):
 
     # on_image_error
     @property
-    def on_image_error(self) -> OptionalEventCallable:
+    def on_image_error(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("imageError")
 
     @on_image_error.setter
-    def on_image_error(self, handler: OptionalEventCallable):
+    def on_image_error(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("imageError", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/map/tile_layer.py
+++ b/sdk/python/packages/flet-core/src/flet_core/map/tile_layer.py
@@ -5,7 +5,7 @@ from flet_core.control import OptionalNumber
 from flet_core.map.map_configuration import MapLatitudeLongitudeBounds
 from flet_core.map.map_layer import MapLayer
 from flet_core.ref import Ref
-from flet_core.types import OptionalEventCallable, DefaultOptionalEventCallable
+from flet_core.types import OptionalEventCallable, OptionalControlEventCallable
 
 
 class MapTileLayerEvictErrorTileStrategy(Enum):
@@ -270,9 +270,9 @@ class TileLayer(MapLayer):
 
     # on_image_error
     @property
-    def on_image_error(self) -> DefaultOptionalEventCallable:
+    def on_image_error(self) -> OptionalControlEventCallable:
         return self._get_event_handler("imageError")
 
     @on_image_error.setter
-    def on_image_error(self, handler: DefaultOptionalEventCallable):
+    def on_image_error(self, handler: OptionalControlEventCallable):
         self._add_event_handler("imageError", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/markdown.py
+++ b/sdk/python/packages/flet-core/src/flet_core/markdown.py
@@ -12,7 +12,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 try:
@@ -194,9 +194,9 @@ class Markdown(ConstrainedControl):
 
     # on_tap_link
     @property
-    def on_tap_link(self) -> DefaultOptionalEventCallable:
+    def on_tap_link(self) -> OptionalControlEventCallable:
         return self._get_event_handler("tap_link")
 
     @on_tap_link.setter
-    def on_tap_link(self, handler: DefaultOptionalEventCallable):
+    def on_tap_link(self, handler: OptionalControlEventCallable):
         self._add_event_handler("tap_link", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/markdown.py
+++ b/sdk/python/packages/flet-core/src/flet_core/markdown.py
@@ -12,6 +12,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 
 try:
@@ -193,9 +194,9 @@ class Markdown(ConstrainedControl):
 
     # on_tap_link
     @property
-    def on_tap_link(self) -> OptionalEventCallable:
+    def on_tap_link(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("tap_link")
 
     @on_tap_link.setter
-    def on_tap_link(self, handler: OptionalEventCallable):
+    def on_tap_link(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("tap_link", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/menu_item_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/menu_item_button.py
@@ -13,6 +13,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 from flet_core.utils import deprecated
 
@@ -225,28 +226,28 @@ class MenuItemButton(ConstrainedControl):
 
     # on_hover
     @property
-    def on_hover(self) -> OptionalEventCallable:
+    def on_hover(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("hover")
 
     @on_hover.setter
-    def on_hover(self, handler: OptionalEventCallable):
+    def on_hover(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("hover", handler)
         self._set_attr("onHover", True if handler is not None else None)
 
     # on_focus
     @property
-    def on_focus(self) -> OptionalEventCallable:
+    def on_focus(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("focus")
 
     @on_focus.setter
-    def on_focus(self, handler: OptionalEventCallable):
+    def on_focus(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("focus", handler)
 
     # on_blur
     @property
-    def on_blur(self) -> OptionalEventCallable:
+    def on_blur(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("blur")
 
     @on_blur.setter
-    def on_blur(self, handler: OptionalEventCallable):
+    def on_blur(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("blur", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/menu_item_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/menu_item_button.py
@@ -13,7 +13,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 from flet_core.utils import deprecated
 
@@ -226,28 +226,28 @@ class MenuItemButton(ConstrainedControl):
 
     # on_hover
     @property
-    def on_hover(self) -> DefaultOptionalEventCallable:
+    def on_hover(self) -> OptionalControlEventCallable:
         return self._get_event_handler("hover")
 
     @on_hover.setter
-    def on_hover(self, handler: DefaultOptionalEventCallable):
+    def on_hover(self, handler: OptionalControlEventCallable):
         self._add_event_handler("hover", handler)
         self._set_attr("onHover", True if handler is not None else None)
 
     # on_focus
     @property
-    def on_focus(self) -> DefaultOptionalEventCallable:
+    def on_focus(self) -> OptionalControlEventCallable:
         return self._get_event_handler("focus")
 
     @on_focus.setter
-    def on_focus(self, handler: DefaultOptionalEventCallable):
+    def on_focus(self, handler: OptionalControlEventCallable):
         self._add_event_handler("focus", handler)
 
     # on_blur
     @property
-    def on_blur(self) -> DefaultOptionalEventCallable:
+    def on_blur(self) -> OptionalControlEventCallable:
         return self._get_event_handler("blur")
 
     @on_blur.setter
-    def on_blur(self, handler: DefaultOptionalEventCallable):
+    def on_blur(self, handler: OptionalControlEventCallable):
         self._add_event_handler("blur", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/navigation_bar.py
+++ b/sdk/python/packages/flet-core/src/flet_core/navigation_bar.py
@@ -16,7 +16,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     ControlState,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 from flet_core.utils import deprecated
 
@@ -412,9 +412,9 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
 
     # on_change
     @property
-    def on_change(self) -> DefaultOptionalEventCallable:
+    def on_change(self) -> OptionalControlEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: DefaultOptionalEventCallable):
+    def on_change(self, handler: OptionalControlEventCallable):
         self._add_event_handler("change", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/navigation_bar.py
+++ b/sdk/python/packages/flet-core/src/flet_core/navigation_bar.py
@@ -10,13 +10,13 @@ from flet_core.ref import Ref
 from flet_core.types import (
     AnimationValue,
     OptionalEventCallable,
-    MaterialState,
     OffsetValue,
     OptionalNumber,
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
     ControlState,
+    DefaultOptionalEventCallable,
 )
 from flet_core.utils import deprecated
 
@@ -412,9 +412,9 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
 
     # on_change
     @property
-    def on_change(self) -> OptionalEventCallable:
+    def on_change(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: OptionalEventCallable):
+    def on_change(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("change", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/navigation_drawer.py
+++ b/sdk/python/packages/flet-core/src/flet_core/navigation_drawer.py
@@ -8,7 +8,7 @@ from flet_core.types import (
     OptionalEventCallable,
     OptionalNumber,
     PaddingValue,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -325,18 +325,18 @@ class NavigationDrawer(Control):
 
     # on_change
     @property
-    def on_change(self) -> DefaultOptionalEventCallable:
+    def on_change(self) -> OptionalControlEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: DefaultOptionalEventCallable):
+    def on_change(self, handler: OptionalControlEventCallable):
         self._add_event_handler("change", handler)
 
     # on_dismiss
     @property
-    def on_dismiss(self) -> DefaultOptionalEventCallable:
+    def on_dismiss(self) -> OptionalControlEventCallable:
         return self._get_event_handler("dismiss")
 
     @on_dismiss.setter
-    def on_dismiss(self, handler: DefaultOptionalEventCallable):
+    def on_dismiss(self, handler: OptionalControlEventCallable):
         self._add_event_handler("dismiss", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/navigation_drawer.py
+++ b/sdk/python/packages/flet-core/src/flet_core/navigation_drawer.py
@@ -8,6 +8,7 @@ from flet_core.types import (
     OptionalEventCallable,
     OptionalNumber,
     PaddingValue,
+    DefaultOptionalEventCallable,
 )
 
 
@@ -324,18 +325,18 @@ class NavigationDrawer(Control):
 
     # on_change
     @property
-    def on_change(self) -> OptionalEventCallable:
+    def on_change(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: OptionalEventCallable):
+    def on_change(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("change", handler)
 
     # on_dismiss
     @property
-    def on_dismiss(self) -> OptionalEventCallable:
+    def on_dismiss(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("dismiss")
 
     @on_dismiss.setter
-    def on_dismiss(self, handler: OptionalEventCallable):
+    def on_dismiss(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("dismiss", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/navigation_rail.py
+++ b/sdk/python/packages/flet-core/src/flet_core/navigation_rail.py
@@ -15,7 +15,7 @@ from flet_core.types import (
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -349,11 +349,11 @@ class NavigationRail(ConstrainedControl):
 
     # on_change
     @property
-    def on_change(self) -> DefaultOptionalEventCallable:
+    def on_change(self) -> OptionalControlEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: DefaultOptionalEventCallable):
+    def on_change(self, handler: OptionalControlEventCallable):
         self._add_event_handler("change", handler)
 
     # selected_index

--- a/sdk/python/packages/flet-core/src/flet_core/navigation_rail.py
+++ b/sdk/python/packages/flet-core/src/flet_core/navigation_rail.py
@@ -15,6 +15,7 @@ from flet_core.types import (
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
+    DefaultOptionalEventCallable,
 )
 
 
@@ -26,22 +27,22 @@ class NavigationRailLabelType(Enum):
 
 class NavigationRailDestination(Control):
     def __init__(
-            self,
-            icon: Optional[str] = None,
-            icon_content: Optional[Control] = None,
-            selected_icon: Optional[str] = None,
-            selected_icon_content: Optional[Control] = None,
-            label: Optional[str] = None,
-            label_content: Optional[Control] = None,
-            padding: PaddingValue = None,
-            indicator_color: Optional[str] = None,
-            indicator_shape: Optional[OutlinedBorder] = None,
-            #
-            # Control
-            #
-            ref: Optional[Ref] = None,
-            disabled: Optional[bool] = None,
-            data: Any = None,
+        self,
+        icon: Optional[str] = None,
+        icon_content: Optional[Control] = None,
+        selected_icon: Optional[str] = None,
+        selected_icon_content: Optional[Control] = None,
+        label: Optional[str] = None,
+        label_content: Optional[Control] = None,
+        padding: PaddingValue = None,
+        indicator_color: Optional[str] = None,
+        indicator_shape: Optional[OutlinedBorder] = None,
+        #
+        # Control
+        #
+        ref: Optional[Ref] = None,
+        disabled: Optional[bool] = None,
+        data: Any = None,
     ) -> None:
         Control.__init__(self, ref=ref, disabled=disabled, data=data)
         self.label = label
@@ -348,11 +349,11 @@ class NavigationRail(ConstrainedControl):
 
     # on_change
     @property
-    def on_change(self) -> OptionalEventCallable:
+    def on_change(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: OptionalEventCallable):
+    def on_change(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("change", handler)
 
     # selected_index

--- a/sdk/python/packages/flet-core/src/flet_core/outlined_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/outlined_button.py
@@ -15,7 +15,7 @@ from flet_core.types import (
     ScaleValue,
     UrlTarget,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 from flet_core.utils import deprecated
 
@@ -227,20 +227,20 @@ class OutlinedButton(ConstrainedControl, AdaptiveControl):
 
     # on_click
     @property
-    def on_click(self) -> DefaultOptionalEventCallable:
+    def on_click(self) -> OptionalControlEventCallable:
         return self._get_event_handler("click")
 
     @on_click.setter
-    def on_click(self, handler: DefaultOptionalEventCallable):
+    def on_click(self, handler: OptionalControlEventCallable):
         self._add_event_handler("click", handler)
 
     # on_long_press
     @property
-    def on_long_press(self) -> DefaultOptionalEventCallable:
+    def on_long_press(self) -> OptionalControlEventCallable:
         return self._get_event_handler("long_press")
 
     @on_long_press.setter
-    def on_long_press(self, handler: DefaultOptionalEventCallable):
+    def on_long_press(self, handler: OptionalControlEventCallable):
         self._add_event_handler("long_press", handler)
         self._set_attr("onLongPress", True if handler is not None else None)
 
@@ -274,28 +274,28 @@ class OutlinedButton(ConstrainedControl, AdaptiveControl):
 
     # on_hover
     @property
-    def on_hover(self) -> DefaultOptionalEventCallable:
+    def on_hover(self) -> OptionalControlEventCallable:
         return self._get_event_handler("hover")
 
     @on_hover.setter
-    def on_hover(self, handler: DefaultOptionalEventCallable):
+    def on_hover(self, handler: OptionalControlEventCallable):
         self._add_event_handler("hover", handler)
         self._set_attr("onHover", True if handler is not None else None)
 
     # on_focus
     @property
-    def on_focus(self) -> DefaultOptionalEventCallable:
+    def on_focus(self) -> OptionalControlEventCallable:
         return self._get_event_handler("focus")
 
     @on_focus.setter
-    def on_focus(self, handler: DefaultOptionalEventCallable):
+    def on_focus(self, handler: OptionalControlEventCallable):
         self._add_event_handler("focus", handler)
 
     # on_blur
     @property
-    def on_blur(self) -> DefaultOptionalEventCallable:
+    def on_blur(self) -> OptionalControlEventCallable:
         return self._get_event_handler("blur")
 
     @on_blur.setter
-    def on_blur(self, handler: DefaultOptionalEventCallable):
+    def on_blur(self, handler: OptionalControlEventCallable):
         self._add_event_handler("blur", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/outlined_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/outlined_button.py
@@ -15,6 +15,7 @@ from flet_core.types import (
     ScaleValue,
     UrlTarget,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 from flet_core.utils import deprecated
 
@@ -226,20 +227,20 @@ class OutlinedButton(ConstrainedControl, AdaptiveControl):
 
     # on_click
     @property
-    def on_click(self) -> OptionalEventCallable:
+    def on_click(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("click")
 
     @on_click.setter
-    def on_click(self, handler: OptionalEventCallable):
+    def on_click(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("click", handler)
 
     # on_long_press
     @property
-    def on_long_press(self) -> OptionalEventCallable:
+    def on_long_press(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("long_press")
 
     @on_long_press.setter
-    def on_long_press(self, handler: OptionalEventCallable):
+    def on_long_press(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("long_press", handler)
         self._set_attr("onLongPress", True if handler is not None else None)
 
@@ -273,28 +274,28 @@ class OutlinedButton(ConstrainedControl, AdaptiveControl):
 
     # on_hover
     @property
-    def on_hover(self) -> OptionalEventCallable:
+    def on_hover(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("hover")
 
     @on_hover.setter
-    def on_hover(self, handler: OptionalEventCallable):
+    def on_hover(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("hover", handler)
         self._set_attr("onHover", True if handler is not None else None)
 
     # on_focus
     @property
-    def on_focus(self) -> OptionalEventCallable:
+    def on_focus(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("focus")
 
     @on_focus.setter
-    def on_focus(self, handler: OptionalEventCallable):
+    def on_focus(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("focus", handler)
 
     # on_blur
     @property
-    def on_blur(self) -> OptionalEventCallable:
+    def on_blur(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("blur")
 
     @on_blur.setter
-    def on_blur(self, handler: OptionalEventCallable):
+    def on_blur(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("blur", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/page.py
+++ b/sdk/python/packages/flet-core/src/flet_core/page.py
@@ -75,8 +75,8 @@ from flet_core.types import (
     ScrollMode,
     ThemeMode,
     Wrapper,
-    OptionalEventCallable,
     WindowEventType,
+    DefaultOptionalEventCallable,
 )
 from flet_core.utils import classproperty, deprecated
 from flet_core.utils.concurrency_utils import is_pyodide
@@ -495,7 +495,10 @@ class Window:
         return self.__on_event
 
     @on_event.setter
-    def on_event(self, handler: "Optional[Callable[[WindowEvent], Union[None, Coroutine[None, None, None]]]]"):
+    def on_event(
+        self,
+        handler: "Optional[Callable[[WindowEvent], Union[None, Coroutine[None, None, None]]]]",
+    ):
         self.__on_event.subscribe(handler)
 
 
@@ -2735,7 +2738,7 @@ class Page(AdaptiveControl):
         return self.__on_close
 
     @on_close.setter
-    def on_close(self, handler: OptionalEventCallable):
+    def on_close(self, handler: DefaultOptionalEventCallable):
         self.__on_close.subscribe(handler)
 
     # on_resize
@@ -2773,7 +2776,7 @@ class Page(AdaptiveControl):
         return self.__on_platform_brightness_change
 
     @on_platform_brightness_change.setter
-    def on_platform_brightness_change(self, handler: OptionalEventCallable):
+    def on_platform_brightness_change(self, handler: DefaultOptionalEventCallable):
         self.__on_platform_brightness_change.subscribe(handler)
 
     # on_app_lifecycle_change
@@ -2850,7 +2853,7 @@ class Page(AdaptiveControl):
         return self.__on_connect
 
     @on_connect.setter
-    def on_connect(self, handler: OptionalEventCallable):
+    def on_connect(self, handler: DefaultOptionalEventCallable):
         self.__on_connect.subscribe(handler)
 
     # on_disconnect
@@ -2859,7 +2862,7 @@ class Page(AdaptiveControl):
         return self.__on_disconnect
 
     @on_disconnect.setter
-    def on_disconnect(self, handler: OptionalEventCallable):
+    def on_disconnect(self, handler: DefaultOptionalEventCallable):
         self.__on_disconnect.subscribe(handler)
 
     # on_login
@@ -2877,7 +2880,7 @@ class Page(AdaptiveControl):
         return self.__on_logout
 
     @on_logout.setter
-    def on_logout(self, handler: OptionalEventCallable):
+    def on_logout(self, handler: DefaultOptionalEventCallable):
         self.__on_logout.subscribe(handler)
 
     # on_error
@@ -2886,7 +2889,7 @@ class Page(AdaptiveControl):
         return self.__on_error
 
     @on_error.setter
-    def on_error(self, handler: OptionalEventCallable):
+    def on_error(self, handler: DefaultOptionalEventCallable):
         self.__on_error.subscribe(handler)
 
     # on_scroll

--- a/sdk/python/packages/flet-core/src/flet_core/page.py
+++ b/sdk/python/packages/flet-core/src/flet_core/page.py
@@ -495,7 +495,7 @@ class Window:
         return self.__on_event
 
     @on_event.setter
-    def on_event(self, handler: "Optional[Callable[[WindowEvent], None]]"):
+    def on_event(self, handler: "Optional[Callable[[WindowEvent], Union[None, Coroutine[None, None, None]]]]"):
         self.__on_event.subscribe(handler)
 
 

--- a/sdk/python/packages/flet-core/src/flet_core/page.py
+++ b/sdk/python/packages/flet-core/src/flet_core/page.py
@@ -76,7 +76,7 @@ from flet_core.types import (
     ThemeMode,
     Wrapper,
     WindowEventType,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 from flet_core.utils import classproperty, deprecated
 from flet_core.utils.concurrency_utils import is_pyodide
@@ -2738,7 +2738,7 @@ class Page(AdaptiveControl):
         return self.__on_close
 
     @on_close.setter
-    def on_close(self, handler: DefaultOptionalEventCallable):
+    def on_close(self, handler: OptionalControlEventCallable):
         self.__on_close.subscribe(handler)
 
     # on_resize
@@ -2776,7 +2776,7 @@ class Page(AdaptiveControl):
         return self.__on_platform_brightness_change
 
     @on_platform_brightness_change.setter
-    def on_platform_brightness_change(self, handler: DefaultOptionalEventCallable):
+    def on_platform_brightness_change(self, handler: OptionalControlEventCallable):
         self.__on_platform_brightness_change.subscribe(handler)
 
     # on_app_lifecycle_change
@@ -2853,7 +2853,7 @@ class Page(AdaptiveControl):
         return self.__on_connect
 
     @on_connect.setter
-    def on_connect(self, handler: DefaultOptionalEventCallable):
+    def on_connect(self, handler: OptionalControlEventCallable):
         self.__on_connect.subscribe(handler)
 
     # on_disconnect
@@ -2862,7 +2862,7 @@ class Page(AdaptiveControl):
         return self.__on_disconnect
 
     @on_disconnect.setter
-    def on_disconnect(self, handler: DefaultOptionalEventCallable):
+    def on_disconnect(self, handler: OptionalControlEventCallable):
         self.__on_disconnect.subscribe(handler)
 
     # on_login
@@ -2880,7 +2880,7 @@ class Page(AdaptiveControl):
         return self.__on_logout
 
     @on_logout.setter
-    def on_logout(self, handler: DefaultOptionalEventCallable):
+    def on_logout(self, handler: OptionalControlEventCallable):
         self.__on_logout.subscribe(handler)
 
     # on_error
@@ -2889,7 +2889,7 @@ class Page(AdaptiveControl):
         return self.__on_error
 
     @on_error.setter
-    def on_error(self, handler: DefaultOptionalEventCallable):
+    def on_error(self, handler: OptionalControlEventCallable):
         self.__on_error.subscribe(handler)
 
     # on_scroll

--- a/sdk/python/packages/flet-core/src/flet_core/popup_menu_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/popup_menu_button.py
@@ -16,7 +16,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -130,11 +130,11 @@ class PopupMenuItem(Control):
 
     # on_click
     @property
-    def on_click(self) -> DefaultOptionalEventCallable:
+    def on_click(self) -> OptionalControlEventCallable:
         return self._get_event_handler("click")
 
     @on_click.setter
-    def on_click(self, handler: DefaultOptionalEventCallable):
+    def on_click(self, handler: OptionalControlEventCallable):
         self._add_event_handler("click", handler)
 
 
@@ -436,16 +436,16 @@ class PopupMenuButton(ConstrainedControl):
 
     # on_cancel
     @property
-    def on_cancel(self) -> DefaultOptionalEventCallable:
+    def on_cancel(self) -> OptionalControlEventCallable:
         return self._get_event_handler("cancel")
 
     @on_cancel.setter
-    def on_cancel(self, handler: DefaultOptionalEventCallable):
+    def on_cancel(self, handler: OptionalControlEventCallable):
         self._add_event_handler("cancel", handler)
 
     # on_cancelled
     @property
-    def on_cancelled(self) -> DefaultOptionalEventCallable:
+    def on_cancelled(self) -> OptionalControlEventCallable:
         warnings.warn(
             f"on_cancelled is deprecated/renamed since version 0.22.0 "
             f"and will be removed in version 0.26.0. Use on_cancel instead.",
@@ -455,7 +455,7 @@ class PopupMenuButton(ConstrainedControl):
         return self._get_event_handler("cancelled")
 
     @on_cancelled.setter
-    def on_cancelled(self, handler: DefaultOptionalEventCallable):
+    def on_cancelled(self, handler: OptionalControlEventCallable):
         self._add_event_handler("cancelled", handler)
         if handler is not None:
             warnings.warn(
@@ -467,9 +467,9 @@ class PopupMenuButton(ConstrainedControl):
 
     # on_open
     @property
-    def on_open(self) -> DefaultOptionalEventCallable:
+    def on_open(self) -> OptionalControlEventCallable:
         return self._get_event_handler("open")
 
     @on_open.setter
-    def on_open(self, handler: DefaultOptionalEventCallable):
+    def on_open(self, handler: OptionalControlEventCallable):
         self._add_event_handler("open", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/popup_menu_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/popup_menu_button.py
@@ -16,6 +16,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 
 
@@ -129,11 +130,11 @@ class PopupMenuItem(Control):
 
     # on_click
     @property
-    def on_click(self) -> OptionalEventCallable:
+    def on_click(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("click")
 
     @on_click.setter
-    def on_click(self, handler: OptionalEventCallable):
+    def on_click(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("click", handler)
 
 
@@ -435,16 +436,16 @@ class PopupMenuButton(ConstrainedControl):
 
     # on_cancel
     @property
-    def on_cancel(self) -> OptionalEventCallable:
+    def on_cancel(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("cancel")
 
     @on_cancel.setter
-    def on_cancel(self, handler: OptionalEventCallable):
+    def on_cancel(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("cancel", handler)
 
     # on_cancelled
     @property
-    def on_cancelled(self) -> OptionalEventCallable:
+    def on_cancelled(self) -> DefaultOptionalEventCallable:
         warnings.warn(
             f"on_cancelled is deprecated/renamed since version 0.22.0 "
             f"and will be removed in version 0.26.0. Use on_cancel instead.",
@@ -454,7 +455,7 @@ class PopupMenuButton(ConstrainedControl):
         return self._get_event_handler("cancelled")
 
     @on_cancelled.setter
-    def on_cancelled(self, handler: OptionalEventCallable):
+    def on_cancelled(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("cancelled", handler)
         if handler is not None:
             warnings.warn(
@@ -466,9 +467,9 @@ class PopupMenuButton(ConstrainedControl):
 
     # on_open
     @property
-    def on_open(self) -> OptionalEventCallable:
+    def on_open(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("open")
 
     @on_open.setter
-    def on_open(self, handler: OptionalEventCallable):
+    def on_open(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("open", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/radio.py
+++ b/sdk/python/packages/flet-core/src/flet_core/radio.py
@@ -17,6 +17,7 @@ from flet_core.types import (
     OptionalEventCallable,
     ThemeVisualDensity,
     VisualDensity,
+    DefaultOptionalEventCallable,
 )
 
 try:
@@ -278,20 +279,20 @@ class Radio(ConstrainedControl, AdaptiveControl):
 
     # on_focus
     @property
-    def on_focus(self) -> OptionalEventCallable:
+    def on_focus(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("focus")
 
     @on_focus.setter
-    def on_focus(self, handler: OptionalEventCallable):
+    def on_focus(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("focus", handler)
 
     # on_blur
     @property
-    def on_blur(self) -> OptionalEventCallable:
+    def on_blur(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("blur")
 
     @on_blur.setter
-    def on_blur(self, handler: OptionalEventCallable):
+    def on_blur(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("blur", handler)
 
     # autofocus

--- a/sdk/python/packages/flet-core/src/flet_core/radio.py
+++ b/sdk/python/packages/flet-core/src/flet_core/radio.py
@@ -17,7 +17,7 @@ from flet_core.types import (
     OptionalEventCallable,
     ThemeVisualDensity,
     VisualDensity,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 try:
@@ -279,20 +279,20 @@ class Radio(ConstrainedControl, AdaptiveControl):
 
     # on_focus
     @property
-    def on_focus(self) -> DefaultOptionalEventCallable:
+    def on_focus(self) -> OptionalControlEventCallable:
         return self._get_event_handler("focus")
 
     @on_focus.setter
-    def on_focus(self, handler: DefaultOptionalEventCallable):
+    def on_focus(self, handler: OptionalControlEventCallable):
         self._add_event_handler("focus", handler)
 
     # on_blur
     @property
-    def on_blur(self) -> DefaultOptionalEventCallable:
+    def on_blur(self) -> OptionalControlEventCallable:
         return self._get_event_handler("blur")
 
     @on_blur.setter
-    def on_blur(self, handler: DefaultOptionalEventCallable):
+    def on_blur(self, handler: OptionalControlEventCallable):
         self._add_event_handler("blur", handler)
 
     # autofocus

--- a/sdk/python/packages/flet-core/src/flet_core/radio_group.py
+++ b/sdk/python/packages/flet-core/src/flet_core/radio_group.py
@@ -1,8 +1,8 @@
 from typing import Any, Optional
 
-from flet_core.types import OptionalEventCallable
 from flet_core.control import Control, OptionalNumber
 from flet_core.ref import Ref
+from flet_core.types import OptionalEventCallable, DefaultOptionalEventCallable
 
 
 class RadioGroup(Control):
@@ -94,9 +94,9 @@ class RadioGroup(Control):
 
     # on_change
     @property
-    def on_change(self) -> OptionalEventCallable:
+    def on_change(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: OptionalEventCallable):
+    def on_change(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("change", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/radio_group.py
+++ b/sdk/python/packages/flet-core/src/flet_core/radio_group.py
@@ -2,7 +2,7 @@ from typing import Any, Optional
 
 from flet_core.control import Control, OptionalNumber
 from flet_core.ref import Ref
-from flet_core.types import OptionalEventCallable, DefaultOptionalEventCallable
+from flet_core.types import OptionalEventCallable, OptionalControlEventCallable
 
 
 class RadioGroup(Control):
@@ -94,9 +94,9 @@ class RadioGroup(Control):
 
     # on_change
     @property
-    def on_change(self) -> DefaultOptionalEventCallable:
+    def on_change(self) -> OptionalControlEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: DefaultOptionalEventCallable):
+    def on_change(self, handler: OptionalControlEventCallable):
         self._add_event_handler("change", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/range_slider.py
+++ b/sdk/python/packages/flet-core/src/flet_core/range_slider.py
@@ -11,7 +11,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -271,27 +271,27 @@ class RangeSlider(ConstrainedControl):
 
     # on_change
     @property
-    def on_change(self) -> DefaultOptionalEventCallable:
+    def on_change(self) -> OptionalControlEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: DefaultOptionalEventCallable):
+    def on_change(self, handler: OptionalControlEventCallable):
         self._add_event_handler("change", handler)
 
     # on_change_start
     @property
-    def on_change_start(self) -> DefaultOptionalEventCallable:
+    def on_change_start(self) -> OptionalControlEventCallable:
         return self._get_event_handler("change_start")
 
     @on_change_start.setter
-    def on_change_start(self, handler: DefaultOptionalEventCallable):
+    def on_change_start(self, handler: OptionalControlEventCallable):
         self._add_event_handler("change_start", handler)
 
     # on_change_end
     @property
-    def on_change_end(self) -> DefaultOptionalEventCallable:
+    def on_change_end(self) -> OptionalControlEventCallable:
         return self._get_event_handler("change_end")
 
     @on_change_end.setter
-    def on_change_end(self, handler: DefaultOptionalEventCallable):
+    def on_change_end(self, handler: OptionalControlEventCallable):
         self._add_event_handler("change_end", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/range_slider.py
+++ b/sdk/python/packages/flet-core/src/flet_core/range_slider.py
@@ -11,6 +11,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 
 
@@ -270,27 +271,27 @@ class RangeSlider(ConstrainedControl):
 
     # on_change
     @property
-    def on_change(self) -> OptionalEventCallable:
+    def on_change(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: OptionalEventCallable):
+    def on_change(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("change", handler)
 
     # on_change_start
     @property
-    def on_change_start(self) -> OptionalEventCallable:
+    def on_change_start(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("change_start")
 
     @on_change_start.setter
-    def on_change_start(self, handler: OptionalEventCallable):
+    def on_change_start(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("change_start", handler)
 
     # on_change_end
     @property
-    def on_change_end(self) -> OptionalEventCallable:
+    def on_change_end(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("change_end")
 
     @on_change_end.setter
-    def on_change_end(self, handler: OptionalEventCallable):
+    def on_change_end(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("change_end", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/scrollable_control.py
+++ b/sdk/python/packages/flet-core/src/flet_core/scrollable_control.py
@@ -1,12 +1,12 @@
 import json
 import time
-from typing import Optional, Callable
+from typing import Optional
 
 from flet_core.animation import AnimationCurve
 from flet_core.control import Control, OptionalNumber
 from flet_core.control_event import ControlEvent
 from flet_core.event_handler import EventHandler
-from flet_core.types import ScrollMode
+from flet_core.types import ScrollMode, OptionalEventCallable
 from flet_core.utils import deprecated
 
 
@@ -17,7 +17,7 @@ class ScrollableControl(Control):
         auto_scroll: Optional[bool] = None,
         reverse: Optional[bool] = None,
         on_scroll_interval: OptionalNumber = None,
-        on_scroll: Optional[Callable[["OnScrollEvent"], None]] = None,
+        on_scroll: OptionalEventCallable["OnScrollEvent"] = None,
     ):
         self.__on_scroll = EventHandler(lambda e: OnScrollEvent(e))
         self._add_event_handler("onScroll", self.__on_scroll.get_handler())
@@ -117,7 +117,7 @@ class ScrollableControl(Control):
         return self.__on_scroll
 
     @on_scroll.setter
-    def on_scroll(self, handler: Optional[Callable[["OnScrollEvent"], None]]):
+    def on_scroll(self, handler: OptionalEventCallable["OnScrollEvent"]):
         self.__on_scroll.subscribe(handler)
         self._set_attr("onScroll", True if handler is not None else None)
 

--- a/sdk/python/packages/flet-core/src/flet_core/search_bar.py
+++ b/sdk/python/packages/flet-core/src/flet_core/search_bar.py
@@ -17,6 +17,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 from flet_core.utils import deprecated
 
@@ -409,30 +410,30 @@ class SearchBar(ConstrainedControl):
 
     # on_change
     @property
-    def on_change(self) -> OptionalEventCallable:
+    def on_change(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: OptionalEventCallable):
+    def on_change(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("change", handler)
         self._set_attr("onchange", True if handler is not None else None)
 
     # on_tap
     @property
-    def on_tap(self) -> OptionalEventCallable:
+    def on_tap(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("tap")
 
     @on_tap.setter
-    def on_tap(self, handler: OptionalEventCallable):
+    def on_tap(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("tap", handler)
         self._set_attr("ontap", True if handler is not None else None)
 
     # on_submit
     @property
-    def on_submit(self) -> OptionalEventCallable:
+    def on_submit(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("submit")
 
     @on_submit.setter
-    def on_submit(self, handler: OptionalEventCallable):
+    def on_submit(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("submit", handler)
         self._set_attr("onsubmit", True if handler is not None else None)

--- a/sdk/python/packages/flet-core/src/flet_core/search_bar.py
+++ b/sdk/python/packages/flet-core/src/flet_core/search_bar.py
@@ -17,7 +17,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 from flet_core.utils import deprecated
 
@@ -410,30 +410,30 @@ class SearchBar(ConstrainedControl):
 
     # on_change
     @property
-    def on_change(self) -> DefaultOptionalEventCallable:
+    def on_change(self) -> OptionalControlEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: DefaultOptionalEventCallable):
+    def on_change(self, handler: OptionalControlEventCallable):
         self._add_event_handler("change", handler)
         self._set_attr("onchange", True if handler is not None else None)
 
     # on_tap
     @property
-    def on_tap(self) -> DefaultOptionalEventCallable:
+    def on_tap(self) -> OptionalControlEventCallable:
         return self._get_event_handler("tap")
 
     @on_tap.setter
-    def on_tap(self, handler: DefaultOptionalEventCallable):
+    def on_tap(self, handler: OptionalControlEventCallable):
         self._add_event_handler("tap", handler)
         self._set_attr("ontap", True if handler is not None else None)
 
     # on_submit
     @property
-    def on_submit(self) -> DefaultOptionalEventCallable:
+    def on_submit(self) -> OptionalControlEventCallable:
         return self._get_event_handler("submit")
 
     @on_submit.setter
-    def on_submit(self, handler: DefaultOptionalEventCallable):
+    def on_submit(self, handler: OptionalControlEventCallable):
         self._add_event_handler("submit", handler)
         self._set_attr("onsubmit", True if handler is not None else None)

--- a/sdk/python/packages/flet-core/src/flet_core/segmented_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/segmented_button.py
@@ -12,7 +12,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -227,11 +227,11 @@ class SegmentedButton(ConstrainedControl):
 
     # on_change
     @property
-    def on_change(self) -> DefaultOptionalEventCallable:
+    def on_change(self) -> OptionalControlEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: DefaultOptionalEventCallable):
+    def on_change(self, handler: OptionalControlEventCallable):
         self._add_event_handler("change", handler)
 
     # segments

--- a/sdk/python/packages/flet-core/src/flet_core/segmented_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/segmented_button.py
@@ -12,6 +12,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 
 
@@ -226,11 +227,11 @@ class SegmentedButton(ConstrainedControl):
 
     # on_change
     @property
-    def on_change(self) -> OptionalEventCallable:
+    def on_change(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: OptionalEventCallable):
+    def on_change(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("change", handler)
 
     # segments

--- a/sdk/python/packages/flet-core/src/flet_core/selection_area.py
+++ b/sdk/python/packages/flet-core/src/flet_core/selection_area.py
@@ -2,7 +2,7 @@ from typing import Any, Optional
 
 from flet_core.control import Control
 from flet_core.ref import Ref
-from flet_core.types import OptionalEventCallable, DefaultOptionalEventCallable
+from flet_core.types import OptionalEventCallable, OptionalControlEventCallable
 
 
 class SelectionArea(Control):
@@ -66,9 +66,9 @@ class SelectionArea(Control):
 
     # on_change
     @property
-    def on_change(self) -> DefaultOptionalEventCallable:
+    def on_change(self) -> OptionalControlEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: DefaultOptionalEventCallable):
+    def on_change(self, handler: OptionalControlEventCallable):
         self._add_event_handler("change", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/selection_area.py
+++ b/sdk/python/packages/flet-core/src/flet_core/selection_area.py
@@ -1,8 +1,8 @@
 from typing import Any, Optional
 
-from flet_core.types import OptionalEventCallable
 from flet_core.control import Control
 from flet_core.ref import Ref
+from flet_core.types import OptionalEventCallable, DefaultOptionalEventCallable
 
 
 class SelectionArea(Control):
@@ -66,9 +66,9 @@ class SelectionArea(Control):
 
     # on_change
     @property
-    def on_change(self) -> OptionalEventCallable:
+    def on_change(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: OptionalEventCallable):
+    def on_change(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("change", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/semantics.py
+++ b/sdk/python/packages/flet-core/src/flet_core/semantics.py
@@ -2,7 +2,7 @@ from typing import Any, Optional
 
 from flet_core.control import Control, OptionalNumber
 from flet_core.ref import Ref
-from flet_core.types import OptionalEventCallable, DefaultOptionalEventCallable
+from flet_core.types import OptionalEventCallable, OptionalControlEventCallable
 
 
 class Semantics(Control):
@@ -389,131 +389,131 @@ class Semantics(Control):
 
     # on_tap
     @property
-    def on_tap(self) -> DefaultOptionalEventCallable:
+    def on_tap(self) -> OptionalControlEventCallable:
         return self._get_event_handler("tap")
 
     @on_tap.setter
-    def on_tap(self, handler: DefaultOptionalEventCallable):
+    def on_tap(self, handler: OptionalControlEventCallable):
         self._add_event_handler("tap", handler)
         self._set_attr("onTap", True if handler is not None else None)
 
     # on_double_tap
     @property
-    def on_double_tap(self) -> DefaultOptionalEventCallable:
+    def on_double_tap(self) -> OptionalControlEventCallable:
         return self._get_event_handler("double_tap")
 
     @on_double_tap.setter
-    def on_double_tap(self, handler: DefaultOptionalEventCallable):
+    def on_double_tap(self, handler: OptionalControlEventCallable):
         self._add_event_handler("double_tap", handler)
         self._set_attr("onDoubleTap", True if handler is not None else None)
 
     # on_increase
     @property
-    def on_increase(self) -> DefaultOptionalEventCallable:
+    def on_increase(self) -> OptionalControlEventCallable:
         return self._get_event_handler("increase")
 
     @on_increase.setter
-    def on_increase(self, handler: DefaultOptionalEventCallable):
+    def on_increase(self, handler: OptionalControlEventCallable):
         self._add_event_handler("increase", handler)
         self._set_attr("onIncrease", True if handler is not None else None)
 
     # on_decrease
     @property
-    def on_decrease(self) -> DefaultOptionalEventCallable:
+    def on_decrease(self) -> OptionalControlEventCallable:
         return self._get_event_handler("decrease")
 
     @on_decrease.setter
-    def on_decrease(self, handler: DefaultOptionalEventCallable):
+    def on_decrease(self, handler: OptionalControlEventCallable):
         self._add_event_handler("decrease", handler)
         self._set_attr("onDecrease", True if handler is not None else None)
 
     # on_dismiss
     @property
-    def on_dismiss(self) -> DefaultOptionalEventCallable:
+    def on_dismiss(self) -> OptionalControlEventCallable:
         return self._get_event_handler("dismiss")
 
     @on_dismiss.setter
-    def on_dismiss(self, handler: DefaultOptionalEventCallable):
+    def on_dismiss(self, handler: OptionalControlEventCallable):
         self._add_event_handler("dismiss", handler)
         self._set_attr("onDismiss", True if handler is not None else None)
 
     # on_scroll_left
     @property
-    def on_scroll_left(self) -> DefaultOptionalEventCallable:
+    def on_scroll_left(self) -> OptionalControlEventCallable:
         return self._get_event_handler("scroll_left")
 
     @on_scroll_left.setter
-    def on_scroll_left(self, handler: DefaultOptionalEventCallable):
+    def on_scroll_left(self, handler: OptionalControlEventCallable):
         self._add_event_handler("scroll_left", handler)
         self._set_attr("onScrollLeft", True if handler is not None else None)
 
     # on_scroll_right
     @property
-    def on_scroll_right(self) -> DefaultOptionalEventCallable:
+    def on_scroll_right(self) -> OptionalControlEventCallable:
         return self._get_event_handler("scroll_right")
 
     @on_scroll_right.setter
-    def on_scroll_right(self, handler: DefaultOptionalEventCallable):
+    def on_scroll_right(self, handler: OptionalControlEventCallable):
         self._add_event_handler("scroll_right", handler)
         self._set_attr("onScrollRight", True if handler is not None else None)
 
     # on_scroll_up
     @property
-    def on_scroll_up(self) -> DefaultOptionalEventCallable:
+    def on_scroll_up(self) -> OptionalControlEventCallable:
         return self._get_event_handler("scroll_up")
 
     @on_scroll_up.setter
-    def on_scroll_up(self, handler: DefaultOptionalEventCallable):
+    def on_scroll_up(self, handler: OptionalControlEventCallable):
         self._add_event_handler("scroll_up", handler)
         self._set_attr("onScrollUp", True if handler is not None else None)
 
     # on_scroll_down
     @property
-    def on_scroll_down(self) -> DefaultOptionalEventCallable:
+    def on_scroll_down(self) -> OptionalControlEventCallable:
         return self._get_event_handler("scroll_down")
 
     @on_scroll_down.setter
-    def on_scroll_down(self, handler: DefaultOptionalEventCallable):
+    def on_scroll_down(self, handler: OptionalControlEventCallable):
         self._add_event_handler("scroll_down", handler)
         self._set_attr("onScrollDown", True if handler is not None else None)
 
     # on_copy
     @property
-    def on_copy(self) -> DefaultOptionalEventCallable:
+    def on_copy(self) -> OptionalControlEventCallable:
         return self._get_event_handler("copy")
 
     @on_copy.setter
-    def on_copy(self, handler: DefaultOptionalEventCallable):
+    def on_copy(self, handler: OptionalControlEventCallable):
         self._add_event_handler("copy", handler)
         self._set_attr("onCopy", True if handler is not None else None)
 
     # on_cut
     @property
-    def on_cut(self) -> DefaultOptionalEventCallable:
+    def on_cut(self) -> OptionalControlEventCallable:
         return self._get_event_handler("cut")
 
     @on_cut.setter
-    def on_cut(self, handler: DefaultOptionalEventCallable):
+    def on_cut(self, handler: OptionalControlEventCallable):
         self._add_event_handler("cut", handler)
         self._set_attr("onCut", True if handler is not None else None)
 
     # on_paste
     @property
-    def on_paste(self) -> DefaultOptionalEventCallable:
+    def on_paste(self) -> OptionalControlEventCallable:
         return self._get_event_handler("paste")
 
     @on_paste.setter
-    def on_paste(self, handler: DefaultOptionalEventCallable):
+    def on_paste(self, handler: OptionalControlEventCallable):
         self._add_event_handler("paste", handler)
         self._set_attr("onPaste", True if handler is not None else None)
 
     # on_long_press
     @property
-    def on_long_press(self) -> DefaultOptionalEventCallable:
+    def on_long_press(self) -> OptionalControlEventCallable:
         return self._get_event_handler("long_press")
 
     @on_long_press.setter
-    def on_long_press(self, handler: DefaultOptionalEventCallable):
+    def on_long_press(self, handler: OptionalControlEventCallable):
         self._add_event_handler("long_press", handler)
         self._set_attr("onLongPress", True if handler is not None else None)
 
@@ -521,12 +521,12 @@ class Semantics(Control):
     @property
     def on_move_cursor_forward_by_character(
         self,
-    ) -> DefaultOptionalEventCallable:
+    ) -> OptionalControlEventCallable:
         return self._get_event_handler("move_cursor_forward_by_character")
 
     @on_move_cursor_forward_by_character.setter
     def on_move_cursor_forward_by_character(
-        self, handler: DefaultOptionalEventCallable
+        self, handler: OptionalControlEventCallable
     ):
         self._add_event_handler("move_cursor_forward_by_character", handler)
         self._set_attr(
@@ -537,12 +537,12 @@ class Semantics(Control):
     @property
     def on_move_cursor_backward_by_character(
         self,
-    ) -> DefaultOptionalEventCallable:
+    ) -> OptionalControlEventCallable:
         return self._get_event_handler("move_cursor_backward_by_character")
 
     @on_move_cursor_backward_by_character.setter
     def on_move_cursor_backward_by_character(
-        self, handler: DefaultOptionalEventCallable
+        self, handler: OptionalControlEventCallable
     ):
         self._add_event_handler("move_cursor_backward_by_character", handler)
         self._set_attr(
@@ -553,11 +553,11 @@ class Semantics(Control):
     @property
     def on_did_gain_accessibility_focus(
         self,
-    ) -> DefaultOptionalEventCallable:
+    ) -> OptionalControlEventCallable:
         return self._get_event_handler("did_gain_accessibility_focus")
 
     @on_did_gain_accessibility_focus.setter
-    def on_did_gain_accessibility_focus(self, handler: DefaultOptionalEventCallable):
+    def on_did_gain_accessibility_focus(self, handler: OptionalControlEventCallable):
         self._add_event_handler("did_gain_accessibility_focus", handler)
         self._set_attr(
             "onDidGainAccessibilityFocus", True if handler is not None else None
@@ -567,11 +567,11 @@ class Semantics(Control):
     @property
     def on_did_lose_accessibility_focus(
         self,
-    ) -> DefaultOptionalEventCallable:
+    ) -> OptionalControlEventCallable:
         return self._get_event_handler("did_lose_accessibility_focus")
 
     @on_did_lose_accessibility_focus.setter
-    def on_did_lose_accessibility_focus(self, handler: DefaultOptionalEventCallable):
+    def on_did_lose_accessibility_focus(self, handler: OptionalControlEventCallable):
         self._add_event_handler("did_lose_accessibility_focus", handler)
         self._set_attr(
             "onDidLoseAccessibilityFocus", True if handler is not None else None

--- a/sdk/python/packages/flet-core/src/flet_core/semantics.py
+++ b/sdk/python/packages/flet-core/src/flet_core/semantics.py
@@ -2,7 +2,7 @@ from typing import Any, Optional
 
 from flet_core.control import Control, OptionalNumber
 from flet_core.ref import Ref
-from flet_core.types import OptionalEventCallable
+from flet_core.types import OptionalEventCallable, DefaultOptionalEventCallable
 
 
 class Semantics(Control):
@@ -389,141 +389,145 @@ class Semantics(Control):
 
     # on_tap
     @property
-    def on_tap(self) -> OptionalEventCallable:
+    def on_tap(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("tap")
 
     @on_tap.setter
-    def on_tap(self, handler: OptionalEventCallable):
+    def on_tap(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("tap", handler)
         self._set_attr("onTap", True if handler is not None else None)
 
     # on_double_tap
     @property
-    def on_double_tap(self) -> OptionalEventCallable:
+    def on_double_tap(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("double_tap")
 
     @on_double_tap.setter
-    def on_double_tap(self, handler: OptionalEventCallable):
+    def on_double_tap(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("double_tap", handler)
         self._set_attr("onDoubleTap", True if handler is not None else None)
 
     # on_increase
     @property
-    def on_increase(self) -> OptionalEventCallable:
+    def on_increase(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("increase")
 
     @on_increase.setter
-    def on_increase(self, handler: OptionalEventCallable):
+    def on_increase(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("increase", handler)
         self._set_attr("onIncrease", True if handler is not None else None)
 
     # on_decrease
     @property
-    def on_decrease(self) -> OptionalEventCallable:
+    def on_decrease(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("decrease")
 
     @on_decrease.setter
-    def on_decrease(self, handler: OptionalEventCallable):
+    def on_decrease(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("decrease", handler)
         self._set_attr("onDecrease", True if handler is not None else None)
 
     # on_dismiss
     @property
-    def on_dismiss(self) -> OptionalEventCallable:
+    def on_dismiss(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("dismiss")
 
     @on_dismiss.setter
-    def on_dismiss(self, handler: OptionalEventCallable):
+    def on_dismiss(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("dismiss", handler)
         self._set_attr("onDismiss", True if handler is not None else None)
 
     # on_scroll_left
     @property
-    def on_scroll_left(self) -> OptionalEventCallable:
+    def on_scroll_left(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("scroll_left")
 
     @on_scroll_left.setter
-    def on_scroll_left(self, handler: OptionalEventCallable):
+    def on_scroll_left(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("scroll_left", handler)
         self._set_attr("onScrollLeft", True if handler is not None else None)
 
     # on_scroll_right
     @property
-    def on_scroll_right(self) -> OptionalEventCallable:
+    def on_scroll_right(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("scroll_right")
 
     @on_scroll_right.setter
-    def on_scroll_right(self, handler: OptionalEventCallable):
+    def on_scroll_right(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("scroll_right", handler)
         self._set_attr("onScrollRight", True if handler is not None else None)
 
     # on_scroll_up
     @property
-    def on_scroll_up(self) -> OptionalEventCallable:
+    def on_scroll_up(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("scroll_up")
 
     @on_scroll_up.setter
-    def on_scroll_up(self, handler: OptionalEventCallable):
+    def on_scroll_up(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("scroll_up", handler)
         self._set_attr("onScrollUp", True if handler is not None else None)
 
     # on_scroll_down
     @property
-    def on_scroll_down(self) -> OptionalEventCallable:
+    def on_scroll_down(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("scroll_down")
 
     @on_scroll_down.setter
-    def on_scroll_down(self, handler: OptionalEventCallable):
+    def on_scroll_down(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("scroll_down", handler)
         self._set_attr("onScrollDown", True if handler is not None else None)
 
     # on_copy
     @property
-    def on_copy(self) -> OptionalEventCallable:
+    def on_copy(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("copy")
 
     @on_copy.setter
-    def on_copy(self, handler: OptionalEventCallable):
+    def on_copy(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("copy", handler)
         self._set_attr("onCopy", True if handler is not None else None)
 
     # on_cut
     @property
-    def on_cut(self) -> OptionalEventCallable:
+    def on_cut(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("cut")
 
     @on_cut.setter
-    def on_cut(self, handler: OptionalEventCallable):
+    def on_cut(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("cut", handler)
         self._set_attr("onCut", True if handler is not None else None)
 
     # on_paste
     @property
-    def on_paste(self) -> OptionalEventCallable:
+    def on_paste(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("paste")
 
     @on_paste.setter
-    def on_paste(self, handler: OptionalEventCallable):
+    def on_paste(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("paste", handler)
         self._set_attr("onPaste", True if handler is not None else None)
 
     # on_long_press
     @property
-    def on_long_press(self) -> OptionalEventCallable:
+    def on_long_press(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("long_press")
 
     @on_long_press.setter
-    def on_long_press(self, handler: OptionalEventCallable):
+    def on_long_press(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("long_press", handler)
         self._set_attr("onLongPress", True if handler is not None else None)
 
     # on_move_cursor_forward_by_character
     @property
-    def on_move_cursor_forward_by_character(self) -> OptionalEventCallable:
+    def on_move_cursor_forward_by_character(
+        self,
+    ) -> DefaultOptionalEventCallable:
         return self._get_event_handler("move_cursor_forward_by_character")
 
     @on_move_cursor_forward_by_character.setter
-    def on_move_cursor_forward_by_character(self, handler: OptionalEventCallable):
+    def on_move_cursor_forward_by_character(
+        self, handler: DefaultOptionalEventCallable
+    ):
         self._add_event_handler("move_cursor_forward_by_character", handler)
         self._set_attr(
             "onMoveCursorForwardByCharacter", True if handler is not None else None
@@ -531,11 +535,15 @@ class Semantics(Control):
 
     # on_move_cursor_backward_by_character
     @property
-    def on_move_cursor_backward_by_character(self) -> OptionalEventCallable:
+    def on_move_cursor_backward_by_character(
+        self,
+    ) -> DefaultOptionalEventCallable:
         return self._get_event_handler("move_cursor_backward_by_character")
 
     @on_move_cursor_backward_by_character.setter
-    def on_move_cursor_backward_by_character(self, handler: OptionalEventCallable):
+    def on_move_cursor_backward_by_character(
+        self, handler: DefaultOptionalEventCallable
+    ):
         self._add_event_handler("move_cursor_backward_by_character", handler)
         self._set_attr(
             "onMoveCursorBackwardByCharacter", True if handler is not None else None
@@ -543,11 +551,13 @@ class Semantics(Control):
 
     # on_did_gain_accessibility_focus
     @property
-    def on_did_gain_accessibility_focus(self) -> OptionalEventCallable:
+    def on_did_gain_accessibility_focus(
+        self,
+    ) -> DefaultOptionalEventCallable:
         return self._get_event_handler("did_gain_accessibility_focus")
 
     @on_did_gain_accessibility_focus.setter
-    def on_did_gain_accessibility_focus(self, handler: OptionalEventCallable):
+    def on_did_gain_accessibility_focus(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("did_gain_accessibility_focus", handler)
         self._set_attr(
             "onDidGainAccessibilityFocus", True if handler is not None else None
@@ -555,11 +565,13 @@ class Semantics(Control):
 
     # on_did_lose_accessibility_focus
     @property
-    def on_did_lose_accessibility_focus(self) -> OptionalEventCallable:
+    def on_did_lose_accessibility_focus(
+        self,
+    ) -> DefaultOptionalEventCallable:
         return self._get_event_handler("did_lose_accessibility_focus")
 
     @on_did_lose_accessibility_focus.setter
-    def on_did_lose_accessibility_focus(self, handler: OptionalEventCallable):
+    def on_did_lose_accessibility_focus(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("did_lose_accessibility_focus", handler)
         self._set_attr(
             "onDidLoseAccessibilityFocus", True if handler is not None else None

--- a/sdk/python/packages/flet-core/src/flet_core/shake_detector.py
+++ b/sdk/python/packages/flet-core/src/flet_core/shake_detector.py
@@ -2,7 +2,7 @@ from typing import Any, Optional
 
 from flet_core.control import Control, OptionalNumber
 from flet_core.ref import Ref
-from flet_core.types import OptionalEventCallable
+from flet_core.types import OptionalEventCallable, DefaultOptionalEventCallable
 
 
 class ShakeDetector(Control):
@@ -40,7 +40,7 @@ class ShakeDetector(Control):
         shake_slop_time_ms: Optional[int] = None,
         shake_count_reset_time_ms: Optional[int] = None,
         shake_threshold_gravity: OptionalNumber = None,
-            on_shake: OptionalEventCallable = None,
+        on_shake: OptionalEventCallable = None,
         #
         # Control
         #
@@ -101,9 +101,9 @@ class ShakeDetector(Control):
 
     # on_shake
     @property
-    def on_shake(self) -> OptionalEventCallable:
+    def on_shake(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("shake")
 
     @on_shake.setter
-    def on_shake(self, handler: OptionalEventCallable):
+    def on_shake(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("shake", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/shake_detector.py
+++ b/sdk/python/packages/flet-core/src/flet_core/shake_detector.py
@@ -2,7 +2,7 @@ from typing import Any, Optional
 
 from flet_core.control import Control, OptionalNumber
 from flet_core.ref import Ref
-from flet_core.types import OptionalEventCallable, DefaultOptionalEventCallable
+from flet_core.types import OptionalEventCallable, OptionalControlEventCallable
 
 
 class ShakeDetector(Control):
@@ -101,9 +101,9 @@ class ShakeDetector(Control):
 
     # on_shake
     @property
-    def on_shake(self) -> DefaultOptionalEventCallable:
+    def on_shake(self) -> OptionalControlEventCallable:
         return self._get_event_handler("shake")
 
     @on_shake.setter
-    def on_shake(self, handler: DefaultOptionalEventCallable):
+    def on_shake(self, handler: OptionalControlEventCallable):
         self._add_event_handler("shake", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/slider.py
+++ b/sdk/python/packages/flet-core/src/flet_core/slider.py
@@ -14,6 +14,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 
 
@@ -311,45 +312,45 @@ class Slider(ConstrainedControl, AdaptiveControl):
 
     # on_change
     @property
-    def on_change(self) -> OptionalEventCallable:
+    def on_change(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: OptionalEventCallable):
+    def on_change(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("change", handler)
 
     # on_change_start
     @property
-    def on_change_start(self) -> OptionalEventCallable:
+    def on_change_start(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("change_start")
 
     @on_change_start.setter
-    def on_change_start(self, handler: OptionalEventCallable):
+    def on_change_start(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("change_start", handler)
 
     # on_change_end
     @property
-    def on_change_end(self) -> OptionalEventCallable:
+    def on_change_end(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("change_end")
 
     @on_change_end.setter
-    def on_change_end(self, handler: OptionalEventCallable):
+    def on_change_end(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("change_end", handler)
 
     # on_focus
     @property
-    def on_focus(self) -> OptionalEventCallable:
+    def on_focus(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("focus")
 
     @on_focus.setter
-    def on_focus(self, handler: OptionalEventCallable):
+    def on_focus(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("focus", handler)
 
     # on_blur
     @property
-    def on_blur(self) -> OptionalEventCallable:
+    def on_blur(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("blur")
 
     @on_blur.setter
-    def on_blur(self, handler: OptionalEventCallable):
+    def on_blur(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("blur", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/slider.py
+++ b/sdk/python/packages/flet-core/src/flet_core/slider.py
@@ -14,7 +14,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -312,45 +312,45 @@ class Slider(ConstrainedControl, AdaptiveControl):
 
     # on_change
     @property
-    def on_change(self) -> DefaultOptionalEventCallable:
+    def on_change(self) -> OptionalControlEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: DefaultOptionalEventCallable):
+    def on_change(self, handler: OptionalControlEventCallable):
         self._add_event_handler("change", handler)
 
     # on_change_start
     @property
-    def on_change_start(self) -> DefaultOptionalEventCallable:
+    def on_change_start(self) -> OptionalControlEventCallable:
         return self._get_event_handler("change_start")
 
     @on_change_start.setter
-    def on_change_start(self, handler: DefaultOptionalEventCallable):
+    def on_change_start(self, handler: OptionalControlEventCallable):
         self._add_event_handler("change_start", handler)
 
     # on_change_end
     @property
-    def on_change_end(self) -> DefaultOptionalEventCallable:
+    def on_change_end(self) -> OptionalControlEventCallable:
         return self._get_event_handler("change_end")
 
     @on_change_end.setter
-    def on_change_end(self, handler: DefaultOptionalEventCallable):
+    def on_change_end(self, handler: OptionalControlEventCallable):
         self._add_event_handler("change_end", handler)
 
     # on_focus
     @property
-    def on_focus(self) -> DefaultOptionalEventCallable:
+    def on_focus(self) -> OptionalControlEventCallable:
         return self._get_event_handler("focus")
 
     @on_focus.setter
-    def on_focus(self, handler: DefaultOptionalEventCallable):
+    def on_focus(self, handler: OptionalControlEventCallable):
         self._add_event_handler("focus", handler)
 
     # on_blur
     @property
-    def on_blur(self) -> DefaultOptionalEventCallable:
+    def on_blur(self) -> OptionalControlEventCallable:
         return self._get_event_handler("blur")
 
     @on_blur.setter
-    def on_blur(self, handler: DefaultOptionalEventCallable):
+    def on_blur(self, handler: OptionalControlEventCallable):
         self._add_event_handler("blur", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/snack_bar.py
+++ b/sdk/python/packages/flet-core/src/flet_core/snack_bar.py
@@ -10,6 +10,7 @@ from flet_core.types import (
     PaddingValue,
     ClipBehavior,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 
 
@@ -302,18 +303,18 @@ class SnackBar(Control):
 
     # on_action
     @property
-    def on_action(self) -> OptionalEventCallable:
+    def on_action(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("action")
 
     @on_action.setter
-    def on_action(self, handler: OptionalEventCallable):
+    def on_action(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("action", handler)
 
     # on_visible
     @property
-    def on_visible(self) -> OptionalEventCallable:
+    def on_visible(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("visible")
 
     @on_visible.setter
-    def on_visible(self, handler: OptionalEventCallable):
+    def on_visible(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("visible", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/snack_bar.py
+++ b/sdk/python/packages/flet-core/src/flet_core/snack_bar.py
@@ -10,7 +10,7 @@ from flet_core.types import (
     PaddingValue,
     ClipBehavior,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -303,18 +303,18 @@ class SnackBar(Control):
 
     # on_action
     @property
-    def on_action(self) -> DefaultOptionalEventCallable:
+    def on_action(self) -> OptionalControlEventCallable:
         return self._get_event_handler("action")
 
     @on_action.setter
-    def on_action(self, handler: DefaultOptionalEventCallable):
+    def on_action(self, handler: OptionalControlEventCallable):
         self._add_event_handler("action", handler)
 
     # on_visible
     @property
-    def on_visible(self) -> DefaultOptionalEventCallable:
+    def on_visible(self) -> OptionalControlEventCallable:
         return self._get_event_handler("visible")
 
     @on_visible.setter
-    def on_visible(self, handler: DefaultOptionalEventCallable):
+    def on_visible(self, handler: OptionalControlEventCallable):
         self._add_event_handler("visible", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/submenu_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/submenu_button.py
@@ -14,7 +14,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 from flet_core.utils import deprecated
 
@@ -241,7 +241,7 @@ class SubmenuButton(ConstrainedControl):
         return self._get_event_handler("open")
 
     @on_open.setter
-    def on_open(self, handler: DefaultOptionalEventCallable):
+    def on_open(self, handler: OptionalControlEventCallable):
         self._add_event_handler("open", handler)
         self._set_attr("onOpen", True if handler is not None else None)
 
@@ -251,7 +251,7 @@ class SubmenuButton(ConstrainedControl):
         return self._get_event_handler("close")
 
     @on_close.setter
-    def on_close(self, handler: DefaultOptionalEventCallable):
+    def on_close(self, handler: OptionalControlEventCallable):
         self._add_event_handler("close", handler)
         self._set_attr("onClose", True if handler is not None else None)
 
@@ -261,7 +261,7 @@ class SubmenuButton(ConstrainedControl):
         return self._get_event_handler("hover")
 
     @on_hover.setter
-    def on_hover(self, handler: DefaultOptionalEventCallable):
+    def on_hover(self, handler: OptionalControlEventCallable):
         self._add_event_handler("hover", handler)
         self._set_attr("onHover", True if handler is not None else None)
 
@@ -271,7 +271,7 @@ class SubmenuButton(ConstrainedControl):
         return self._get_event_handler("focus")
 
     @on_focus.setter
-    def on_focus(self, handler: DefaultOptionalEventCallable):
+    def on_focus(self, handler: OptionalControlEventCallable):
         self._add_event_handler("focus", handler)
 
     # on_blur
@@ -280,5 +280,5 @@ class SubmenuButton(ConstrainedControl):
         return self._get_event_handler("blur")
 
     @on_blur.setter
-    def on_blur(self, handler: DefaultOptionalEventCallable):
+    def on_blur(self, handler: OptionalControlEventCallable):
         self._add_event_handler("blur", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/submenu_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/submenu_button.py
@@ -14,6 +14,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 from flet_core.utils import deprecated
 
@@ -240,7 +241,7 @@ class SubmenuButton(ConstrainedControl):
         return self._get_event_handler("open")
 
     @on_open.setter
-    def on_open(self, handler: OptionalEventCallable):
+    def on_open(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("open", handler)
         self._set_attr("onOpen", True if handler is not None else None)
 
@@ -250,7 +251,7 @@ class SubmenuButton(ConstrainedControl):
         return self._get_event_handler("close")
 
     @on_close.setter
-    def on_close(self, handler: OptionalEventCallable):
+    def on_close(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("close", handler)
         self._set_attr("onClose", True if handler is not None else None)
 
@@ -260,7 +261,7 @@ class SubmenuButton(ConstrainedControl):
         return self._get_event_handler("hover")
 
     @on_hover.setter
-    def on_hover(self, handler: OptionalEventCallable):
+    def on_hover(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("hover", handler)
         self._set_attr("onHover", True if handler is not None else None)
 
@@ -270,7 +271,7 @@ class SubmenuButton(ConstrainedControl):
         return self._get_event_handler("focus")
 
     @on_focus.setter
-    def on_focus(self, handler: OptionalEventCallable):
+    def on_focus(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("focus", handler)
 
     # on_blur
@@ -279,5 +280,5 @@ class SubmenuButton(ConstrainedControl):
         return self._get_event_handler("blur")
 
     @on_blur.setter
-    def on_blur(self, handler: OptionalEventCallable):
+    def on_blur(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("blur", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/switch.py
+++ b/sdk/python/packages/flet-core/src/flet_core/switch.py
@@ -15,7 +15,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -343,27 +343,27 @@ class Switch(ConstrainedControl, AdaptiveControl):
 
     # on_change
     @property
-    def on_change(self) -> DefaultOptionalEventCallable:
+    def on_change(self) -> OptionalControlEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: DefaultOptionalEventCallable):
+    def on_change(self, handler: OptionalControlEventCallable):
         self._add_event_handler("change", handler)
 
     # on_focus
     @property
-    def on_focus(self) -> DefaultOptionalEventCallable:
+    def on_focus(self) -> OptionalControlEventCallable:
         return self._get_event_handler("focus")
 
     @on_focus.setter
-    def on_focus(self, handler: DefaultOptionalEventCallable):
+    def on_focus(self, handler: OptionalControlEventCallable):
         self._add_event_handler("focus", handler)
 
     # on_blur
     @property
-    def on_blur(self) -> DefaultOptionalEventCallable:
+    def on_blur(self) -> OptionalControlEventCallable:
         return self._get_event_handler("blur")
 
     @on_blur.setter
-    def on_blur(self, handler: DefaultOptionalEventCallable):
+    def on_blur(self, handler: OptionalControlEventCallable):
         self._add_event_handler("blur", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/switch.py
+++ b/sdk/python/packages/flet-core/src/flet_core/switch.py
@@ -15,6 +15,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 
 
@@ -73,9 +74,9 @@ class Switch(ConstrainedControl, AdaptiveControl):
         overlay_color: Union[None, str, Dict[ControlState, str]] = None,
         track_outline_color: Union[None, str, Dict[ControlState, str]] = None,
         mouse_cursor: Optional[MouseCursor] = None,
-            on_change: OptionalEventCallable = None,
-            on_focus: OptionalEventCallable = None,
-            on_blur: OptionalEventCallable = None,
+        on_change: OptionalEventCallable = None,
+        on_focus: OptionalEventCallable = None,
+        on_blur: OptionalEventCallable = None,
         #
         # ConstrainedControl
         #
@@ -101,7 +102,7 @@ class Switch(ConstrainedControl, AdaptiveControl):
         animate_rotation: AnimationValue = None,
         animate_scale: AnimationValue = None,
         animate_offset: AnimationValue = None,
-            on_animation_end: OptionalEventCallable = None,
+        on_animation_end: OptionalEventCallable = None,
         tooltip: Optional[str] = None,
         visible: Optional[bool] = None,
         disabled: Optional[bool] = None,
@@ -342,27 +343,27 @@ class Switch(ConstrainedControl, AdaptiveControl):
 
     # on_change
     @property
-    def on_change(self) -> OptionalEventCallable:
+    def on_change(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: OptionalEventCallable):
+    def on_change(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("change", handler)
 
     # on_focus
     @property
-    def on_focus(self) -> OptionalEventCallable:
+    def on_focus(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("focus")
 
     @on_focus.setter
-    def on_focus(self, handler: OptionalEventCallable):
+    def on_focus(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("focus", handler)
 
     # on_blur
     @property
-    def on_blur(self) -> OptionalEventCallable:
+    def on_blur(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("blur")
 
     @on_blur.setter
-    def on_blur(self, handler: OptionalEventCallable):
+    def on_blur(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("blur", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/tabs.py
+++ b/sdk/python/packages/flet-core/src/flet_core/tabs.py
@@ -18,6 +18,7 @@ from flet_core.types import (
     ScaleValue,
     TabAlignment,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 
 
@@ -273,11 +274,11 @@ class Tabs(ConstrainedControl, AdaptiveControl):
 
     # on_change
     @property
-    def on_change(self) -> OptionalEventCallable:
+    def on_change(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: OptionalEventCallable):
+    def on_change(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("change", handler)
 
     # selected_index

--- a/sdk/python/packages/flet-core/src/flet_core/tabs.py
+++ b/sdk/python/packages/flet-core/src/flet_core/tabs.py
@@ -18,7 +18,7 @@ from flet_core.types import (
     ScaleValue,
     TabAlignment,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -274,11 +274,11 @@ class Tabs(ConstrainedControl, AdaptiveControl):
 
     # on_change
     @property
-    def on_change(self) -> DefaultOptionalEventCallable:
+    def on_change(self) -> OptionalControlEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: DefaultOptionalEventCallable):
+    def on_change(self, handler: OptionalControlEventCallable):
         self._add_event_handler("change", handler)
 
     # selected_index

--- a/sdk/python/packages/flet-core/src/flet_core/text_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/text_button.py
@@ -14,7 +14,7 @@ from flet_core.types import (
     ScaleValue,
     UrlTarget,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 from flet_core.utils import deprecated
 
@@ -221,20 +221,20 @@ class TextButton(ConstrainedControl, AdaptiveControl):
 
     # on_click
     @property
-    def on_click(self) -> DefaultOptionalEventCallable:
+    def on_click(self) -> OptionalControlEventCallable:
         return self._get_event_handler("click")
 
     @on_click.setter
-    def on_click(self, handler: DefaultOptionalEventCallable):
+    def on_click(self, handler: OptionalControlEventCallable):
         self._add_event_handler("click", handler)
 
     # on_long_press
     @property
-    def on_long_press(self) -> DefaultOptionalEventCallable:
+    def on_long_press(self) -> OptionalControlEventCallable:
         return self._get_event_handler("long_press")
 
     @on_long_press.setter
-    def on_long_press(self, handler: DefaultOptionalEventCallable):
+    def on_long_press(self, handler: OptionalControlEventCallable):
         self._add_event_handler("long_press", handler)
         self._set_attr("onLongPress", True if handler is not None else None)
 
@@ -258,28 +258,28 @@ class TextButton(ConstrainedControl, AdaptiveControl):
 
     # on_hover
     @property
-    def on_hover(self) -> DefaultOptionalEventCallable:
+    def on_hover(self) -> OptionalControlEventCallable:
         return self._get_event_handler("hover")
 
     @on_hover.setter
-    def on_hover(self, handler: DefaultOptionalEventCallable):
+    def on_hover(self, handler: OptionalControlEventCallable):
         self._add_event_handler("hover", handler)
         self._set_attr("onHover", True if handler is not None else None)
 
     # on_focus
     @property
-    def on_focus(self) -> DefaultOptionalEventCallable:
+    def on_focus(self) -> OptionalControlEventCallable:
         return self._get_event_handler("focus")
 
     @on_focus.setter
-    def on_focus(self, handler: DefaultOptionalEventCallable):
+    def on_focus(self, handler: OptionalControlEventCallable):
         self._add_event_handler("focus", handler)
 
     # on_blur
     @property
-    def on_blur(self) -> DefaultOptionalEventCallable:
+    def on_blur(self) -> OptionalControlEventCallable:
         return self._get_event_handler("blur")
 
     @on_blur.setter
-    def on_blur(self, handler: DefaultOptionalEventCallable):
+    def on_blur(self, handler: OptionalControlEventCallable):
         self._add_event_handler("blur", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/text_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/text_button.py
@@ -14,6 +14,7 @@ from flet_core.types import (
     ScaleValue,
     UrlTarget,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 from flet_core.utils import deprecated
 
@@ -220,20 +221,20 @@ class TextButton(ConstrainedControl, AdaptiveControl):
 
     # on_click
     @property
-    def on_click(self) -> OptionalEventCallable:
+    def on_click(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("click")
 
     @on_click.setter
-    def on_click(self, handler: OptionalEventCallable):
+    def on_click(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("click", handler)
 
     # on_long_press
     @property
-    def on_long_press(self) -> OptionalEventCallable:
+    def on_long_press(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("long_press")
 
     @on_long_press.setter
-    def on_long_press(self, handler: OptionalEventCallable):
+    def on_long_press(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("long_press", handler)
         self._set_attr("onLongPress", True if handler is not None else None)
 
@@ -257,28 +258,28 @@ class TextButton(ConstrainedControl, AdaptiveControl):
 
     # on_hover
     @property
-    def on_hover(self) -> OptionalEventCallable:
+    def on_hover(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("hover")
 
     @on_hover.setter
-    def on_hover(self, handler: OptionalEventCallable):
+    def on_hover(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("hover", handler)
         self._set_attr("onHover", True if handler is not None else None)
 
     # on_focus
     @property
-    def on_focus(self) -> OptionalEventCallable:
+    def on_focus(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("focus")
 
     @on_focus.setter
-    def on_focus(self, handler: OptionalEventCallable):
+    def on_focus(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("focus", handler)
 
     # on_blur
     @property
-    def on_blur(self) -> OptionalEventCallable:
+    def on_blur(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("blur")
 
     @on_blur.setter
-    def on_blur(self, handler: OptionalEventCallable):
+    def on_blur(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("blur", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/text_span.py
+++ b/sdk/python/packages/flet-core/src/flet_core/text_span.py
@@ -2,7 +2,11 @@ from typing import Any, List, Optional
 
 from flet_core.inline_span import InlineSpan
 from flet_core.text_style import TextStyle
-from flet_core.types import UrlTarget, OptionalEventCallable
+from flet_core.types import (
+    UrlTarget,
+    OptionalEventCallable,
+    DefaultOptionalEventCallable,
+)
 
 
 class TextSpan(InlineSpan):
@@ -95,30 +99,30 @@ class TextSpan(InlineSpan):
 
     # on_click
     @property
-    def on_click(self) -> OptionalEventCallable:
+    def on_click(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("click")
 
     @on_click.setter
-    def on_click(self, handler: OptionalEventCallable):
+    def on_click(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("click", handler)
         self._set_attr("onClick", True if handler is not None else None)
 
     # on_enter
     @property
-    def on_enter(self) -> OptionalEventCallable:
+    def on_enter(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("enter")
 
     @on_enter.setter
-    def on_enter(self, handler: OptionalEventCallable):
+    def on_enter(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("enter", handler)
         self._set_attr("onEnter", True if handler is not None else None)
 
     # on_exit
     @property
-    def on_exit(self) -> OptionalEventCallable:
+    def on_exit(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("exit")
 
     @on_exit.setter
-    def on_exit(self, handler: OptionalEventCallable):
+    def on_exit(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("exit", handler)
         self._set_attr("onExit", True if handler is not None else None)

--- a/sdk/python/packages/flet-core/src/flet_core/text_span.py
+++ b/sdk/python/packages/flet-core/src/flet_core/text_span.py
@@ -5,7 +5,7 @@ from flet_core.text_style import TextStyle
 from flet_core.types import (
     UrlTarget,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -99,30 +99,30 @@ class TextSpan(InlineSpan):
 
     # on_click
     @property
-    def on_click(self) -> DefaultOptionalEventCallable:
+    def on_click(self) -> OptionalControlEventCallable:
         return self._get_event_handler("click")
 
     @on_click.setter
-    def on_click(self, handler: DefaultOptionalEventCallable):
+    def on_click(self, handler: OptionalControlEventCallable):
         self._add_event_handler("click", handler)
         self._set_attr("onClick", True if handler is not None else None)
 
     # on_enter
     @property
-    def on_enter(self) -> DefaultOptionalEventCallable:
+    def on_enter(self) -> OptionalControlEventCallable:
         return self._get_event_handler("enter")
 
     @on_enter.setter
-    def on_enter(self, handler: DefaultOptionalEventCallable):
+    def on_enter(self, handler: OptionalControlEventCallable):
         self._add_event_handler("enter", handler)
         self._set_attr("onEnter", True if handler is not None else None)
 
     # on_exit
     @property
-    def on_exit(self) -> DefaultOptionalEventCallable:
+    def on_exit(self) -> OptionalControlEventCallable:
         return self._get_event_handler("exit")
 
     @on_exit.setter
-    def on_exit(self, handler: DefaultOptionalEventCallable):
+    def on_exit(self, handler: OptionalControlEventCallable):
         self._add_event_handler("exit", handler)
         self._set_attr("onExit", True if handler is not None else None)

--- a/sdk/python/packages/flet-core/src/flet_core/textfield.py
+++ b/sdk/python/packages/flet-core/src/flet_core/textfield.py
@@ -21,7 +21,7 @@ from flet_core.types import (
     TextAlign,
     VerticalAlignment,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 from flet_core.utils import deprecated
 
@@ -582,33 +582,33 @@ class TextField(FormFieldControl, AdaptiveControl):
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: DefaultOptionalEventCallable):
+    def on_change(self, handler: OptionalControlEventCallable):
         self._add_event_handler("change", handler)
         self._set_attr("onChange", True if handler is not None else None)
 
     # on_submit
     @property
-    def on_submit(self) -> DefaultOptionalEventCallable:
+    def on_submit(self) -> OptionalControlEventCallable:
         return self._get_event_handler("submit")
 
     @on_submit.setter
-    def on_submit(self, handler: DefaultOptionalEventCallable):
+    def on_submit(self, handler: OptionalControlEventCallable):
         self._add_event_handler("submit", handler)
 
     # on_focus
     @property
-    def on_focus(self) -> DefaultOptionalEventCallable:
+    def on_focus(self) -> OptionalControlEventCallable:
         return self._get_event_handler("focus")
 
     @on_focus.setter
-    def on_focus(self, handler: DefaultOptionalEventCallable):
+    def on_focus(self, handler: OptionalControlEventCallable):
         self._add_event_handler("focus", handler)
 
     # on_blur
     @property
-    def on_blur(self) -> DefaultOptionalEventCallable:
+    def on_blur(self) -> OptionalControlEventCallable:
         return self._get_event_handler("blur")
 
     @on_blur.setter
-    def on_blur(self, handler: DefaultOptionalEventCallable):
+    def on_blur(self, handler: OptionalControlEventCallable):
         self._add_event_handler("blur", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/textfield.py
+++ b/sdk/python/packages/flet-core/src/flet_core/textfield.py
@@ -21,6 +21,7 @@ from flet_core.types import (
     TextAlign,
     VerticalAlignment,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 from flet_core.utils import deprecated
 
@@ -581,33 +582,33 @@ class TextField(FormFieldControl, AdaptiveControl):
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: OptionalEventCallable):
+    def on_change(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("change", handler)
         self._set_attr("onChange", True if handler is not None else None)
 
     # on_submit
     @property
-    def on_submit(self) -> OptionalEventCallable:
+    def on_submit(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("submit")
 
     @on_submit.setter
-    def on_submit(self, handler: OptionalEventCallable):
+    def on_submit(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("submit", handler)
 
     # on_focus
     @property
-    def on_focus(self) -> OptionalEventCallable:
+    def on_focus(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("focus")
 
     @on_focus.setter
-    def on_focus(self, handler: OptionalEventCallable):
+    def on_focus(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("focus", handler)
 
     # on_blur
     @property
-    def on_blur(self) -> OptionalEventCallable:
+    def on_blur(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("blur")
 
     @on_blur.setter
-    def on_blur(self, handler: OptionalEventCallable):
+    def on_blur(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("blur", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/time_picker.py
+++ b/sdk/python/packages/flet-core/src/flet_core/time_picker.py
@@ -6,7 +6,12 @@ from flet_core import ControlEvent
 from flet_core.control import Control, OptionalNumber
 from flet_core.event_handler import EventHandler
 from flet_core.ref import Ref
-from flet_core.types import Orientation, ResponsiveNumber, OptionalEventCallable
+from flet_core.types import (
+    Orientation,
+    ResponsiveNumber,
+    OptionalEventCallable,
+    DefaultOptionalEventCallable,
+)
 from flet_core.utils import deprecated
 
 
@@ -261,20 +266,20 @@ class TimePicker(Control):
 
     # on_change
     @property
-    def on_change(self) -> OptionalEventCallable:
+    def on_change(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: OptionalEventCallable):
+    def on_change(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("change", handler)
 
     # on_dismiss
     @property
-    def on_dismiss(self) -> OptionalEventCallable:
+    def on_dismiss(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("dismiss")
 
     @on_dismiss.setter
-    def on_dismiss(self, handler: OptionalEventCallable):
+    def on_dismiss(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("dismiss", handler)
 
     # on_entry_mode_change

--- a/sdk/python/packages/flet-core/src/flet_core/time_picker.py
+++ b/sdk/python/packages/flet-core/src/flet_core/time_picker.py
@@ -10,7 +10,7 @@ from flet_core.types import (
     Orientation,
     ResponsiveNumber,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 from flet_core.utils import deprecated
 
@@ -266,20 +266,20 @@ class TimePicker(Control):
 
     # on_change
     @property
-    def on_change(self) -> DefaultOptionalEventCallable:
+    def on_change(self) -> OptionalControlEventCallable:
         return self._get_event_handler("change")
 
     @on_change.setter
-    def on_change(self, handler: DefaultOptionalEventCallable):
+    def on_change(self, handler: OptionalControlEventCallable):
         self._add_event_handler("change", handler)
 
     # on_dismiss
     @property
-    def on_dismiss(self) -> DefaultOptionalEventCallable:
+    def on_dismiss(self) -> OptionalControlEventCallable:
         return self._get_event_handler("dismiss")
 
     @on_dismiss.setter
-    def on_dismiss(self, handler: DefaultOptionalEventCallable):
+    def on_dismiss(self, handler: OptionalControlEventCallable):
         self._add_event_handler("dismiss", handler)
 
     # on_entry_mode_change

--- a/sdk/python/packages/flet-core/src/flet_core/types.py
+++ b/sdk/python/packages/flet-core/src/flet_core/types.py
@@ -1,5 +1,14 @@
 from enum import Enum, EnumMeta
-from typing import Any, Callable, Coroutine, Dict, Optional, Protocol, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Optional,
+    Protocol,
+    Tuple,
+    TypeVar,
+    Union,
+)
 from warnings import warn
 
 from flet_core.animation import Animation
@@ -393,8 +402,11 @@ class VisualDensity(Enum):
 
 
 # Events
-EventCallable = Callable[[ControlEvent], Union[None, Coroutine[None, None, None]]]
+ControlEventType = TypeVar("ControlEventType", bound=ControlEvent)
+EventCallable = Callable[[ControlEventType], Any]
 OptionalEventCallable = Optional[EventCallable]
+DefaultOptionalEventCallable = OptionalEventCallable[ControlEvent]
+
 
 # Wrapper
 Wrapper = Callable[..., Any]

--- a/sdk/python/packages/flet-core/src/flet_core/types.py
+++ b/sdk/python/packages/flet-core/src/flet_core/types.py
@@ -405,7 +405,7 @@ class VisualDensity(Enum):
 ControlEventType = TypeVar("ControlEventType", bound=ControlEvent)
 EventCallable = Callable[[ControlEventType], Any]
 OptionalEventCallable = Optional[EventCallable]
-DefaultOptionalEventCallable = OptionalEventCallable[ControlEvent]
+OptionalControlEventCallable = OptionalEventCallable[ControlEvent]
 
 
 # Wrapper

--- a/sdk/python/packages/flet-core/src/flet_core/types.py
+++ b/sdk/python/packages/flet-core/src/flet_core/types.py
@@ -1,5 +1,5 @@
 from enum import Enum, EnumMeta
-from typing import Any, Callable, Dict, Optional, Protocol, Tuple, Union
+from typing import Any, Callable, Coroutine, Dict, Optional, Protocol, Tuple, Union
 from warnings import warn
 
 from flet_core.animation import Animation
@@ -393,7 +393,8 @@ class VisualDensity(Enum):
 
 
 # Events
-OptionalEventCallable = Optional[Callable[[ControlEvent], None]]
+EventCallable = Callable[[ControlEvent], Union[None, Coroutine[None, None, None]]]
+OptionalEventCallable = Optional[EventCallable]
 
 # Wrapper
 Wrapper = Callable[..., Any]

--- a/sdk/python/packages/flet-core/src/flet_core/video.py
+++ b/sdk/python/packages/flet-core/src/flet_core/video.py
@@ -17,7 +17,7 @@ from flet_core.types import (
     ScaleValue,
     TextAlign,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 from flet_core.utils import deprecated
 
@@ -560,36 +560,36 @@ class Video(ConstrainedControl):
         return self._get_event_handler("enter_fullscreen")
 
     @on_enter_fullscreen.setter
-    def on_enter_fullscreen(self, handler: DefaultOptionalEventCallable):
+    def on_enter_fullscreen(self, handler: OptionalControlEventCallable):
         self._add_event_handler("enter_fullscreen", handler)
         self._set_attr("onEnterFullscreen", True if handler is not None else None)
 
     # on_exit_fullscreen
     @property
-    def on_exit_fullscreen(self) -> DefaultOptionalEventCallable:
+    def on_exit_fullscreen(self) -> OptionalControlEventCallable:
         return self._get_event_handler("exit_fullscreen")
 
     @on_exit_fullscreen.setter
-    def on_exit_fullscreen(self, handler: DefaultOptionalEventCallable):
+    def on_exit_fullscreen(self, handler: OptionalControlEventCallable):
         self._add_event_handler("exit_fullscreen", handler)
         self._set_attr("onExitFullscreen", True if handler is not None else None)
 
     # on_loaded
     @property
-    def on_loaded(self) -> DefaultOptionalEventCallable:
+    def on_loaded(self) -> OptionalControlEventCallable:
         return self._get_event_handler("loaded")
 
     @on_loaded.setter
-    def on_loaded(self, handler: DefaultOptionalEventCallable):
+    def on_loaded(self, handler: OptionalControlEventCallable):
         self._set_attr("onLoaded", True if handler is not None else None)
         self._add_event_handler("loaded", handler)
 
     # on_error
     @property
-    def on_error(self) -> DefaultOptionalEventCallable:
+    def on_error(self) -> OptionalControlEventCallable:
         return self._get_event_handler("error")
 
     @on_error.setter
-    def on_error(self, handler: DefaultOptionalEventCallable):
+    def on_error(self, handler: OptionalControlEventCallable):
         self._set_attr("onError", True if handler is not None else None)
         self._add_event_handler("error", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/video.py
+++ b/sdk/python/packages/flet-core/src/flet_core/video.py
@@ -17,6 +17,7 @@ from flet_core.types import (
     ScaleValue,
     TextAlign,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 from flet_core.utils import deprecated
 
@@ -559,36 +560,36 @@ class Video(ConstrainedControl):
         return self._get_event_handler("enter_fullscreen")
 
     @on_enter_fullscreen.setter
-    def on_enter_fullscreen(self, handler: OptionalEventCallable):
+    def on_enter_fullscreen(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("enter_fullscreen", handler)
         self._set_attr("onEnterFullscreen", True if handler is not None else None)
 
     # on_exit_fullscreen
     @property
-    def on_exit_fullscreen(self) -> OptionalEventCallable:
+    def on_exit_fullscreen(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("exit_fullscreen")
 
     @on_exit_fullscreen.setter
-    def on_exit_fullscreen(self, handler: OptionalEventCallable):
+    def on_exit_fullscreen(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("exit_fullscreen", handler)
         self._set_attr("onExitFullscreen", True if handler is not None else None)
 
     # on_loaded
     @property
-    def on_loaded(self) -> OptionalEventCallable:
+    def on_loaded(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("loaded")
 
     @on_loaded.setter
-    def on_loaded(self, handler: OptionalEventCallable):
+    def on_loaded(self, handler: DefaultOptionalEventCallable):
         self._set_attr("onLoaded", True if handler is not None else None)
         self._add_event_handler("loaded", handler)
 
     # on_error
     @property
-    def on_error(self) -> OptionalEventCallable:
+    def on_error(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("error")
 
     @on_error.setter
-    def on_error(self, handler: OptionalEventCallable):
+    def on_error(self, handler: DefaultOptionalEventCallable):
         self._set_attr("onError", True if handler is not None else None)
         self._add_event_handler("error", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/webview.py
+++ b/sdk/python/packages/flet-core/src/flet_core/webview.py
@@ -10,6 +10,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
+    DefaultOptionalEventCallable,
 )
 
 
@@ -193,27 +194,27 @@ class WebView(ConstrainedControl):
 
     # on_page_started
     @property
-    def on_page_started(self) -> OptionalEventCallable:
+    def on_page_started(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("page_started")
 
     @on_page_started.setter
-    def on_page_started(self, handler: OptionalEventCallable):
+    def on_page_started(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("page_started", handler)
 
     # on_page_ended
     @property
-    def on_page_ended(self) -> OptionalEventCallable:
+    def on_page_ended(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("page_ended")
 
     @on_page_ended.setter
-    def on_page_ended(self, handler: OptionalEventCallable):
+    def on_page_ended(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("page_ended", handler)
 
     # on_web_resource_error
     @property
-    def on_web_resource_error(self) -> OptionalEventCallable:
+    def on_web_resource_error(self) -> DefaultOptionalEventCallable:
         return self._get_event_handler("web_resource_error")
 
     @on_web_resource_error.setter
-    def on_web_resource_error(self, handler: OptionalEventCallable):
+    def on_web_resource_error(self, handler: DefaultOptionalEventCallable):
         self._add_event_handler("web_resource_error", handler)

--- a/sdk/python/packages/flet-core/src/flet_core/webview.py
+++ b/sdk/python/packages/flet-core/src/flet_core/webview.py
@@ -10,7 +10,7 @@ from flet_core.types import (
     RotateValue,
     ScaleValue,
     OptionalEventCallable,
-    DefaultOptionalEventCallable,
+    OptionalControlEventCallable,
 )
 
 
@@ -194,27 +194,27 @@ class WebView(ConstrainedControl):
 
     # on_page_started
     @property
-    def on_page_started(self) -> DefaultOptionalEventCallable:
+    def on_page_started(self) -> OptionalControlEventCallable:
         return self._get_event_handler("page_started")
 
     @on_page_started.setter
-    def on_page_started(self, handler: DefaultOptionalEventCallable):
+    def on_page_started(self, handler: OptionalControlEventCallable):
         self._add_event_handler("page_started", handler)
 
     # on_page_ended
     @property
-    def on_page_ended(self) -> DefaultOptionalEventCallable:
+    def on_page_ended(self) -> OptionalControlEventCallable:
         return self._get_event_handler("page_ended")
 
     @on_page_ended.setter
-    def on_page_ended(self, handler: DefaultOptionalEventCallable):
+    def on_page_ended(self, handler: OptionalControlEventCallable):
         self._add_event_handler("page_ended", handler)
 
     # on_web_resource_error
     @property
-    def on_web_resource_error(self) -> DefaultOptionalEventCallable:
+    def on_web_resource_error(self) -> OptionalControlEventCallable:
         return self._get_event_handler("web_resource_error")
 
     @on_web_resource_error.setter
-    def on_web_resource_error(self, handler: DefaultOptionalEventCallable):
+    def on_web_resource_error(self, handler: OptionalControlEventCallable):
         self._add_event_handler("web_resource_error", handler)


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
The current annotation is only correct for synchronous functions.  
I will replace `Callable[[ControlEvent], None]]` with `Callable[[ControlEvent], Union[None, Coroutine[None, None, None]]]` to support asynchronous functions.

<!-- If it fixes an open issue, please link to the issue here. -->


## Test Code

```python
import flet as ft


async def demo(e):
    pass


ft.TextButton("Hello, World!", on_click=demo)
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I signed the CLA.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
<!-- - [ ] I have added tests that prove my fix is effective or that my feature works as expected -->

- [x] New and existing tests pass locally with my changes
- [x] I have made corresponding changes to the [documentation](https://github.com/flet-dev/website) (if applicable)


## Additional details

<!-- Add any other context to be known about this PR. -->
