### PR TITLE
feat(build cli): `--no-rich-output` flag to prevent rich output 

### DIFF
--- a/sdk/python/packages/flet/src/flet/cli/commands/build.py
+++ b/sdk/python/packages/flet/src/flet/cli/commands/build.py
@@ -10,7 +10,7 @@ import sys
 import tempfile
 import urllib.request
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 
 import yaml
 from packaging import version
@@ -838,7 +838,7 @@ class Command(BaseCommand):
                     console.log(build_result.stderr, style=error_style)
                 self.cleanup(build_result.returncode, check_flutter_version=True)
             console.log(
-                f"Built [cyan]{self.platforms[target_platform]['self.status_text']}[/cyan] {checkmark}",
+                f"Built [cyan]{self.platforms[target_platform]['status_text']}[/cyan] {checkmark}",
             )
 
             # copy build results to `out_dir`
@@ -985,10 +985,10 @@ class Command(BaseCommand):
                             )
                             console.log(flutter_msg, style=error_style)
             # run flutter doctor
-            self.run_flutter_doctor()
+            self.run_flutter_doctor(style=error_style)
         sys.exit(exit_code)
 
-    def run_flutter_doctor(self):
+    def run_flutter_doctor(self, style: Optional[Union[Style, str]] = None):
         self.status.update("[bold blue]Running Flutter doctor ⏳... ")
         flutter_doctor = self.run(
             [self.flutter_exe, "doctor"],
@@ -996,4 +996,4 @@ class Command(BaseCommand):
             capture_output=True,
         )
         if flutter_doctor.returncode == 0 and flutter_doctor.stdout:
-            console.log(flutter_doctor.stdout, style=error_style)
+            console.log(flutter_doctor.stdout, style=style)

--- a/sdk/python/packages/flet/src/flet/cli/commands/build.py
+++ b/sdk/python/packages/flet/src/flet/cli/commands/build.py
@@ -21,7 +21,12 @@ import flet.version
 from flet.cli.commands.base import BaseCommand
 from flet.version import update_version
 from flet_core.utils import random_string, slugify
-from flet_runtime.utils import calculate_file_hash, copy_tree, is_windows
+from flet_runtime.utils import (
+    calculate_file_hash,
+    copy_tree,
+    is_windows,
+    get_bool_env_var,
+)
 
 if is_windows():
     from ctypes import windll
@@ -42,6 +47,10 @@ class Command(BaseCommand):
     def __init__(self, parser: argparse.ArgumentParser) -> None:
         super().__init__(parser)
 
+        self.dart_exe = None
+        self.verbose = None
+        self.flutter_dir = None
+        self.flutter_exe = None
         self.platforms = {
             "windows": {
                 "build_command": "windows",
@@ -302,10 +311,21 @@ class Command(BaseCommand):
             default=False,
             help="displays the build platform matrix in a table, then exits",
         )
+        parser.add_argument(
+            "--no-rich-output",
+            action="store_true",
+            default=False,
+            help="disables rich output and uses plain text instead",
+        )
 
     def handle(self, options: argparse.Namespace) -> None:
         self.verbose = options.verbose
         self.flutter_dir = None
+        checkmark = (
+            "[green]✓[/]"
+            if options.no_rich_output or get_bool_env_var("FLET_BUILD_NO_RICH_OUTPUT")
+            else "✅"
+        )
         target_platform = options.target_platform.lower()
         # platform check
         current_platform = platform.system()
@@ -335,7 +355,7 @@ class Command(BaseCommand):
         with console.status(
             f"[bold blue]Initializing {target_platform} build... ",
             spinner="bouncingBall",
-        ) as status:
+        ) as self.status:
             from cookiecutter.main import cookiecutter
 
             # get `flutter` and `dart` executables from PATH
@@ -410,7 +430,11 @@ class Command(BaseCommand):
                     )
 
             if self.verbose > 0:
-                console.log("Additional Flutter dependencies:", flutter_dependencies)
+                console.log(
+                    f"Additional Flutter dependencies: {flutter_dependencies}"
+                    if flutter_dependencies
+                    else "No additional Flutter dependencies!"
+                )
 
             template_data = {
                 "out_dir": self.flutter_dir.name,
@@ -444,7 +468,7 @@ class Command(BaseCommand):
                     )
 
             # create Flutter project from a template
-            status.update(
+            self.status.update(
                 f"[bold blue]Creating Flutter bootstrap project from {template_url} with ref {template_ref} ⏳... ",
             )
             try:
@@ -460,7 +484,7 @@ class Command(BaseCommand):
             except Exception as e:
                 self.cleanup(1, f"{e}")
             console.log(
-                f"Created Flutter bootstrap project from {template_url} with ref {template_ref} ✅",
+                f"Created Flutter bootstrap project from {template_url} with ref {template_ref} {checkmark}",
             )
 
             # load pubspec.yaml
@@ -487,7 +511,7 @@ class Command(BaseCommand):
                     )
 
             # copy icons to `flutter_dir`
-            status.update(
+            self.status.update(
                 "[bold blue]Customizing app icons and splash images ⏳... ",
             )
             assets_path = python_app_path.joinpath("assets")
@@ -657,14 +681,14 @@ class Command(BaseCommand):
             pubspec["flutter_native_splash"]["ios"] = not options.no_ios_splash
             pubspec["flutter_native_splash"]["android"] = not options.no_android_splash
 
-            console.log("Customized app icons and splash images ✅")
+            console.log(f"Customized app icons and splash images {checkmark}")
 
             # save pubspec.yaml
             with open(pubspec_path, "w", encoding="utf8") as f:
                 yaml.dump(pubspec, f)
 
             # generate icons
-            status.update("[bold blue]Generating app icons ⏳... ")
+            self.status.update("[bold blue]Generating app icons ⏳... ")
             icons_result = self.run(
                 [self.dart_exe, "run", "flutter_launcher_icons"],
                 cwd=str(self.flutter_dir),
@@ -677,10 +701,10 @@ class Command(BaseCommand):
                     console.log(icons_result.stderr, style=error_style)
                 self.cleanup(icons_result.returncode, check_flutter_version=True)
 
-            console.log("Generated app icons ✅")
+            console.log(f"Generated app icons {checkmark}")
             # generate splash
             if target_platform in ["web", "ipa", "apk", "aab"]:
-                status.update(
+                self.status.update(
                     "[bold blue]Generating splash screens ⏳... ",
                 )
                 splash_result = self.run(
@@ -695,7 +719,7 @@ class Command(BaseCommand):
                         console.log(splash_result.stderr, style=error_style)
                     self.cleanup(splash_result.returncode, check_flutter_version=True)
 
-                console.log("Generated splash screens ✅")
+                console.log(f"Generated splash screens {checkmark}")
 
             exclude_list = ["build"]
 
@@ -703,7 +727,7 @@ class Command(BaseCommand):
                 exclude_list.extend(options.exclude)
 
             # package Python app
-            status.update(
+            self.status.update(
                 f"[bold blue]Packaging Python app ⏳... ",
             )
             package_args = [
@@ -774,10 +798,10 @@ class Command(BaseCommand):
             app_hash_path = self.flutter_dir.joinpath("app", "app.zip.hash")
             with open(app_hash_path, "w", encoding="utf8") as hf:
                 hf.write(calculate_file_hash(app_zip_path))
-            console.log("Packaged Python app ✅")
+            console.log(f"Packaged Python app {checkmark}")
 
             # run `flutter build`
-            status.update(
+            self.status.update(
                 f"[bold blue]Building [cyan]{self.platforms[target_platform]['status_text']}[/cyan] ⏳... ",
             )
             build_args = [
@@ -814,11 +838,11 @@ class Command(BaseCommand):
                     console.log(build_result.stderr, style=error_style)
                 self.cleanup(build_result.returncode, check_flutter_version=True)
             console.log(
-                f"Built [cyan]{self.platforms[target_platform]['status_text']}[/cyan] ✅",
+                f"Built [cyan]{self.platforms[target_platform]['self.status_text']}[/cyan] {checkmark}",
             )
 
             # copy build results to `out_dir`
-            status.update(
+            self.status.update(
                 f"[bold blue]Copying build to [cyan]{rel_out_dir}[/cyan] directory ⏳... ",
             )
             arch = platform.machine().lower()
@@ -858,7 +882,9 @@ class Command(BaseCommand):
                 # copy `assets` directory contents to the output directory
                 copy_tree(str(assets_path), str(out_dir))
 
-            console.log(f"Copied build to [cyan]{rel_out_dir}[/cyan] directory ✅")
+            console.log(
+                f"Copied build to [cyan]{rel_out_dir}[/cyan] directory {checkmark}"
+            )
 
             self.cleanup(
                 0,
@@ -937,6 +963,8 @@ class Command(BaseCommand):
                 if message is not None
                 else "Error building Flet app - see the log of failed command above."
             )
+            console.log(msg, style=error_style)
+
             if check_flutter_version:
                 version_results = self.run(
                     [self.flutter_exe, "--version"],
@@ -955,6 +983,17 @@ class Command(BaseCommand):
                                 + f"Flet build requires Flutter {MINIMAL_FLUTTER_VERSION} or above. "
                                 + f"You have {flutter_version}."
                             )
-                            msg = f"{msg}\n{flutter_msg}"
-            console.log(msg, style=error_style)
+                            console.log(flutter_msg, style=error_style)
+            # run flutter doctor
+            self.run_flutter_doctor()
         sys.exit(exit_code)
+
+    def run_flutter_doctor(self):
+        self.status.update("[bold blue]Running Flutter doctor ⏳... ")
+        flutter_doctor = self.run(
+            [self.flutter_exe, "doctor"],
+            cwd=os.getcwd(),
+            capture_output=True,
+        )
+        if flutter_doctor.returncode == 0 and flutter_doctor.stdout:
+            console.log(flutter_doctor.stdout, style=error_style)


### PR DESCRIPTION
## Context
The error in the below code block occured in a github action when trying to `build` a simple Windows application. It is raised because github action cli uses `cp1252` encoding, causing characters like ✅ not to be displayed. 
In this PR, we make it possible through the new optional `--no-rich-output` flag to prevent rich output (✅) from being displayed. When provided "✓" is used instead.
```bash
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\hostedtoolcache\windows\Python\3.12.2\x64\Scripts\flet.exe\__main__.py", line 7, in <module>
  File "C:\hostedtoolcache\windows\Python\3.12.2\x64\Lib\site-packages\flet\cli\cli.py", line 88, in main
    args.handler(args)
  File "C:\hostedtoolcache\windows\Python\3.12.2\x64\Lib\site-packages\flet\cli\commands\build.py", line 335, in handle
    with console.status(
  File "C:\hostedtoolcache\windows\Python\3.12.2\x64\Lib\site-packages\rich\status.py", line 106, in __exit__
    self.stop()
  File "C:\hostedtoolcache\windows\Python\3.12.2\x64\Lib\site-packages\rich\status.py", line 91, in stop
    self._live.stop()
  File "C:\hostedtoolcache\windows\Python\3.12.2\x64\Lib\site-packages\rich\live.py", line 147, in stop
    with self.console:
  File "C:\hostedtoolcache\windows\Python\3.12.2\x64\Lib\site-packages\rich\console.py", line 865, in __exit__
    self._exit_buffer()
  File "C:\hostedtoolcache\windows\Python\3.12.2\x64\Lib\site-packages\rich\console.py", line 823, in _exit_buffer
    self._check_buffer()
  File "C:\hostedtoolcache\windows\Python\3.12.2\x64\Lib\site-packages\rich\console.py", line [202](https://github.com/ndonkoHenri/test-flet-github-actions/actions/runs/10085185884/job/27885499164#step:6:203)7, in _check_buffer
    legacy_windows_render(buffer, LegacyWindowsTerm(self.file))
  File "C:\hostedtoolcache\windows\Python\3.12.2\x64\Lib\site-packages\rich\_windows_renderer.py", line 17, in legacy_windows_render
    term.write_styled(text, style)
  File "C:\hostedtoolcache\windows\Python\3.12.2\x64\Lib\site-packages\rich\_win32_console.py", line 442, in write_styled
    self.write_text(text)
  File "C:\hostedtoolcache\windows\Python\3.12.2\x64\Lib\site-packages\rich\_win32_console.py", line 403, in write_text
    self.write(text)
  File "C:\hostedtoolcache\windows\Python\3.12.2\x64\Lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeEncodeError: 'charmap' codec can't encode character '\u2705' in position 1: character maps to <undefined>
           gh:flet-dev/flet-build-template with ref 0.23.2
```

Also, I created a method which runs `flutter doctor` in cases where the build fails.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request adds a new `--no-rich-output` flag to the build CLI, allowing users to disable rich output and use plain text instead. This is particularly useful for environments that do not support rich text encoding, such as certain GitHub Actions runners. Additionally, console log messages have been updated to respect this new flag.

- **New Features**:
    - Introduced a `--no-rich-output` flag to the build CLI to disable rich output and use plain text instead.
- **Enhancements**:
    - Updated various console log messages to conditionally use plain text or rich output based on the `--no-rich-output` flag.

<!-- Generated by sourcery-ai[bot]: end summary -->