### PR TITLE
Added on_completed event to flet_video

### DIFF
--- a/packages/flet_video/lib/src/video.dart
+++ b/packages/flet_video/lib/src/video.dart
@@ -62,6 +62,12 @@ class _VideoControlState extends State<VideoControl> with FletStoreMixin {
         .triggerControlEvent(widget.control.id, "error", message ?? "");
   }
 
+  void _onCompleted(String? message) {
+  debugPrint("Video onCompleted: $message");
+  widget.backend
+      .triggerControlEvent(widget.control.id, "complete", message ?? "");
+  }
+
   @override
   Widget build(BuildContext context) {
     debugPrint("Video build: ${widget.control.id}");
@@ -91,6 +97,8 @@ class _VideoControlState extends State<VideoControl> with FletStoreMixin {
           subtitleConfiguration?["subtitleViewConfiguration"];
 
       bool onError = widget.control.attrBool("onError", false)!;
+      bool onCompleted = widget.control.attrBool("onCompleted", false)!;
+
 
       double? volume = widget.control.attrDouble("volume");
       double? pitch = widget.control.attrDouble("pitch");
@@ -259,6 +267,12 @@ class _VideoControlState extends State<VideoControl> with FletStoreMixin {
         }
       });
 
+      player.stream.completed.listen((event) {
+        if (onCompleted) {
+          _onCompleted(event.toString());
+        }
+      });
+      
       return constrainedControl(context, video, widget.parent, widget.control);
     });
   }

--- a/sdk/python/packages/flet-core/src/flet_core/video.py
+++ b/sdk/python/packages/flet-core/src/flet_core/video.py
@@ -96,6 +96,8 @@ class Video(ConstrainedControl):
         on_enter_fullscreen: OptionalEventCallable = None,
         on_exit_fullscreen: OptionalEventCallable = None,
         on_error: OptionalEventCallable = None,
+        on_completed: OptionalEventCallable = None,
+
         #
         # ConstrainedControl
         #
@@ -178,6 +180,8 @@ class Video(ConstrainedControl):
         self.on_exit_fullscreen = on_exit_fullscreen
         self.on_loaded = on_loaded
         self.on_error = on_error
+        self.on_completed = on_completed
+
 
     def _get_control_name(self):
         return "video"
@@ -593,3 +597,13 @@ class Video(ConstrainedControl):
     def on_error(self, handler: OptionalControlEventCallable):
         self._set_attr("onError", True if handler is not None else None)
         self._add_event_handler("error", handler)
+
+    # on_completed
+    @property
+    def on_completed(self) -> OptionalControlEventCallable:
+        return self._get_event_handler("completed")
+
+    @on_completed.setter
+    def on_completed(self, handler: OptionalControlEventCallable):
+        self._set_attr("onCompleted", True if handler is not None else None)
+        self._add_event_handler("completed", handler)


### PR DESCRIPTION
Allows people to know when a song has completed.  Will allow people to keep track of what song is playing by knowing when one has finished.

Just wanted to add this one PR for flet_video, and hope progress being made on next flet_video using audio_service :)

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Introduce an on_completed event to the flet_video package, allowing users to track when a video has completed playback.

New Features:
- Added an on_completed event to the flet_video package to notify when a video has finished playing.

<!-- Generated by sourcery-ai[bot]: end summary -->