### PR TITLE
fix: scrolling controls are not able to scroll due to wrong super class call

### DIFF
--- a/sdk/python/packages/flet-core/src/flet_core/scrollable_control.py
+++ b/sdk/python/packages/flet-core/src/flet_core/scrollable_control.py
@@ -19,7 +19,7 @@ class ScrollableControl(Control):
         on_scroll_interval: OptionalNumber = None,
         on_scroll: Optional[Callable[["OnScrollEvent"], None]] = None,
     ):
-        Control.__init__(self)
+        super().__init__()
         self.__on_scroll = EventHandler(lambda e: OnScrollEvent(e))
         self._add_event_handler("onScroll", self.__on_scroll.get_handler())
 


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a bug in the scrolling controls by correcting the superclass call in the `ScrollableControl` class, ensuring proper functionality.

- **Bug Fixes**:
    - Fixed an issue where scrolling controls were not functioning due to an incorrect superclass call.

<!-- Generated by sourcery-ai[bot]: end summary -->