### PR TITLE
Fix `Dismissible`

### DIFF
--- a/sdk/python/packages/flet-core/src/flet_core/dismissible.py
+++ b/sdk/python/packages/flet-core/src/flet_core/dismissible.py
@@ -117,7 +117,7 @@ class Dismissible(ConstrainedControl, AdaptiveControl):
 
         AdaptiveControl.__init__(self, adaptive=adaptive)
 
-        self.__on_dismiss = EventHandler(lambda e: DismissibleDismissEvent(e.data))
+        self.__on_dismiss = EventHandler(lambda e: DismissibleDismissEvent(e))
         self.__on_update = EventHandler(lambda e: DismissibleUpdateEvent(e))
         self.__on_confirm_dismiss = EventHandler(lambda e: DismissibleDismissEvent(e))
 
@@ -292,8 +292,7 @@ class Dismissible(ConstrainedControl, AdaptiveControl):
 class DismissibleDismissEvent(ControlEvent):
     def __init__(self, e: ControlEvent):
         super().__init__(e.target, e.name, e.data, e.control, e.page)
-        d = json.loads(e.data)
-        self.direction = DismissDirection(d["direction"])
+        self.direction = DismissDirection(e.data)
 
 
 class DismissibleUpdateEvent(ControlEvent):


### PR DESCRIPTION
Closes #3679

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request fixes the `Dismissible` component to ensure that dismiss events are handled correctly by passing the entire event object, addressing issue #3679.

- **Bug Fixes**:
    - Fixed the `Dismissible` component to correctly handle dismiss events by passing the entire event object instead of just the event data.

<!-- Generated by sourcery-ai[bot]: end summary -->