### PR TITLE
Window destroy on android and iOS

### DIFF
--- a/packages/flet/lib/src/utils/desktop.dart
+++ b/packages/flet/lib/src/utils/desktop.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:window_manager/window_manager.dart';
 import 'package:window_to_front/window_to_front.dart';
+import 'package:flutter/services.dart';
 
 import '../models/window_media_data.dart';
 
@@ -244,9 +245,15 @@ Future blurWindow() async {
 }
 
 Future destroyWindow() async {
-  if (isDesktop()) {
+  if (isDesktop() || isMobile()) {
     debugPrint("destroyWindow()");
+  }
+  if (isDesktop()) {
     await windowManager.destroy();
+  } else if (defaultTargetPlatform == TargetPlatform.iOS) {
+    exit(0);
+  } else if (defaultTargetPlatform == TargetPlatform.android) {
+    SystemNavigator.pop();
   }
 }
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
This PR should provide window destroy (app exit) function for Android and IOS platforms

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I signed the CLA.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
<!-- - [ ] I have added tests that prove my fix is effective or that my feature works as expected -->

- [ ] New and existing tests pass locally with my changes
- [ ] I have made corresponding changes to the [documentation](https://github.com/flet-dev/website) (if applicable)
