### PR TITLE
fix!: `InputFilter` clears `TextField` when an invalid character is entered 

### DIFF
--- a/packages/flet/lib/src/controls/textfield.dart
+++ b/packages/flet/lib/src/controls/textfield.dart
@@ -360,3 +360,19 @@ class TextCapitalizationFormatter extends TextInputFormatter {
       .map((str) => inCaps(str))
       .join(" ");
 }
+
+class CustomNumberFormatter extends TextInputFormatter {
+  final String pattern;
+
+  CustomNumberFormatter(this.pattern);
+
+  @override
+  TextEditingValue formatEditUpdate(TextEditingValue oldValue, TextEditingValue newValue) {
+    final regExp = RegExp(pattern);
+    if (regExp.hasMatch(newValue.text)) {
+      return newValue;
+    }
+    // If newValue is invalid, keep the old value
+    return oldValue;
+  }
+}

--- a/packages/flet/lib/src/utils/textfield.dart
+++ b/packages/flet/lib/src/utils/textfield.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
 
 import '../models/control.dart';
@@ -51,13 +50,10 @@ class CustomFilteringTextInputFormatter extends FilteringTextInputFormatter {
   @override
   TextEditingValue formatEditUpdate(
       TextEditingValue oldValue, TextEditingValue newValue) {
-    debugPrint(
-        "oldValue: ${oldValue.text}, newValue: ${newValue.text}, hasMatch: ${_pattern.hasMatch(newValue.text)}");
-    // Check if the new value matches the regex pattern
+    // Check if the new value matches the regex pattern and return it if it does
     if (_pattern.hasMatch(newValue.text)) {
-      return newValue; // Accept the new value if it matches the pattern
+      return newValue;
     }
-    // If the new value does not match the pattern, return the old value
     return oldValue;
   }
 }

--- a/sdk/python/packages/flet-core/src/flet_core/textfield.py
+++ b/sdk/python/packages/flet-core/src/flet_core/textfield.py
@@ -1,6 +1,5 @@
 import dataclasses
 import time
-from dataclasses import field
 from enum import Enum
 from typing import Any, Optional, Union, List
 
@@ -54,18 +53,22 @@ class TextCapitalization(Enum):
 @dataclasses.dataclass
 class InputFilter:
     regex_string: str
-    allow: bool = field(default=True)
-    replacement_string: str = field(default="")
+    allow: bool = True
+    replacement_string: str = ""
+    multiline: bool = False
+    case_sensitive: bool = True
+    unicode: bool = False
+    dot_all: bool = False
 
 
 class NumbersOnlyInputFilter(InputFilter):
     def __init__(self):
-        super().__init__(regex_string=r"[0-9]")
+        super().__init__(regex_string=r"^[0-9]*$", allow=True, replacement_string="")
 
 
 class TextOnlyInputFilter(InputFilter):
     def __init__(self):
-        super().__init__(regex_string=r"[a-zA-Z]")
+        super().__init__(regex_string=r"^[a-zA-Z]*$", allow=True, replacement_string="")
 
 
 class TextField(FormFieldControl, AdaptiveControl):
@@ -130,7 +133,7 @@ class TextField(FormFieldControl, AdaptiveControl):
         on_focus: OptionalEventCallable = None,
         on_blur: OptionalEventCallable = None,
         #
-        # FormField specific
+        # FormField
         #
         text_size: OptionalNumber = None,
         text_style: Optional[TextStyle] = None,


### PR DESCRIPTION
## Description
Fixes #3769

A custom `FilteringTextInputFormatter` has been created to prevent non-matching characters from causing the deletion of the whole field content.

## Breaking Change
Solving this issue resulted to a breaking change: most of the `regex_string`s must be updated to use anchors.

### Why?
This is caused by `RegExp.hasMatch()` allowing non-matching characters to be entered/visible (without replacement), as long as the field content contains a matching substring.

### Migration
Use start(`^`) and end(`$`) anchors in the pattern/regexString:
- `r"[a-zA-Z]"`   ->   `r"^[a-zA-Z]*$"`
- `r"[0-9]"`  ->  `r"^[0-9]*$"`

In the above cases, the `*` is important, else it will be impossible to delete the last character in the field.
 
#### AI Prompt
To ease migration, below is a simple prompt that can be useful:
```
Help me update the following regex pattern: ####### 
Ensure the entire string matches the pattern and allows for an empty string. 
```
## Test Code

```python
import flet as ft


def main(page: ft.Page):

    page.add(
        ft.TextField(
            label="Ex: 2244.89",
            keyboard_type=ft.KeyboardType.NUMBER,
            input_filter=ft.InputFilter(
                allow=True,
                regex_string=r"^\d*(\.\d{0,2})?$",
                replacement_string="",
            ),
        )
    )


ft.app(target=main)

```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix issue where `InputFilter` clears `TextField` when an invalid character is entered by introducing `CustomFilteringTextInputFormatter`. This change requires updating most `regex_string`s to use start (`^`) and end (`$`) anchors to ensure proper matching.

Bug Fixes:
- Prevent `InputFilter` from clearing the entire `TextField` content when an invalid character is entered.

Enhancements:
- Introduce `CustomFilteringTextInputFormatter` to handle input filtering with more control over regex patterns and matching behavior.

<!-- Generated by sourcery-ai[bot]: end summary -->