### PR TITLE
[Typing] Using Sequence instead of list

### DIFF
--- a/sdk/python/packages/flet-core/src/flet_core/column.py
+++ b/sdk/python/packages/flet-core/src/flet_core/column.py
@@ -145,7 +145,7 @@ class Column(ConstrainedControl, ScrollableControl, AdaptiveControl):
 
         AdaptiveControl.__init__(self, adaptive=adaptive)
 
-        self.controls = list(controls) if controls is not None else None
+        self.controls = controls
         self.horizontal_alignment = horizontal_alignment
         self.alignment = alignment
         self.spacing = spacing
@@ -236,5 +236,5 @@ class Column(ConstrainedControl, ScrollableControl, AdaptiveControl):
         return self.__controls
 
     @controls.setter
-    def controls(self, value: Optional[List[Control]]):
-        self.__controls = value if value is not None else []
+    def controls(self, value: Optional[Sequence[Control]]):
+        self.__controls = list (value) if value is not None else []

--- a/sdk/python/packages/flet-core/src/flet_core/column.py
+++ b/sdk/python/packages/flet-core/src/flet_core/column.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Union, Callable
+from typing import Any, List, Optional, Sequence, Union, Callable
 
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.constrained_control import ConstrainedControl
@@ -58,7 +58,7 @@ class Column(ConstrainedControl, ScrollableControl, AdaptiveControl):
 
     def __init__(
         self,
-        controls: Optional[List[Control]] = None,
+        controls: Optional[Sequence[Control]] = None,
         alignment: Optional[MainAxisAlignment] = None,
         horizontal_alignment: Optional[CrossAxisAlignment] = None,
         spacing: OptionalNumber = None,
@@ -145,7 +145,7 @@ class Column(ConstrainedControl, ScrollableControl, AdaptiveControl):
 
         AdaptiveControl.__init__(self, adaptive=adaptive)
 
-        self.controls = controls
+        self.controls = list(controls) if controls is not None else None
         self.horizontal_alignment = horizontal_alignment
         self.alignment = alignment
         self.spacing = spacing

--- a/sdk/python/packages/flet-core/src/flet_core/column.py
+++ b/sdk/python/packages/flet-core/src/flet_core/column.py
@@ -237,4 +237,4 @@ class Column(ConstrainedControl, ScrollableControl, AdaptiveControl):
 
     @controls.setter
     def controls(self, value: Optional[Sequence[Control]]):
-        self.__controls = list (value) if value is not None else []
+        self.__controls = list(value) if value is not None else []

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_picker.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_picker.py
@@ -105,7 +105,7 @@ class CupertinoPicker(ConstrainedControl):
         self.off_axis_fraction = off_axis_fraction
         self.use_magnifier = use_magnifier
         self.item_extent = item_extent
-        self.controls = list(controls)
+        self.controls = controls
         self.looping = looping
         self.selected_index = selected_index
 
@@ -209,8 +209,8 @@ class CupertinoPicker(ConstrainedControl):
         return self.__controls
 
     @controls.setter
-    def controls(self, value: Optional[List[Control]]):
-        self.__controls = value if value is not None else []
+    def controls(self, value: Optional[Sequence[Control]]):
+        self.__controls = list (value) if value is not None else []
 
     # on_change
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_picker.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_picker.py
@@ -210,7 +210,7 @@ class CupertinoPicker(ConstrainedControl):
 
     @controls.setter
     def controls(self, value: Optional[Sequence[Control]]):
-        self.__controls = list (value) if value is not None else []
+        self.__controls = list(value) if value is not None else []
 
     # on_change
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_picker.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_picker.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional, Sequence, Union
 
 from flet_core.constrained_control import ConstrainedControl
 from flet_core.control import Control, OptionalNumber
@@ -24,7 +24,7 @@ class CupertinoPicker(ConstrainedControl):
 
     def __init__(
         self,
-        controls: List[Control],
+        controls: Sequence[Control],
         item_extent: OptionalNumber = None,
         selected_index: Optional[int] = None,
         bgcolor: Optional[str] = None,
@@ -105,7 +105,7 @@ class CupertinoPicker(ConstrainedControl):
         self.off_axis_fraction = off_axis_fraction
         self.use_magnifier = use_magnifier
         self.item_extent = item_extent
-        self.controls = controls
+        self.controls = list(controls)
         self.looping = looping
         self.selected_index = selected_index
 

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_picker.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_picker.py
@@ -209,8 +209,8 @@ class CupertinoPicker(ConstrainedControl):
         return self.__controls
 
     @controls.setter
-    def controls(self, value: Optional[Sequence[Control]]):
-        self.__controls = list(value) if value is not None else []
+    def controls(self, value: Sequence[Control]):
+        self.__controls = list(value)
 
     # on_change
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_segmented_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_segmented_button.py
@@ -94,7 +94,7 @@ class CupertinoSegmentedButton(ConstrainedControl):
             disabled=disabled,
             data=data,
         )
-        self.controls = list(controls)
+        self.controls = controls
         self.padding = padding
         self.border_color = border_color
         self.selected_index = selected_index

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_segmented_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_segmented_button.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Union, List
+from typing import Any, Optional, Sequence, Union, List
 
 from flet_core.constrained_control import ConstrainedControl
 from flet_core.control import OptionalNumber, Control
@@ -25,7 +25,7 @@ class CupertinoSegmentedButton(ConstrainedControl):
 
     def __init__(
         self,
-        controls: List[Control],
+        controls: Sequence[Control],
         selected_index: Optional[int] = None,
         selected_color: Optional[str] = None,
         unselected_color: Optional[str] = None,
@@ -94,7 +94,7 @@ class CupertinoSegmentedButton(ConstrainedControl):
             disabled=disabled,
             data=data,
         )
-        self.controls = controls
+        self.controls = list(controls)
         self.padding = padding
         self.border_color = border_color
         self.selected_index = selected_index

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_segmented_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_segmented_button.py
@@ -125,8 +125,8 @@ class CupertinoSegmentedButton(ConstrainedControl):
         return self.__controls
 
     @controls.setter
-    def controls(self, value: List[Control]):
-        self.__controls = value
+    def controls(self, value: Optional[Sequence[Control]]):
+        self.__controls = list(value) if value is not None else []
 
     # border_color
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_segmented_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_segmented_button.py
@@ -125,8 +125,8 @@ class CupertinoSegmentedButton(ConstrainedControl):
         return self.__controls
 
     @controls.setter
-    def controls(self, value: Optional[Sequence[Control]]):
-        self.__controls = list(value) if value is not None else []
+    def controls(self, value: Sequence[Control]):
+        self.__controls = list(value)
 
     # border_color
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_sliding_segmented_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_sliding_segmented_button.py
@@ -91,7 +91,7 @@ class CupertinoSlidingSegmentedButton(ConstrainedControl):
             disabled=disabled,
             data=data,
         )
-        self.controls = list(controls)
+        self.controls = controls
         self.padding = padding
         self.selected_index = selected_index
         self.bgcolor = bgcolor

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_sliding_segmented_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_sliding_segmented_button.py
@@ -117,8 +117,8 @@ class CupertinoSlidingSegmentedButton(ConstrainedControl):
         return self.__controls
 
     @controls.setter
-    def controls(self, value: List[Control]):
-        self.__controls = value
+    def controls(self, value: Optional[Sequence[Control]]):
+        self.__controls = list(value) if value is not None else []
 
     # selected_index
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_sliding_segmented_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_sliding_segmented_button.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Union, List
+from typing import Any, Optional, Sequence, Union, List
 
 from flet_core.constrained_control import ConstrainedControl
 from flet_core.control import OptionalNumber, Control
@@ -24,7 +24,7 @@ class CupertinoSlidingSegmentedButton(ConstrainedControl):
 
     def __init__(
         self,
-        controls: List[Control],
+        controls: Sequence[Control],
         selected_index: Optional[int] = None,
         bgcolor: Optional[str] = None,
         thumb_color: Optional[str] = None,
@@ -91,7 +91,7 @@ class CupertinoSlidingSegmentedButton(ConstrainedControl):
             disabled=disabled,
             data=data,
         )
-        self.controls = controls
+        self.controls = list(controls)
         self.padding = padding
         self.selected_index = selected_index
         self.bgcolor = bgcolor

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_sliding_segmented_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_sliding_segmented_button.py
@@ -117,8 +117,8 @@ class CupertinoSlidingSegmentedButton(ConstrainedControl):
         return self.__controls
 
     @controls.setter
-    def controls(self, value: Optional[Sequence[Control]]):
-        self.__controls = list(value) if value is not None else []
+    def controls(self, value: Sequence[Control]):
+        self.__controls = list(value)
 
     # selected_index
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/expansion_panel.py
+++ b/sdk/python/packages/flet-core/src/flet_core/expansion_panel.py
@@ -317,8 +317,8 @@ class ExpansionPanelList(ConstrainedControl):
         return self.__controls
 
     @controls.setter
-    def controls(self, value: Optional[List[ExpansionPanel]]):
-        self.__controls = value if value is not None else []
+    def controls(self, value: Optional[Sequence[ExpansionPanel]]):
+        self.__controls = list (value) if value is not None else []
 
     # on_change
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/expansion_panel.py
+++ b/sdk/python/packages/flet-core/src/flet_core/expansion_panel.py
@@ -318,7 +318,7 @@ class ExpansionPanelList(ConstrainedControl):
 
     @controls.setter
     def controls(self, value: Optional[Sequence[ExpansionPanel]]):
-        self.__controls = list (value) if value is not None else []
+        self.__controls = list(value) if value is not None else []
 
     # on_change
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/expansion_panel.py
+++ b/sdk/python/packages/flet-core/src/flet_core/expansion_panel.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Union
+from typing import Any, Optional, Sequence, Union
 
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.constrained_control import ConstrainedControl
@@ -176,7 +176,7 @@ class ExpansionPanelList(ConstrainedControl):
 
     def __init__(
         self,
-        controls: Optional[List[ExpansionPanel]] = None,
+        controls: Optional[Sequence[ExpansionPanel]] = None,
         divider_color: Optional[str] = None,
         elevation: OptionalNumber = None,
         expanded_header_padding: PaddingValue = None,

--- a/sdk/python/packages/flet-core/src/flet_core/expansion_tile.py
+++ b/sdk/python/packages/flet-core/src/flet_core/expansion_tile.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional, Union, Sequence
 
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.alignment import Alignment
@@ -40,7 +40,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
     def __init__(
         self,
         title: Control,
-        controls: Optional[List[Control]] = None,
+        controls: Optional[Sequence[Control]] = None,
         subtitle: Optional[Control] = None,
         leading: Optional[Control] = None,
         trailing: Optional[Control] = None,
@@ -132,7 +132,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
 
         AdaptiveControl.__init__(self, adaptive=adaptive)
 
-        self.controls = controls
+        self.controls = list(controls) if controls is not None else None
         self.controls_padding = controls_padding
         self.expanded_alignment = expanded_alignment
         self.expanded_cross_axis_alignment = expanded_cross_axis_alignment

--- a/sdk/python/packages/flet-core/src/flet_core/expansion_tile.py
+++ b/sdk/python/packages/flet-core/src/flet_core/expansion_tile.py
@@ -194,7 +194,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
 
     @controls.setter
     def controls(self, value: Optional[Sequence[Control]]):
-        self.__controls = list (value) if value is not None else []
+        self.__controls = list(value) if value is not None else []
 
     # controls_padding
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/expansion_tile.py
+++ b/sdk/python/packages/flet-core/src/flet_core/expansion_tile.py
@@ -132,7 +132,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
 
         AdaptiveControl.__init__(self, adaptive=adaptive)
 
-        self.controls = list(controls) if controls is not None else None
+        self.controls = controls
         self.controls_padding = controls_padding
         self.expanded_alignment = expanded_alignment
         self.expanded_cross_axis_alignment = expanded_cross_axis_alignment
@@ -193,8 +193,8 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
         return self.__controls
 
     @controls.setter
-    def controls(self, value: Optional[List[Control]]):
-        self.__controls = value if value is not None else []
+    def controls(self, value: Optional[Sequence[Control]]):
+        self.__controls = list (value) if value is not None else []
 
     # controls_padding
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/grid_view.py
+++ b/sdk/python/packages/flet-core/src/flet_core/grid_view.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Union, Callable
+from typing import Any, List, Optional, Union, Callable, Sequence
 
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.constrained_control import ConstrainedControl
@@ -67,7 +67,7 @@ class GridView(ConstrainedControl, ScrollableControl, AdaptiveControl):
 
     def __init__(
         self,
-        controls: Optional[List[Control]] = None,
+        controls: Optional[Sequence[Control]] = None,
         horizontal: Optional[bool] = None,
         runs_count: Optional[int] = None,
         max_extent: Optional[int] = None,
@@ -160,7 +160,7 @@ class GridView(ConstrainedControl, ScrollableControl, AdaptiveControl):
         AdaptiveControl.__init__(self, adaptive=adaptive)
 
         self.__controls: List[Control] = []
-        self.controls = controls
+        self.controls = list(controls) if controls is not None else None
         self.horizontal = horizontal
         self.runs_count = runs_count
         self.max_extent = max_extent

--- a/sdk/python/packages/flet-core/src/flet_core/grid_view.py
+++ b/sdk/python/packages/flet-core/src/flet_core/grid_view.py
@@ -160,7 +160,7 @@ class GridView(ConstrainedControl, ScrollableControl, AdaptiveControl):
         AdaptiveControl.__init__(self, adaptive=adaptive)
 
         self.__controls: List[Control] = []
-        self.controls = list(controls) if controls is not None else None
+        self.controls = controls
         self.horizontal = horizontal
         self.runs_count = runs_count
         self.max_extent = max_extent
@@ -272,8 +272,8 @@ class GridView(ConstrainedControl, ScrollableControl, AdaptiveControl):
         return self.__controls
 
     @controls.setter
-    def controls(self, value):
-        self.__controls = value if value is not None else []
+    def controls(self, value: Optional[Sequence[Control]]):
+        self.__controls = list (value) if value is not None else []
 
     # clip_behavior
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/grid_view.py
+++ b/sdk/python/packages/flet-core/src/flet_core/grid_view.py
@@ -273,7 +273,7 @@ class GridView(ConstrainedControl, ScrollableControl, AdaptiveControl):
 
     @controls.setter
     def controls(self, value: Optional[Sequence[Control]]):
-        self.__controls = list (value) if value is not None else []
+        self.__controls = list(value) if value is not None else []
 
     # clip_behavior
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/list_view.py
+++ b/sdk/python/packages/flet-core/src/flet_core/list_view.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Union, Callable
+from typing import Any, List, Optional, Union, Callable, Sequence
 
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.constrained_control import ConstrainedControl
@@ -59,7 +59,7 @@ class ListView(ConstrainedControl, ScrollableControl, AdaptiveControl):
 
     def __init__(
         self,
-        controls: Optional[List[Control]] = None,
+        controls: Optional[Sequence[Control]] = None,
         horizontal: Optional[bool] = None,
         spacing: OptionalNumber = None,
         item_extent: OptionalNumber = None,
@@ -151,7 +151,7 @@ class ListView(ConstrainedControl, ScrollableControl, AdaptiveControl):
         AdaptiveControl.__init__(self, adaptive=adaptive)
 
         self.__controls: List[Control] = []
-        self.controls = controls
+        self.controls = list(controls) if controls is not None else None
         self.horizontal = horizontal
         self.spacing = spacing
         self.divider_thickness = divider_thickness

--- a/sdk/python/packages/flet-core/src/flet_core/list_view.py
+++ b/sdk/python/packages/flet-core/src/flet_core/list_view.py
@@ -151,7 +151,7 @@ class ListView(ConstrainedControl, ScrollableControl, AdaptiveControl):
         AdaptiveControl.__init__(self, adaptive=adaptive)
 
         self.__controls: List[Control] = []
-        self.controls = list(controls) if controls is not None else None
+        self.controls = controls
         self.horizontal = horizontal
         self.spacing = spacing
         self.divider_thickness = divider_thickness
@@ -249,12 +249,12 @@ class ListView(ConstrainedControl, ScrollableControl, AdaptiveControl):
 
     # controls
     @property
-    def controls(self):
+    def controls(self) -> List[Control]:
         return self.__controls
 
     @controls.setter
-    def controls(self, value):
-        self.__controls = value if value is not None else []
+    def controls(self, value: Optional[Sequence[Control]]):
+        self.__controls = list(value) if value is not None else []
 
     # clip_behavior
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/menu_bar.py
+++ b/sdk/python/packages/flet-core/src/flet_core/menu_bar.py
@@ -84,7 +84,7 @@ class MenuBar(Control):
             data=data,
         )
 
-        self.controls = list(controls)
+        self.controls = controls
         self.clip_behavior = clip_behavior
         self.style = style
 

--- a/sdk/python/packages/flet-core/src/flet_core/menu_bar.py
+++ b/sdk/python/packages/flet-core/src/flet_core/menu_bar.py
@@ -116,8 +116,8 @@ class MenuBar(Control):
         return self.__controls
 
     @controls.setter
-    def controls(self, value: List[Control]):
-        self.__controls = value
+    def controls(self, value: Optional[Sequence[Control]]):
+        self.__controls = list(value) if value is not None else []
 
     # clip_behavior
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/menu_bar.py
+++ b/sdk/python/packages/flet-core/src/flet_core/menu_bar.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 from flet_core.alignment import Alignment
 from flet_core.border import BorderSide
@@ -57,7 +57,7 @@ class MenuBar(Control):
 
     def __init__(
         self,
-        controls: List[Control],
+        controls: Sequence[Control],
         clip_behavior: Optional[ClipBehavior] = None,
         style: Optional[MenuStyle] = None,
         #
@@ -84,7 +84,7 @@ class MenuBar(Control):
             data=data,
         )
 
-        self.controls = controls
+        self.controls = list(controls)
         self.clip_behavior = clip_behavior
         self.style = style
 

--- a/sdk/python/packages/flet-core/src/flet_core/menu_bar.py
+++ b/sdk/python/packages/flet-core/src/flet_core/menu_bar.py
@@ -116,8 +116,8 @@ class MenuBar(Control):
         return self.__controls
 
     @controls.setter
-    def controls(self, value: Optional[Sequence[Control]]):
-        self.__controls = list(value) if value is not None else []
+    def controls(self, value: Sequence[Control]):
+        self.__controls = list(value)
 
     # clip_behavior
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/navigation_drawer.py
+++ b/sdk/python/packages/flet-core/src/flet_core/navigation_drawer.py
@@ -199,7 +199,7 @@ class NavigationDrawer(Control):
         )
 
         self.open = open
-        self.controls = list(controls) if controls is not None else None
+        self.controls = controls
         self.selected_index = selected_index
         self.bgcolor = bgcolor
         self.elevation = elevation
@@ -238,7 +238,7 @@ class NavigationDrawer(Control):
         return self.__controls
 
     @controls.setter
-    def controls(self, value: Optional[List[Control]]):
+    def controls(self, value: Optional[Sequence[Control]]):
         self.__controls = value or []
 
     # selected_index

--- a/sdk/python/packages/flet-core/src/flet_core/navigation_drawer.py
+++ b/sdk/python/packages/flet-core/src/flet_core/navigation_drawer.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Sequence
 
 from flet_core.buttons import OutlinedBorder
 from flet_core.control import Control
@@ -169,7 +169,7 @@ class NavigationDrawer(Control):
 
     def __init__(
         self,
-        controls: Optional[List[Control]] = None,
+        controls: Optional[Sequence[Control]] = None,
         open: bool = False,
         selected_index: Optional[int] = None,
         bgcolor: Optional[str] = None,
@@ -199,7 +199,7 @@ class NavigationDrawer(Control):
         )
 
         self.open = open
-        self.controls = controls
+        self.controls = list(controls) if controls is not None else None
         self.selected_index = selected_index
         self.bgcolor = bgcolor
         self.elevation = elevation

--- a/sdk/python/packages/flet-core/src/flet_core/navigation_drawer.py
+++ b/sdk/python/packages/flet-core/src/flet_core/navigation_drawer.py
@@ -239,7 +239,7 @@ class NavigationDrawer(Control):
 
     @controls.setter
     def controls(self, value: Optional[Sequence[Control]]):
-        self.__controls = value or []
+        self.__controls = list(value) if value is not  None else []
 
     # selected_index
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/page.py
+++ b/sdk/python/packages/flet-core/src/flet_core/page.py
@@ -1853,7 +1853,7 @@ class Page(AdaptiveControl):
         return self.__default_view.controls
 
     @controls.setter
-    def controls(self, value: Optional[List[Control]]):
+    def controls(self, value: Optional[Sequence[Control]]):
         self.__default_view.controls = value if value is not None else []
 
     # appbar

--- a/sdk/python/packages/flet-core/src/flet_core/page.py
+++ b/sdk/python/packages/flet-core/src/flet_core/page.py
@@ -18,6 +18,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Sequence,
     Tuple,
     Type,
     TypeVar,
@@ -1854,7 +1855,7 @@ class Page(AdaptiveControl):
 
     @controls.setter
     def controls(self, value: Optional[Sequence[Control]]):
-        self.__default_view.controls = value if value is not None else []
+        self.__default_view.controls = list(value) if value is not None else []
 
     # appbar
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/responsive_row.py
+++ b/sdk/python/packages/flet-core/src/flet_core/responsive_row.py
@@ -210,4 +210,4 @@ class ResponsiveRow(ConstrainedControl, AdaptiveControl):
 
     @controls.setter
     def controls(self, value: Optional[Sequence[Control]]):
-        self.__controls = list (value) if value is not None else []
+        self.__controls = list(value) if value is not None else []

--- a/sdk/python/packages/flet-core/src/flet_core/responsive_row.py
+++ b/sdk/python/packages/flet-core/src/flet_core/responsive_row.py
@@ -125,7 +125,7 @@ class ResponsiveRow(ConstrainedControl, AdaptiveControl):
 
         AdaptiveControl.__init__(self, adaptive=adaptive)
 
-        self.controls = list(controls) if controls is not None else None
+        self.controls = controls
         self.alignment = alignment
         self.vertical_alignment = vertical_alignment
         self.spacing = spacing
@@ -209,5 +209,5 @@ class ResponsiveRow(ConstrainedControl, AdaptiveControl):
         return self.__controls
 
     @controls.setter
-    def controls(self, value):
-        self.__controls = value if value is not None else []
+    def controls(self, value: Optional[Sequence[Control]]):
+        self.__controls = list (value) if value is not None else []

--- a/sdk/python/packages/flet-core/src/flet_core/responsive_row.py
+++ b/sdk/python/packages/flet-core/src/flet_core/responsive_row.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional, Union, Sequence
 
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.constrained_control import ConstrainedControl
@@ -51,7 +51,7 @@ class ResponsiveRow(ConstrainedControl, AdaptiveControl):
 
     def __init__(
         self,
-        controls: Optional[List[Control]] = None,
+        controls: Optional[Sequence[Control]] = None,
         columns: Optional[ResponsiveNumber] = None,
         alignment: Optional[MainAxisAlignment] = None,
         vertical_alignment: Optional[CrossAxisAlignment] = None,
@@ -125,7 +125,7 @@ class ResponsiveRow(ConstrainedControl, AdaptiveControl):
 
         AdaptiveControl.__init__(self, adaptive=adaptive)
 
-        self.controls = controls
+        self.controls = list(controls) if controls is not None else None
         self.alignment = alignment
         self.vertical_alignment = vertical_alignment
         self.spacing = spacing

--- a/sdk/python/packages/flet-core/src/flet_core/row.py
+++ b/sdk/python/packages/flet-core/src/flet_core/row.py
@@ -151,7 +151,7 @@ class Row(ConstrainedControl, ScrollableControl, AdaptiveControl):
 
         AdaptiveControl.__init__(self, adaptive=adaptive)
 
-        self.controls = list(controls) if controls is not None else None
+        self.controls = controls
         self.alignment = alignment
         self.vertical_alignment = vertical_alignment
         self.spacing = spacing
@@ -240,5 +240,5 @@ class Row(ConstrainedControl, ScrollableControl, AdaptiveControl):
         return self.__controls
 
     @controls.setter
-    def controls(self, value: Optional[List[Control]]):
+    def controls(self, value: Optional[Sequence[Control]]):
         self.__controls = value if value else []

--- a/sdk/python/packages/flet-core/src/flet_core/row.py
+++ b/sdk/python/packages/flet-core/src/flet_core/row.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Union, Callable
+from typing import Any, List, Optional, Union, Callable, Sequence
 
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.constrained_control import ConstrainedControl
@@ -61,7 +61,7 @@ class Row(ConstrainedControl, ScrollableControl, AdaptiveControl):
 
     def __init__(
         self,
-        controls: Optional[List[Control]] = None,
+        controls: Optional[Sequence[Control]] = None,
         alignment: Optional[MainAxisAlignment] = None,
         vertical_alignment: Optional[CrossAxisAlignment] = None,
         spacing: OptionalNumber = None,
@@ -151,7 +151,7 @@ class Row(ConstrainedControl, ScrollableControl, AdaptiveControl):
 
         AdaptiveControl.__init__(self, adaptive=adaptive)
 
-        self.controls = controls
+        self.controls = list(controls) if controls is not None else None
         self.alignment = alignment
         self.vertical_alignment = vertical_alignment
         self.spacing = spacing

--- a/sdk/python/packages/flet-core/src/flet_core/row.py
+++ b/sdk/python/packages/flet-core/src/flet_core/row.py
@@ -241,4 +241,4 @@ class Row(ConstrainedControl, ScrollableControl, AdaptiveControl):
 
     @controls.setter
     def controls(self, value: Optional[Sequence[Control]]):
-        self.__controls = value if value else []
+        self.__controls = list(value) if value else []

--- a/sdk/python/packages/flet-core/src/flet_core/search_bar.py
+++ b/sdk/python/packages/flet-core/src/flet_core/search_bar.py
@@ -1,5 +1,5 @@
 import time
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, Sequence
 
 from flet_core.border import BorderSide
 from flet_core.buttons import OutlinedBorder
@@ -32,7 +32,7 @@ class SearchBar(ConstrainedControl):
 
     def __init__(
         self,
-        controls: Optional[List[Control]] = None,
+        controls: Optional[Sequence[Control]] = None,
         value: Optional[str] = None,
         bar_leading: Optional[Control] = None,
         bar_trailing: Optional[List[Control]] = None,
@@ -112,7 +112,7 @@ class SearchBar(ConstrainedControl):
         )
 
         self.value = value
-        self.controls = controls
+        self.controls = list(controls) if controls is not None else None
         self.bar_leading = bar_leading
         self.bar_trailing = bar_trailing
         self.bar_hint_text = bar_hint_text

--- a/sdk/python/packages/flet-core/src/flet_core/search_bar.py
+++ b/sdk/python/packages/flet-core/src/flet_core/search_bar.py
@@ -112,7 +112,7 @@ class SearchBar(ConstrainedControl):
         )
 
         self.value = value
-        self.controls = list(controls) if controls is not None else None
+        self.controls = controls
         self.bar_leading = bar_leading
         self.bar_trailing = bar_trailing
         self.bar_hint_text = bar_hint_text
@@ -395,8 +395,8 @@ class SearchBar(ConstrainedControl):
         return self.__controls
 
     @controls.setter
-    def controls(self, value: Optional[List[Control]]):
-        self.__controls = value if value is not None else []
+    def controls(self, value: Optional[Sequence[Control]]):
+        self.__controls = list (value) if value is not None else []
 
     # value
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/search_bar.py
+++ b/sdk/python/packages/flet-core/src/flet_core/search_bar.py
@@ -396,7 +396,7 @@ class SearchBar(ConstrainedControl):
 
     @controls.setter
     def controls(self, value: Optional[Sequence[Control]]):
-        self.__controls = list (value) if value is not None else []
+        self.__controls = list(value) if value is not None else []
 
     # value
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/stack.py
+++ b/sdk/python/packages/flet-core/src/flet_core/stack.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional, Union, Sequence
 
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.alignment import Alignment
@@ -74,7 +74,7 @@ class Stack(ConstrainedControl, AdaptiveControl):
 
     def __init__(
         self,
-        controls: Optional[List[Control]] = None,
+        controls: Optional[Sequence[Control]] = None,
         clip_behavior: Optional[ClipBehavior] = None,
         alignment: Optional[Alignment] = None,
         fit: Optional[StackFit] = None,
@@ -142,7 +142,7 @@ class Stack(ConstrainedControl, AdaptiveControl):
         AdaptiveControl.__init__(self, adaptive=adaptive)
 
         self.__controls: List[Control] = []
-        self.controls = controls
+        self.controls = list(controls) if controls is not None else None
         self.clip_behavior = clip_behavior
         self.alignment = alignment
         self.fit = fit

--- a/sdk/python/packages/flet-core/src/flet_core/stack.py
+++ b/sdk/python/packages/flet-core/src/flet_core/stack.py
@@ -164,7 +164,7 @@ class Stack(ConstrainedControl, AdaptiveControl):
 
     @controls.setter
     def controls(self, value: Optional[Sequence[Control]]):
-        self.__controls = list (value) if value is not None else []
+        self.__controls = list(value) if value is not None else []
 
     # clip_behavior
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/stack.py
+++ b/sdk/python/packages/flet-core/src/flet_core/stack.py
@@ -142,7 +142,7 @@ class Stack(ConstrainedControl, AdaptiveControl):
         AdaptiveControl.__init__(self, adaptive=adaptive)
 
         self.__controls: List[Control] = []
-        self.controls = list(controls) if controls is not None else None
+        self.controls = controls
         self.clip_behavior = clip_behavior
         self.alignment = alignment
         self.fit = fit
@@ -163,8 +163,8 @@ class Stack(ConstrainedControl, AdaptiveControl):
         return self.__controls
 
     @controls.setter
-    def controls(self, value):
-        self.__controls = value if value is not None else []
+    def controls(self, value: Optional[Sequence[Control]]):
+        self.__controls = list (value) if value is not None else []
 
     # clip_behavior
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/submenu_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/submenu_button.py
@@ -105,7 +105,7 @@ class SubmenuButton(ConstrainedControl):
         )
 
         self.content = content
-        self.controls = list(controls) if controls is not None else None
+        self.controls = controls
         self.leading = leading
         self.trailing = trailing
         self.clip_behavior = clip_behavior
@@ -167,8 +167,8 @@ class SubmenuButton(ConstrainedControl):
         return self.__controls
 
     @controls.setter
-    def controls(self, value: Optional[List[Control]]):
-        self.__controls = value if value is not None else []
+    def controls(self, value: Optional[Sequence[Control]]):
+        self.__controls = list (value) if value is not None else []
 
     # leading
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/submenu_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/submenu_button.py
@@ -168,7 +168,7 @@ class SubmenuButton(ConstrainedControl):
 
     @controls.setter
     def controls(self, value: Optional[Sequence[Control]]):
-        self.__controls = list (value) if value is not None else []
+        self.__controls = list(value) if value is not None else []
 
     # leading
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/submenu_button.py
+++ b/sdk/python/packages/flet-core/src/flet_core/submenu_button.py
@@ -1,5 +1,5 @@
 import time
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional, Union, Sequence
 
 from flet_core.buttons import ButtonStyle
 from flet_core.constrained_control import ConstrainedControl
@@ -30,7 +30,7 @@ class SubmenuButton(ConstrainedControl):
     def __init__(
         self,
         content: Optional[Control] = None,
-        controls: Optional[List[Control]] = None,
+        controls: Optional[Sequence[Control]] = None,
         leading: Optional[Control] = None,
         trailing: Optional[Control] = None,
         clip_behavior: Optional[ClipBehavior] = None,
@@ -105,7 +105,7 @@ class SubmenuButton(ConstrainedControl):
         )
 
         self.content = content
-        self.controls = controls
+        self.controls = list(controls) if controls is not None else None
         self.leading = leading
         self.trailing = trailing
         self.clip_behavior = clip_behavior

--- a/sdk/python/packages/flet-core/src/flet_core/view.py
+++ b/sdk/python/packages/flet-core/src/flet_core/view.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union, Callable
+from typing import List, Optional, Union, Callable, Sequence
 
 from flet_core import Control
 from flet_core.adaptive_control import AdaptiveControl
@@ -35,7 +35,7 @@ class View(ScrollableControl, AdaptiveControl):
     def __init__(
         self,
         route: Optional[str] = None,
-        controls: Optional[List[Control]] = None,
+        controls: Optional[Sequence[Control]] = None,
         appbar: Union[AppBar, CupertinoAppBar, None] = None,
         bottom_appbar: Optional[BottomAppBar] = None,
         floating_action_button: Optional[FloatingActionButton] = None,
@@ -75,7 +75,7 @@ class View(ScrollableControl, AdaptiveControl):
 
         AdaptiveControl.__init__(self, adaptive=adaptive)
 
-        self.controls = controls if controls is not None else []
+        self.controls =list(controls) if controls is not None else []
         self.route = route
         self.appbar = appbar
         self.bottom_appbar = bottom_appbar

--- a/sdk/python/packages/flet-core/src/flet_core/view.py
+++ b/sdk/python/packages/flet-core/src/flet_core/view.py
@@ -75,7 +75,7 @@ class View(ScrollableControl, AdaptiveControl):
 
         AdaptiveControl.__init__(self, adaptive=adaptive)
 
-        self.controls =list(controls) if controls is not None else []
+        self.controls = controls
         self.route = route
         self.appbar = appbar
         self.bottom_appbar = bottom_appbar
@@ -139,8 +139,8 @@ class View(ScrollableControl, AdaptiveControl):
         return self.__controls
 
     @controls.setter
-    def controls(self, value: List[Control]):
-        self.__controls = value
+    def controls(self, value: Optional[Sequence[Control]]):
+        self.__controls = list(value) if value is not None else []
 
     # appbar
     @property


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->


<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #3660

## Test Code

```python
import flet as ft

controls = [
    ft.Text("Hello, World!"),
    ft.Text("Hello, World!"),
]

a = ft.Row(controls)
a = ft.Column(controls)
a = ft.Stack(controls)
a = ft.View(controls=controls)
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I signed the CLA.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
<!-- - [ ] I have added tests that prove my fix is effective or that my feature works as expected -->

- [x] New and existing tests pass locally with my changes
- [x] I have made corresponding changes to the [documentation](https://github.com/flet-dev/website) (if applicable)

## Screenshots (if applicable):

## Additional details

<!-- Add any other context to be known about this PR. -->

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the type hints for 'controls' parameters from List[Control] to Sequence[Control] in various components to enhance flexibility in input types.

- **Enhancements**:
    - Replaced type hints for 'controls' parameters from List[Control] to Sequence[Control] across multiple files to allow for more flexible input types.

<!-- Generated by sourcery-ai[bot]: end summary -->