### PR TITLE
adds floating_action_button_theme property to Theme

### DIFF
--- a/sdk/python/packages/flet-core/src/flet_core/theme.py
+++ b/sdk/python/packages/flet-core/src/flet_core/theme.py
@@ -686,6 +686,7 @@ class Theme:
     divider_theme: Optional[DividerTheme] = field(default=None)
     # dropdown_menu_theme: Optional[DropdownMenuTheme] = field(default=None)
     expansion_tile_theme: Optional[ExpansionTileTheme] = field(default=None)
+    floating_action_button_theme: Optional[FloatingActionButtonTheme] = field(default=None)
     list_tile_theme: Optional[ListTileTheme] = field(default=None)
     navigation_bar_theme: Optional[NavigationBarTheme] = field(default=None)
     navigation_drawer_theme: Optional[NavigationDrawerTheme] = field(default=None)


### PR DESCRIPTION
## Description

Adds `floating_action_button_theme` to `flet.Theme` to override `FloatingActionButtonTheme`
Fixes #(issue)

#3770 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I signed the CLA.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
<!-- - [ ] I have added tests that prove my fix is effective or that my feature works as expected -->

- [x] New and existing tests pass locally with my changes
- [ ] I have made corresponding changes to the [documentation](https://github.com/flet-dev/website) (if applicable)

## Screenshots (if applicable):

## Additional details

<!-- Add any other context to be known about this PR. -->

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Introduce a new property `floating_action_button_theme` to the `flet.Theme` class, enabling customization of the `FloatingActionButtonTheme`.

New Features:
- Add `floating_action_button_theme` property to `flet.Theme` to allow overriding `FloatingActionButtonTheme`.

<!-- Generated by sourcery-ai[bot]: end summary -->