### PR TITLE
Flet video typo fix on on_completed handler

### DIFF
--- a/packages/flet_video/lib/src/video.dart
+++ b/packages/flet_video/lib/src/video.dart
@@ -65,7 +65,7 @@ class _VideoControlState extends State<VideoControl> with FletStoreMixin {
   void _onCompleted(String? message) {
   debugPrint("Video onCompleted: $message");
   widget.backend
-      .triggerControlEvent(widget.control.id, "complete", message ?? "");
+      .triggerControlEvent(widget.control.id, "completed", message ?? "");
   }
 
   @override


### PR DESCRIPTION
## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x ] I signed the CLA.
- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] My changes generate no new warnings
<!-- - [ ] I have added tests that prove my fix is effective or that my feature works as expected -->

- [ x] New and existing tests pass locally with my changes
- [ ] I have made corresponding changes to the [documentation](https://github.com/flet-dev/website) (if applicable)

## Additional details

Tested main branch today, "complete" should have been "completed" in dart file to match video.py, with this change handler works as expected in my tests.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix typo in the video handler event name to ensure the 'onCompleted' event triggers correctly.

Bug Fixes:
- Correct the event name from 'complete' to 'completed' in the video handler to ensure proper functionality.

<!-- Generated by sourcery-ai[bot]: end summary -->