### PR TITLE
chore: remove (biased) event-handler subscription, preventing an event of having more than 1 handlers 

### DIFF
--- a/sdk/python/packages/flet-core/src/flet_core/auto_complete.py
+++ b/sdk/python/packages/flet-core/src/flet_core/auto_complete.py
@@ -28,7 +28,7 @@ class AutoComplete(Control):
         self,
         suggestions: Optional[List[AutoCompleteSuggestion]] = None,
         suggestions_max_height: OptionalNumber = None,
-        on_select=None,
+        on_select: OptionalEventCallable["AutoCompleteSelectEvent"] = None,
         #
         # Control
         #
@@ -87,12 +87,12 @@ class AutoComplete(Control):
 
     # on_select
     @property
-    def on_select(self):
-        return self._get_event_handler("select")
+    def on_select(self) -> OptionalEventCallable["AutoCompleteSelectEvent"]:
+        return self.__on_select.handler
 
     @on_select.setter
     def on_select(self, handler: OptionalEventCallable["AutoCompleteSelectEvent"]):
-        self.__on_select.subscribe(handler)
+        self.__on_select.handler = handler
 
 
 class AutoCompleteSelectEvent(ControlEvent):

--- a/sdk/python/packages/flet-core/src/flet_core/canvas/canvas.py
+++ b/sdk/python/packages/flet-core/src/flet_core/canvas/canvas.py
@@ -141,12 +141,12 @@ class Canvas(ConstrainedControl):
 
     # on_resize
     @property
-    def on_resize(self):
-        return self.__on_resize
+    def on_resize(self) -> OptionalEventCallable["CanvasResizeEvent"]:
+        return self.__on_resize.handler
 
     @on_resize.setter
     def on_resize(self, handler: OptionalEventCallable["CanvasResizeEvent"]):
-        self.__on_resize.subscribe(handler)
+        self.__on_resize.handler = handler
         self._set_attr("onresize", True if handler is not None else None)
 
 

--- a/sdk/python/packages/flet-core/src/flet_core/charts/bar_chart.py
+++ b/sdk/python/packages/flet-core/src/flet_core/charts/bar_chart.py
@@ -407,12 +407,12 @@ class BarChart(ConstrainedControl):
 
     # on_chart_event
     @property
-    def on_chart_event(self):
-        return self.__on_chart_event
+    def on_chart_event(self) -> OptionalEventCallable["BarChartEvent"]:
+        return self.__on_chart_event.handler
 
     @on_chart_event.setter
     def on_chart_event(self, handler: OptionalEventCallable["BarChartEvent"]):
-        self.__on_chart_event.subscribe(handler)
+        self.__on_chart_event.handler = handler
         self._set_attr("onChartEvent", True if handler is not None else None)
 
 

--- a/sdk/python/packages/flet-core/src/flet_core/charts/line_chart.py
+++ b/sdk/python/packages/flet-core/src/flet_core/charts/line_chart.py
@@ -453,12 +453,12 @@ class LineChart(ConstrainedControl):
 
     # on_chart_event
     @property
-    def on_chart_event(self):
-        return self.__on_chart_event
+    def on_chart_event(self) -> OptionalEventCallable["LineChartEvent"]:
+        return self.__on_chart_event.handler
 
     @on_chart_event.setter
     def on_chart_event(self, handler: OptionalEventCallable["LineChartEvent"]):
-        self.__on_chart_event.subscribe(handler)
+        self.__on_chart_event.handler = handler
         self._set_attr("onChartEvent", True if handler is not None else None)
 
 

--- a/sdk/python/packages/flet-core/src/flet_core/charts/pie_chart.py
+++ b/sdk/python/packages/flet-core/src/flet_core/charts/pie_chart.py
@@ -168,12 +168,12 @@ class PieChart(ConstrainedControl):
 
     # on_chart_event
     @property
-    def on_chart_event(self):
-        return self.__on_chart_event
+    def on_chart_event(self) -> OptionalEventCallable["PieChartEvent"]:
+        return self.__on_chart_event.handler
 
     @on_chart_event.setter
     def on_chart_event(self, handler: OptionalEventCallable["PieChartEvent"]):
-        self.__on_chart_event.subscribe(handler)
+        self.__on_chart_event.handler = handler
         self._set_attr("onChartEvent", True if handler is not None else None)
 
 

--- a/sdk/python/packages/flet-core/src/flet_core/container.py
+++ b/sdk/python/packages/flet-core/src/flet_core/container.py
@@ -295,9 +295,7 @@ class Container(ConstrainedControl, AdaptiveControl):
     @blend_mode.setter
     def blend_mode(self, value: Optional[BlendMode]):
         self.__blend_mode = value
-        self._set_attr(
-            "blendMode", value.value if isinstance(value, BlendMode) else value
-        )
+        self._set_enum_attr("blendMode", value, BlendMode)
 
     # blur
     @property
@@ -569,12 +567,12 @@ class Container(ConstrainedControl, AdaptiveControl):
 
     # on_tap_down
     @property
-    def on_tap_down(self):
-        return self.__on_tap_down
+    def on_tap_down(self) -> OptionalEventCallable["ContainerTapEvent"]:
+        return self.__on_tap_down.handler
 
     @on_tap_down.setter
     def on_tap_down(self, handler: OptionalEventCallable["ContainerTapEvent"]):
-        self.__on_tap_down.subscribe(handler)
+        self.__on_tap_down.handler = handler
         self._set_attr("onTapDown", True if handler is not None else None)
 
     # on_long_press

--- a/sdk/python/packages/flet-core/src/flet_core/control.py
+++ b/sdk/python/packages/flet-core/src/flet_core/control.py
@@ -73,7 +73,7 @@ class Control:
         self.data = data
         self.rtl = rtl
 
-        self.__event_handlers: Dict[str, OptionalEventCallable] = {}
+        self.__event_handlers: Dict[str, OptionalControlEventCallable] = {}
         self.parent: Optional[Control] = None
 
     def is_isolated(self) -> bool:
@@ -103,7 +103,7 @@ class Control:
         )
 
     def _add_event_handler(
-        self, event_name: str, handler: OptionalEventCallable
+        self, event_name: str, handler: OptionalControlEventCallable
     ) -> None:
         self.__event_handlers[event_name] = handler
 

--- a/sdk/python/packages/flet-core/src/flet_core/datatable.py
+++ b/sdk/python/packages/flet-core/src/flet_core/datatable.py
@@ -97,12 +97,12 @@ class DataColumn(Control):
 
     # on_sort
     @property
-    def on_sort(self):
-        return self.__on_sort
+    def on_sort(self) -> OptionalEventCallable["DataColumnSortEvent"]:
+        return self.__on_sort.handler
 
     @on_sort.setter
-    def on_sort(self, handler: Optional[Callable[[DataColumnSortEvent], None]]):
-        self.__on_sort.subscribe(handler)
+    def on_sort(self, handler: OptionalEventCallable["DataColumnSortEvent"]):
+        self.__on_sort.handler = handler
         self._set_attr("onSort", True if handler is not None else None)
 
 
@@ -218,12 +218,12 @@ class DataCell(Control):
 
     # on_tap_down
     @property
-    def on_tap_down(self):
-        return self.__on_tap_down
+    def on_tap_down(self) -> OptionalEventCallable[TapEvent]:
+        return self.__on_tap_down.handler
 
     @on_tap_down.setter
-    def on_tap_down(self, handler: Optional[Callable[[TapEvent], None]]):
-        self.__on_tap_down.subscribe(handler)
+    def on_tap_down(self, handler: OptionalEventCallable[TapEvent]):
+        self.__on_tap_down.handler = handler
         self._set_attr("onTapDown", True if handler is not None else None)
 
 

--- a/sdk/python/packages/flet-core/src/flet_core/date_picker.py
+++ b/sdk/python/packages/flet-core/src/flet_core/date_picker.py
@@ -378,11 +378,13 @@ class DatePicker(Control):
 
     # on_entry_mode_change
     @property
-    def on_entry_mode_change(self):
-        return self.__on_entry_mode_change
+    def on_entry_mode_change(
+        self,
+    ) -> OptionalEventCallable[DatePickerEntryModeChangeEvent]:
+        return self.__on_entry_mode_change.handler
 
     @on_entry_mode_change.setter
     def on_entry_mode_change(
-        self, handler: Optional[Callable[[DatePickerEntryModeChangeEvent], None]]
+        self, handler: OptionalEventCallable[DatePickerEntryModeChangeEvent]
     ):
-        self.__on_entry_mode_change.subscribe(handler)
+        self.__on_entry_mode_change.handler = handler

--- a/sdk/python/packages/flet-core/src/flet_core/dismissible.py
+++ b/sdk/python/packages/flet-core/src/flet_core/dismissible.py
@@ -247,34 +247,34 @@ class Dismissible(ConstrainedControl, AdaptiveControl):
 
     # on_dismiss
     @property
-    def on_dismiss(self):
-        return self._get_event_handler("dismiss")
+    def on_dismiss(self) -> OptionalEventCallable["DismissibleDismissEvent"]:
+        return self.__on_dismiss.handler
 
     @on_dismiss.setter
     def on_dismiss(self, handler: OptionalEventCallable["DismissibleDismissEvent"]):
-        self.__on_dismiss.subscribe(handler)
+        self.__on_dismiss.handler = handler
         self._set_attr("onDismiss", True if handler is not None else None)
 
     # on_confirm_dismiss
     @property
-    def on_confirm_dismiss(self):
-        return self._get_event_handler("confirm_dismiss")
+    def on_confirm_dismiss(self) -> OptionalEventCallable["DismissibleDismissEvent"]:
+        return self.__on_confirm_dismiss.handler
 
     @on_confirm_dismiss.setter
     def on_confirm_dismiss(
         self, handler: OptionalEventCallable["DismissibleDismissEvent"]
     ):
-        self.__on_confirm_dismiss.subscribe(handler)
+        self.__on_confirm_dismiss.handler = handler
         self._set_attr("onConfirmDismiss", True if handler is not None else None)
 
     # on_update
     @property
-    def on_update(self):
-        return self._get_event_handler("update")
+    def on_update(self) -> OptionalEventCallable["DismissibleUpdateEvent"]:
+        return self.__on_update.handler
 
     @on_update.setter
     def on_update(self, handler: OptionalEventCallable["DismissibleUpdateEvent"]):
-        self.__on_update.subscribe(handler)
+        self.__on_update.handler = handler
         self._set_attr("onUpdate", True if handler is not None else None)
 
     # on_resize

--- a/sdk/python/packages/flet-core/src/flet_core/drag_target.py
+++ b/sdk/python/packages/flet-core/src/flet_core/drag_target.py
@@ -6,6 +6,7 @@ from flet_core.control import Control
 from flet_core.control_event import ControlEvent
 from flet_core.event_handler import EventHandler
 from flet_core.ref import Ref
+from flet_core.types import OptionalControlEventCallable, OptionalEventCallable
 
 
 class DragTarget(Control):
@@ -106,10 +107,10 @@ class DragTarget(Control):
         self,
         content: Control,
         group: Optional[str] = None,
-        on_will_accept=None,
-        on_accept=None,
-        on_leave=None,
-        on_move=None,
+        on_will_accept: OptionalControlEventCallable = None,
+        on_accept: OptionalEventCallable["DragTargetEvent"] = None,
+        on_leave: OptionalControlEventCallable = None,
+        on_move: OptionalEventCallable["DragTargetEvent"] = None,
         #
         # Control
         #
@@ -170,39 +171,39 @@ class DragTarget(Control):
 
     # on_will_accept
     @property
-    def on_will_accept(self):
+    def on_will_accept(self) -> OptionalControlEventCallable:
         return self._get_event_handler("will_accept")
 
     @on_will_accept.setter
-    def on_will_accept(self, handler):
+    def on_will_accept(self, handler: OptionalControlEventCallable):
         self._add_event_handler("will_accept", handler)
 
     # on_accept
     @property
-    def on_accept(self):
-        return self.__on_accept
+    def on_accept(self) -> OptionalEventCallable["DragTargetEvent"]:
+        return self.__on_accept.handler
 
     @on_accept.setter
-    def on_accept(self, handler):
-        self.__on_accept.subscribe(handler)
+    def on_accept(self, handler: OptionalEventCallable["DragTargetEvent"]):
+        self.__on_accept.handler = handler
 
     # on_leave
     @property
-    def on_leave(self):
+    def on_leave(self) -> OptionalControlEventCallable:
         return self._get_event_handler("leave")
 
     @on_leave.setter
-    def on_leave(self, handler):
+    def on_leave(self, handler: OptionalControlEventCallable):
         self._add_event_handler("leave", handler)
 
     # on_move
     @property
-    def on_move(self):
-        return self.__on_move
+    def on_move(self) -> OptionalEventCallable["DragTargetEvent"]:
+        return self.__on_move.handler
 
     @on_move.setter
-    def on_move(self, handler):
-        self.__on_move.subscribe(handler)
+    def on_move(self, handler: OptionalEventCallable["DragTargetEvent"]):
+        self.__on_move.handler = handler
 
 
 class DragTargetAcceptEvent(ControlEvent):

--- a/sdk/python/packages/flet-core/src/flet_core/event_handler.py
+++ b/sdk/python/packages/flet-core/src/flet_core/event_handler.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Callable
+from typing import Callable, Optional
 
 from flet_core.control_event import ControlEvent
 from flet_core.types import OptionalControlEventCallable
@@ -8,11 +8,11 @@ from flet_core.types import OptionalControlEventCallable
 class EventHandler:
     def __init__(self, result_converter=None) -> None:
         self.__result_converter = result_converter
-        self.__handlers = {}
+        self.handler: OptionalControlEventCallable = None
 
     def get_handler(self):
         async def fn(e: ControlEvent):
-            for handler in self.__handlers.keys():
+            if self.handler is not None:
                 ce = e
                 if self.__result_converter is not None:
                     ce = self.__result_converter(e)
@@ -24,20 +24,9 @@ class EventHandler:
                         ce.page = e.page
 
                 if ce is not None:
-                    if asyncio.iscoroutinefunction(handler):
-                        await handler(ce)
+                    if asyncio.iscoroutinefunction(self.handler):
+                        await self.handler(ce)
                     else:
-                        e.page.run_thread(handler, ce)
+                        e.page.run_thread(self.handler, ce)
 
         return fn
-
-    def subscribe(self, handler: OptionalControlEventCallable):
-        if handler is not None:
-            self.__handlers[handler] = True
-
-    def unsubscribe(self, handler: Callable[[ControlEvent], None]):
-        if handler in self.__handlers:
-            self.__handlers.pop(handler)
-
-    def count(self) -> int:
-        return len(self.__handlers)

--- a/sdk/python/packages/flet-core/src/flet_core/file_picker.py
+++ b/sdk/python/packages/flet-core/src/flet_core/file_picker.py
@@ -7,6 +7,7 @@ from flet_core.control import Control
 from flet_core.control_event import ControlEvent
 from flet_core.event_handler import EventHandler
 from flet_core.ref import Ref
+from flet_core.types import OptionalEventCallable
 from flet_core.utils import deprecated
 
 try:
@@ -329,18 +330,18 @@ class FilePicker(Control):
 
     # on_result
     @property
-    def on_result(self):
-        return self.__on_result
+    def on_result(self) -> OptionalEventCallable[FilePickerResultEvent]:
+        return self.__on_result.handler
 
     @on_result.setter
-    def on_result(self, handler: Optional[Callable[[FilePickerResultEvent], None]]):
-        self.__on_result.subscribe(handler)
+    def on_result(self, handler: OptionalEventCallable[FilePickerResultEvent]):
+        self.__on_result.handler = handler
 
     # on_upload
     @property
     def on_upload(self):
-        return self.__on_upload
+        return self.__on_upload.handler
 
     @on_upload.setter
-    def on_upload(self, handler: Optional[Callable[[FilePickerUploadEvent], None]]):
-        self.__on_upload.subscribe(handler)
+    def on_upload(self, handler: OptionalEventCallable[FilePickerUploadEvent]):
+        self.__on_upload.handler = handler

--- a/sdk/python/packages/flet-core/src/flet_core/gesture_detector.py
+++ b/sdk/python/packages/flet-core/src/flet_core/gesture_detector.py
@@ -377,32 +377,32 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
 
     # on_tap_down
     @property
-    def on_tap_down(self):
-        return self.__on_tap_down
+    def on_tap_down(self) -> OptionalEventCallable["TapEvent"]:
+        return self.__on_tap_down.handler
 
     @on_tap_down.setter
     def on_tap_down(self, handler: OptionalEventCallable["TapEvent"]):
-        self.__on_tap_down.subscribe(handler)
+        self.__on_tap_down.handler = handler
         self._set_attr("onTapDown", True if handler is not None else None)
 
     # on_tap_up
     @property
-    def on_tap_up(self):
-        return self.__on_tap_up
+    def on_tap_up(self) -> OptionalEventCallable["TapEvent"]:
+        return self.__on_tap_up.handler
 
     @on_tap_up.setter
     def on_tap_up(self, handler: OptionalEventCallable["TapEvent"]):
-        self.__on_tap_up.subscribe(handler)
+        self.__on_tap_up.handler = handler
         self._set_attr("onTapUp", True if handler is not None else None)
 
     # on_multi_tap
     @property
-    def on_multi_tap(self):
-        return self.__on_multi_tap
+    def on_multi_tap(self) -> OptionalEventCallable["MultiTapEvent"]:
+        return self.__on_multi_tap.handler
 
     @on_multi_tap.setter
     def on_multi_tap(self, handler: OptionalEventCallable["MultiTapEvent"]):
-        self.__on_multi_tap.subscribe(handler)
+        self.__on_multi_tap.handler = handler
         self._set_attr("onMultiTap", True if handler is not None else None)
 
     # multi_tap_touches
@@ -436,70 +436,72 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
 
     # on_tap_down
     @property
-    def on_secondary_tap_down(self):
-        return self.__on_secondary_tap_down
+    def on_secondary_tap_down(self) -> OptionalEventCallable["TapEvent"]:
+        return self.__on_secondary_tap_down.handler
 
     @on_secondary_tap_down.setter
     def on_secondary_tap_down(self, handler: OptionalEventCallable["TapEvent"]):
-        self.__on_secondary_tap_down.subscribe(handler)
+        self.__on_secondary_tap_down.handler = handler
         self._set_attr("onSecondaryTapDown", True if handler is not None else None)
 
     # on_secondary_tap_up
     @property
-    def on_secondary_tap_up(self):
-        return self.__on_secondary_tap_up
+    def on_secondary_tap_up(self) -> OptionalEventCallable["TapEvent"]:
+        return self.__on_secondary_tap_up.handler
 
     @on_secondary_tap_up.setter
     def on_secondary_tap_up(self, handler: OptionalEventCallable["TapEvent"]):
-        self.__on_secondary_tap_up.subscribe(handler)
+        self.__on_secondary_tap_up.handler = handler
         self._set_attr("onSecondaryTapUp", True if handler is not None else None)
 
     # on_long_press_start
     @property
-    def on_long_press_start(self):
-        return self.__on_long_press_start
+    def on_long_press_start(self) -> OptionalEventCallable["LongPressStartEvent"]:
+        return self.__on_long_press_start.handler
 
     @on_long_press_start.setter
     def on_long_press_start(
         self, handler: OptionalEventCallable["LongPressStartEvent"]
     ):
-        self.__on_long_press_start.subscribe(handler)
+        self.__on_long_press_start.handler = handler
         self._set_attr("onLongPressStart", True if handler is not None else None)
 
     # on_long_press_end
     @property
-    def on_long_press_end(self):
-        return self.__on_long_press_end
+    def on_long_press_end(self) -> OptionalEventCallable["LongPressEndEvent"]:
+        return self.__on_long_press_end.handler
 
     @on_long_press_end.setter
     def on_long_press_end(self, handler: OptionalEventCallable["LongPressEndEvent"]):
-        self.__on_long_press_end.subscribe(handler)
+        self.__on_long_press_end.handler = handler
         self._set_attr("onLongPressEnd", True if handler is not None else None)
 
     # on_secondary_long_press_start
     @property
-    def on_secondary_long_press_start(self):
-        return self.__on_secondary_long_press_start
+    def on_secondary_long_press_start(
+        self,
+    ) -> OptionalEventCallable["LongPressStartEvent"]:
+        return self.__on_secondary_long_press_start.handler
 
     @on_secondary_long_press_start.setter
     def on_secondary_long_press_start(
         self, handler: OptionalEventCallable["LongPressStartEvent"]
     ):
-        self.__on_secondary_long_press_start.subscribe(handler)
+        self.__on_secondary_long_press_start.handler = handler
         self._set_attr(
             "onSecondaryLongPressStart", True if handler is not None else None
         )
 
     # on_secondary_long_press_end
     @property
-    def on_secondary_long_press_end(self):
-        return self.__on_secondary_long_press_end
+    def on_secondary_long_press_end(self) -> OptionalEventCallable["LongPressEndEvent"]:
+        return self.__on_secondary_long_press_end.handler
 
     @on_secondary_long_press_end.setter
     def on_secondary_long_press_end(
         self, handler: OptionalEventCallable["LongPressEndEvent"]
     ):
-        self.__on_secondary_long_press_end.subscribe(handler)
+        self.__on_secondary_long_press_end.handler = handler
         self._set_attr("onSecondaryLongPressEnd", True if handler is not None else None)
 
     # on_double_tap
@@ -514,178 +516,178 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
 
     # on_double_tap_down
     @property
-    def on_double_tap_down(self):
-        return self.__on_double_tap_down
+    def on_double_tap_down(self) -> OptionalEventCallable["TapEvent"]:
+        return self.__on_double_tap_down.handler
 
     @on_double_tap_down.setter
     def on_double_tap_down(self, handler: OptionalEventCallable["TapEvent"]):
-        self.__on_double_tap_down.subscribe(handler)
+        self.__on_double_tap_down.handler = handler
         self._set_attr("onDoubleTapDown", True if handler is not None else None)
 
     # on_horizontal_drag_start
     @property
-    def on_horizontal_drag_start(self):
-        return self.__on_horizontal_drag_start
+    def on_horizontal_drag_start(self) -> OptionalEventCallable["DragStartEvent"]:
+        return self.__on_horizontal_drag_start.handler
 
     @on_horizontal_drag_start.setter
     def on_horizontal_drag_start(
         self, handler: OptionalEventCallable["DragStartEvent"]
     ):
-        self.__on_horizontal_drag_start.subscribe(handler)
+        self.__on_horizontal_drag_start.handler = handler
         self._set_attr("onHorizontalDragStart", True if handler is not None else None)
 
     # on_horizontal_drag_update
     @property
-    def on_horizontal_drag_update(self):
-        return self.__on_horizontal_drag_update
+    def on_horizontal_drag_update(self) -> OptionalEventCallable["DragUpdateEvent"]:
+        return self.__on_horizontal_drag_update.handler
 
     @on_horizontal_drag_update.setter
     def on_horizontal_drag_update(
         self, handler: OptionalEventCallable["DragUpdateEvent"]
     ):
-        self.__on_horizontal_drag_update.subscribe(handler)
+        self.__on_horizontal_drag_update.handler = handler
         self._set_attr("onHorizontalDragUpdate", True if handler is not None else None)
 
     # on_horizontal_drag_end
     @property
-    def on_horizontal_drag_end(self):
-        return self.__on_horizontal_drag_end
+    def on_horizontal_drag_end(self) -> OptionalEventCallable["DragEndEvent"]:
+        return self.__on_horizontal_drag_end.handler
 
     @on_horizontal_drag_end.setter
     def on_horizontal_drag_end(self, handler: OptionalEventCallable["DragEndEvent"]):
-        self.__on_horizontal_drag_end.subscribe(handler)
+        self.__on_horizontal_drag_end.handler = handler
         self._set_attr("onHorizontalDragEnd", True if handler is not None else None)
 
     # on_vertical_drag_start
     @property
-    def on_vertical_drag_start(self):
-        return self.__on_vertical_drag_start
+    def on_vertical_drag_start(self) -> OptionalEventCallable["DragStartEvent"]:
+        return self.__on_vertical_drag_start.handler
 
     @on_vertical_drag_start.setter
     def on_vertical_drag_start(self, handler: OptionalEventCallable["DragStartEvent"]):
-        self.__on_vertical_drag_start.subscribe(handler)
+        self.__on_vertical_drag_start.handler = handler
         self._set_attr("onVerticalDragStart", True if handler is not None else None)
 
     # on_vertical_drag_update
     @property
-    def on_vertical_drag_update(self):
-        return self.__on_vertical_drag_update
+    def on_vertical_drag_update(self) -> OptionalEventCallable["DragUpdateEvent"]:
+        return self.__on_vertical_drag_update.handler
 
     @on_vertical_drag_update.setter
     def on_vertical_drag_update(
         self, handler: OptionalEventCallable["DragUpdateEvent"]
     ):
-        self.__on_vertical_drag_update.subscribe(handler)
+        self.__on_vertical_drag_update.handler = handler
         self._set_attr("onVerticalDragUpdate", True if handler is not None else None)
 
     # on_vertical_drag_end
     @property
-    def on_vertical_drag_end(self):
-        return self.__on_vertical_drag_end
+    def on_vertical_drag_end(self) -> OptionalEventCallable["DragEndEvent"]:
+        return self.__on_vertical_drag_end.handler
 
     @on_vertical_drag_end.setter
     def on_vertical_drag_end(self, handler: OptionalEventCallable["DragEndEvent"]):
-        self.__on_vertical_drag_end.subscribe(handler)
+        self.__on_vertical_drag_end.handler = handler
         self._set_attr("onVerticalDragEnd", True if handler is not None else None)
 
     # on_pan_start
     @property
-    def on_pan_start(self):
-        return self.__on_pan_start
+    def on_pan_start(self) -> OptionalEventCallable["DragStartEvent"]:
+        return self.__on_pan_start.handler
 
     @on_pan_start.setter
     def on_pan_start(self, handler: OptionalEventCallable["DragStartEvent"]):
-        self.__on_pan_start.subscribe(handler)
+        self.__on_pan_start.handler = handler
         self._set_attr("onPanStart", True if handler is not None else None)
 
     # on_pan_updatevertical_drag
     @property
-    def on_pan_update(self):
-        return self.__on_pan_update
+    def on_pan_update(self) -> OptionalEventCallable["DragUpdateEvent"]:
+        return self.__on_pan_update.handler
 
     @on_pan_update.setter
     def on_pan_update(self, handler: OptionalEventCallable["DragUpdateEvent"]):
-        self.__on_pan_update.subscribe(handler)
+        self.__on_pan_update.handler = handler
         self._set_attr("onPanUpdate", True if handler is not None else None)
 
     # on_pan_end
     @property
-    def on_pan_end(self):
-        return self.__on_pan_end
+    def on_pan_end(self) -> OptionalEventCallable["DragEndEvent"]:
+        return self.__on_pan_end.handler
 
     @on_pan_end.setter
     def on_pan_end(self, handler: OptionalEventCallable["DragEndEvent"]):
-        self.__on_pan_end.subscribe(handler)
+        self.__on_pan_end.handler = handler
         self._set_attr("onPanEnd", True if handler is not None else None)
 
     # on_scale_start
     @property
-    def on_scale_start(self):
-        return self.__on_scale_start
+    def on_scale_start(self) -> OptionalEventCallable["ScaleStartEvent"]:
+        return self.__on_scale_start.handler
 
     @on_scale_start.setter
     def on_scale_start(self, handler: OptionalEventCallable["ScaleStartEvent"]):
-        self.__on_scale_start.subscribe(handler)
+        self.__on_scale_start.handler = handler
         self._set_attr("onScaleStart", True if handler is not None else None)
 
     # on_scale_update
     @property
-    def on_scale_update(self):
-        return self.__on_scale_update
+    def on_scale_update(self) -> OptionalEventCallable["ScaleUpdateEvent"]:
+        return self.__on_scale_update.handler
 
     @on_scale_update.setter
     def on_scale_update(self, handler: OptionalEventCallable["ScaleUpdateEvent"]):
-        self.__on_scale_update.subscribe(handler)
+        self.__on_scale_update.handler = handler
         self._set_attr("onScaleUpdate", True if handler is not None else None)
 
     # on_scale_end
     @property
-    def on_scale_end(self):
-        return self.__on_scale_end
+    def on_scale_end(self) -> OptionalEventCallable["ScaleEndEvent"]:
+        return self.__on_scale_end.handler
 
     @on_scale_end.setter
     def on_scale_end(self, handler: OptionalEventCallable["ScaleEndEvent"]):
-        self.__on_scale_end.subscribe(handler)
+        self.__on_scale_end.handler = handler
         self._set_attr("onScaleEnd", True if handler is not None else None)
 
     # on_hover
     @property
-    def on_hover(self):
-        return self.__on_hover
+    def on_hover(self) -> OptionalEventCallable["HoverEvent"]:
+        return self.__on_hover.handler
 
     @on_hover.setter
     def on_hover(self, handler: OptionalEventCallable["HoverEvent"]):
-        self.__on_hover.subscribe(handler)
+        self.__on_hover.handler = handler
         self._set_attr("onHover", True if handler is not None else None)
 
     # on_enter
     @property
-    def on_enter(self):
-        return self.__on_enter
+    def on_enter(self) -> OptionalEventCallable["HoverEvent"]:
+        return self.__on_enter.handler
 
     @on_enter.setter
     def on_enter(self, handler: OptionalEventCallable["HoverEvent"]):
-        self.__on_enter.subscribe(handler)
+        self.__on_enter.handler = handler
         self._set_attr("onEnter", True if handler is not None else None)
 
     # on_exit
     @property
-    def on_exit(self):
-        return self.__on_exit
+    def on_exit(self) -> OptionalEventCallable["HoverEvent"]:
+        return self.__on_exit.handler
 
     @on_exit.setter
     def on_exit(self, handler: OptionalEventCallable["HoverEvent"]):
-        self.__on_exit.subscribe(handler)
+        self.__on_exit.handler = handler
         self._set_attr("onExit", True if handler is not None else None)
 
     # on_scroll
     @property
-    def on_scroll(self):
-        return self.__on_scroll
+    def on_scroll(self) -> OptionalEventCallable["ScrollEvent"]:
+        return self.__on_scroll.handler
 
     @on_scroll.setter
     def on_scroll(self, handler: OptionalEventCallable["ScrollEvent"]):
-        self.__on_scroll.subscribe(handler)
+        self.__on_scroll.handler = handler
         self._set_attr("onScroll", True if handler is not None else None)
 
 

--- a/sdk/python/packages/flet-core/src/flet_core/interactive_viewer.py
+++ b/sdk/python/packages/flet-core/src/flet_core/interactive_viewer.py
@@ -310,35 +310,41 @@ class InteractiveViewer(ConstrainedControl, AdaptiveControl):
 
     # on_interaction_start
     @property
-    def on_interaction_start(self):
-        return self._get_event_handler("interaction_start")
+    def on_interaction_start(
+        self,
+    ) -> OptionalEventCallable[InteractiveViewerInteractionStartEvent]:
+        return self.__on_interaction_start.handler
 
     @on_interaction_start.setter
     def on_interaction_start(
         self,
-        handler: Optional[Callable[[InteractiveViewerInteractionStartEvent], None]],
+        handler: OptionalEventCallable[InteractiveViewerInteractionStartEvent],
     ):
-        self.__on_interaction_start.subscribe(handler)
+        self.__on_interaction_start.handler = handler
 
     # on_interaction_update
     @property
-    def on_interaction_update(self):
-        return self._get_event_handler("interaction_update")
+    def on_interaction_update(
+        self,
+    ) -> OptionalEventCallable[InteractiveViewerInteractionUpdateEvent]:
+        return self.__on_interaction_update.handler
 
     @on_interaction_update.setter
     def on_interaction_update(
         self,
-        handler: Optional[Callable[[InteractiveViewerInteractionUpdateEvent], None]],
+        handler: OptionalEventCallable[InteractiveViewerInteractionUpdateEvent],
     ):
-        self.__on_interaction_update.subscribe(handler)
+        self.__on_interaction_update.handler = handler
 
     # on_interaction_end
     @property
-    def on_interaction_end(self):
-        return self._get_event_handler("interaction_end")
+    def on_interaction_end(
+        self,
+    ) -> OptionalEventCallable[InteractiveViewerInteractionEndEvent]:
+        return self.__on_interaction_end.handler
 
     @on_interaction_end.setter
     def on_interaction_end(
-        self, handler: Optional[Callable[[InteractiveViewerInteractionEndEvent], None]]
+        self, handler: OptionalEventCallable[InteractiveViewerInteractionEndEvent]
     ):
-        self.__on_interaction_end.subscribe(handler)
+        self.__on_interaction_end.handler = handler

--- a/sdk/python/packages/flet-core/src/flet_core/map/map_configuration.py
+++ b/sdk/python/packages/flet-core/src/flet_core/map/map_configuration.py
@@ -230,42 +230,42 @@ class MapConfiguration(Control):
 
     # on_tap
     @property
-    def on_tap(self):
-        return self.__on_tap
+    def on_tap(self) -> OptionalEventCallable["MapTapEvent"]:
+        return self.__on_tap.handler
 
     @on_tap.setter
     def on_tap(self, handler: OptionalEventCallable["MapTapEvent"]):
-        self.__on_tap.subscribe(handler)
+        self.__on_tap.handler = handler
         self._set_attr("onTap", True if handler is not None else None)
 
     # on_secondary_tap
     @property
-    def on_secondary_tap(self):
-        return self.__on_secondary_tap
+    def on_secondary_tap(self) -> OptionalEventCallable["MapTapEvent"]:
+        return self.__on_secondary_tap.handler
 
     @on_secondary_tap.setter
     def on_secondary_tap(self, handler: OptionalEventCallable["MapTapEvent"]):
-        self.__on_secondary_tap.subscribe(handler)
+        self.__on_secondary_tap.handler = handler
         self._set_attr("onSecondaryTap", True if handler is not None else None)
 
     # on_long_press
     @property
-    def on_long_press(self):
-        return self.__on_long_press
+    def on_long_press(self) -> OptionalEventCallable["MapTapEvent"]:
+        return self.__on_long_press.handler
 
     @on_long_press.setter
     def on_long_press(self, handler: OptionalEventCallable["MapTapEvent"]):
-        self.__on_long_press.subscribe(handler)
+        self.__on_long_press.handler = handler
         self._set_attr("onLongPress", True if handler is not None else None)
 
     # on_event
     @property
-    def on_event(self):
-        return self.__on_event
+    def on_event(self) -> OptionalEventCallable["MapEvent"]:
+        return self.__on_event.handler
 
     @on_event.setter
     def on_event(self, handler: OptionalEventCallable["MapEvent"]):
-        self.__on_event.subscribe(handler)
+        self.__on_event.handler = handler
         self._set_attr("onEvent", True if handler is not None else None)
 
     # on_init
@@ -280,44 +280,44 @@ class MapConfiguration(Control):
 
     # on_position_change
     @property
-    def on_position_change(self):
-        return self.__on_position_change
+    def on_position_change(self) -> OptionalEventCallable["MapPositionChangeEvent"]:
+        return self.__on_position_change.handler
 
     @on_position_change.setter
     def on_position_change(
         self, handler: OptionalEventCallable["MapPositionChangeEvent"]
     ):
-        self.__on_position_change.subscribe(handler)
+        self.__on_position_change.handler = handler
         self._set_attr("onPositionChange", True if handler is not None else None)
 
     # on_pointer_down
     @property
-    def on_pointer_down(self):
-        return self.__on_pointer_down
+    def on_pointer_down(self) -> OptionalEventCallable["MapPointerEvent"]:
+        return self.__on_pointer_down.handler
 
     @on_pointer_down.setter
     def on_pointer_down(self, handler: OptionalEventCallable["MapPointerEvent"]):
-        self.__on_pointer_down.subscribe(handler)
+        self.__on_pointer_down.handler = handler
         self._set_attr("onPointerDown", True if handler is not None else None)
 
     # on_pointer_cancel
     @property
-    def on_pointer_cancel(self):
-        return self.__on_pointer_cancel
+    def on_pointer_cancel(self) -> OptionalEventCallable["MapPointerEvent"]:
+        return self.__on_pointer_cancel.handler
 
     @on_pointer_cancel.setter
     def on_pointer_cancel(self, handler: OptionalEventCallable["MapPointerEvent"]):
-        self.__on_pointer_cancel.subscribe(handler)
+        self.__on_pointer_cancel.handler = handler
         self._set_attr("onPointerCancel", True if handler is not None else None)
 
     # on_pointer_up
     @property
-    def on_pointer_up(self):
-        return self.__on_pointer_up
+    def on_pointer_up(self) -> OptionalEventCallable["MapPointerEvent"]:
+        return self.__on_pointer_up.handler
 
     @on_pointer_up.setter
     def on_pointer_up(self, handler: OptionalEventCallable["MapPointerEvent"]):
-        self.__on_pointer_up.subscribe(handler)
+        self.__on_pointer_up.handler = handler
         self._set_attr("onPointerUp", True if handler is not None else None)
 
 

--- a/sdk/python/packages/flet-core/src/flet_core/markdown.py
+++ b/sdk/python/packages/flet-core/src/flet_core/markdown.py
@@ -510,11 +510,13 @@ class Markdown(ConstrainedControl):
 
     # on_selection_change
     @property
-    def on_selection_change(self):
-        return self._get_event_handler("selection_change")
+    def on_selection_change(
+        self,
+    ) -> OptionalEventCallable[MarkdownSelectionChangeEvent]:
+        return self.__on_selection_change.handler
 
     @on_selection_change.setter
     def on_selection_change(
         self, handler: OptionalEventCallable[MarkdownSelectionChangeEvent]
     ):
-        self.__on_selection_change.subscribe(handler)
+        self.__on_selection_change.handler = handler

--- a/sdk/python/packages/flet-core/src/flet_core/page.py
+++ b/sdk/python/packages/flet-core/src/flet_core/page.py
@@ -78,6 +78,7 @@ from flet_core.types import (
     Wrapper,
     WindowEventType,
     OptionalControlEventCallable,
+    OptionalEventCallable,
 )
 from flet_core.utils import classproperty, deprecated
 from flet_core.utils.concurrency_utils import is_pyodide
@@ -492,15 +493,15 @@ class Window:
     # Events
     # on_event
     @property
-    def on_event(self):
-        return self.__on_event
+    def on_event(self) -> OptionalEventCallable["WindowEvent"]:
+        return self.__on_event.handler
 
     @on_event.setter
     def on_event(
         self,
-        handler: "Optional[Callable[[WindowEvent], Union[None, Coroutine[None, None, None]]]]",
+        handler: OptionalEventCallable["WindowEvent"],
     ):
-        self.__on_event.subscribe(handler)
+        self.__on_event.handler = handler
 
 
 class Page(AdaptiveControl):
@@ -657,10 +658,6 @@ class Page(AdaptiveControl):
         self._set_attr_json("localeConfiguration", self.__locale_configuration)
         self._set_attr_json("darkTheme", self.__dark_theme)
         self._set_attr_json("windowAlignment", self.__window.alignment)
-
-        # keyboard event
-        if self.__on_keyboard_event.count() > 0:
-            self._set_attr("onKeyboardEvent", True)
 
     def _get_control_name(self):
         return "page"
@@ -2737,12 +2734,12 @@ class Page(AdaptiveControl):
 
     # on_close
     @property
-    def on_close(self):
-        return self.__on_close
+    def on_close(self) -> OptionalControlEventCallable:
+        return self.__on_close.handler
 
     @on_close.setter
     def on_close(self, handler: OptionalControlEventCallable):
-        self.__on_close.subscribe(handler)
+        self.__on_close.handler = handler
 
     # on_resize
     @property
@@ -2752,8 +2749,8 @@ class Page(AdaptiveControl):
         delete_version="0.26.0",
         is_method=False,
     )
-    def on_resize(self):
-        return self.__on_resized
+    def on_resize(self) -> OptionalEventCallable["WindowResizeEvent"]:
+        return self.__on_resized.handler
 
     @on_resize.setter
     @deprecated(
@@ -2762,63 +2759,66 @@ class Page(AdaptiveControl):
         delete_version="0.26.0",
         is_method=False,
     )
-    def on_resize(self, handler: "Optional[Callable[[WindowResizeEvent], None]]"):
-        self.__on_resized.subscribe(handler)
+    def on_resize(self, handler: OptionalEventCallable["WindowResizeEvent"]):
+        self.__on_resized.handler = handler
 
     @property
-    def on_resized(self):
-        return self.__on_resized
+    def on_resized(self) -> OptionalEventCallable["WindowResizeEvent"]:
+        return self.__on_resized.handler
 
     @on_resized.setter
-    def on_resized(self, handler: "Optional[Callable[[WindowResizeEvent], None]]"):
-        self.__on_resized.subscribe(handler)
+    def on_resized(self, handler: OptionalEventCallable["WindowResizeEvent"]):
+        self.__on_resized.handler = handler
 
     # on_platform_brightness_change
     @property
-    def on_platform_brightness_change(self):
-        return self.__on_platform_brightness_change
+    def on_platform_brightness_change(self) -> OptionalControlEventCallable:
+        return self.__on_platform_brightness_change.handler
 
     @on_platform_brightness_change.setter
     def on_platform_brightness_change(self, handler: OptionalControlEventCallable):
-        self.__on_platform_brightness_change.subscribe(handler)
+        self.__on_platform_brightness_change.handler = handler
 
     # on_app_lifecycle_change
     @property
-    def on_app_lifecycle_state_change(self):
-        return self.__on_app_lifecycle_state_change
+    def on_app_lifecycle_state_change(
+        self,
+    ) -> OptionalEventCallable["AppLifecycleStateChangeEvent"]:
+        return self.__on_app_lifecycle_state_change.handler
 
     @on_app_lifecycle_state_change.setter
     def on_app_lifecycle_state_change(
-        self, handler: "Optional[Callable[[AppLifecycleStateChangeEvent], None]]"
+        self, handler: OptionalEventCallable["AppLifecycleStateChangeEvent"]
     ):
-        self.__on_app_lifecycle_state_change.subscribe(handler)
+        self.__on_app_lifecycle_state_change.handler = handler
 
     # on_route_change
     @property
-    def on_route_change(self):
-        return self.__on_route_change
+    def on_route_change(self) -> OptionalEventCallable["RouteChangeEvent"]:
+        return self.__on_route_change.handler
 
     @on_route_change.setter
-    def on_route_change(self, handler: "Optional[Callable[[RouteChangeEvent], None]]"):
-        self.__on_route_change.subscribe(handler)
+    def on_route_change(self, handler: OptionalEventCallable["RouteChangeEvent"]):
+        self.__on_route_change.handler = handler
 
     # on_view_pop
     @property
-    def on_view_pop(self):
-        return self.__on_view_pop
+    def on_view_pop(self) -> OptionalEventCallable["ViewPopEvent"]:
+        return self.__on_view_pop.handler
 
     @on_view_pop.setter
-    def on_view_pop(self, handler: "Optional[Callable[[ViewPopEvent], None]]"):
-        self.__on_view_pop.subscribe(handler)
+    def on_view_pop(self, handler: OptionalEventCallable["ViewPopEvent"]):
+        self.__on_view_pop.handler = handler
 
     # on_keyboard_event
     @property
-    def on_keyboard_event(self):
-        return self.__on_keyboard_event
+    def on_keyboard_event(self) -> OptionalEventCallable["KeyboardEvent"]:
+        return self.__on_keyboard_event.handler
 
     @on_keyboard_event.setter
-    def on_keyboard_event(self, handler: "Optional[Callable[[KeyboardEvent], None]]"):
-        self.__on_keyboard_event.subscribe(handler)
+    def on_keyboard_event(self, handler: OptionalEventCallable["KeyboardEvent"]):
+        self.__on_keyboard_event.handler = handler
+        self._set_attr("onKeyboardEvent", True if handler else None)
 
     # on_window_event
     @property
@@ -2828,8 +2828,8 @@ class Page(AdaptiveControl):
         delete_version="0.26.0",
         is_method=False,
     )
-    def on_window_event(self):
-        return self.__window.on_event
+    def on_window_event(self) -> OptionalEventCallable["WindowEvent"]:
+        return self.__window.on_event.handler
 
     @on_window_event.setter
     @deprecated(
@@ -2838,62 +2838,62 @@ class Page(AdaptiveControl):
         delete_version="0.26.0",
         is_method=False,
     )
-    def on_window_event(self, handler: "Optional[Callable[[WindowEvent], None]]"):
-        self.__window.on_event.subscribe(handler)
+    def on_window_event(self, handler: OptionalEventCallable["WindowEvent"]):
+        self.__window.on_event.handler = handler
 
     # on_media_change
     @property
-    def on_media_change(self):
-        return self.__on_page_media_change_event
+    def on_media_change(self) -> OptionalEventCallable["PageMediaData"]:
+        return self.__on_page_media_change_event.handler
 
     @on_media_change.setter
-    def on_media_change(self, handler: "Optional[Callable[[PageMediaData], None]]"):
-        self.__on_page_media_change_event.subscribe(handler)
+    def on_media_change(self, handler: OptionalEventCallable["PageMediaData"]):
+        self.__on_page_media_change_event.handler = handler
 
     # on_connect
     @property
-    def on_connect(self):
-        return self.__on_connect
+    def on_connect(self) -> OptionalControlEventCallable:
+        return self.__on_connect.handler
 
     @on_connect.setter
     def on_connect(self, handler: OptionalControlEventCallable):
-        self.__on_connect.subscribe(handler)
+        self.__on_connect.handler = handler
 
     # on_disconnect
     @property
-    def on_disconnect(self):
-        return self.__on_disconnect
+    def on_disconnect(self) -> OptionalControlEventCallable:
+        return self.__on_disconnect.handler
 
     @on_disconnect.setter
     def on_disconnect(self, handler: OptionalControlEventCallable):
-        self.__on_disconnect.subscribe(handler)
+        self.__on_disconnect.handler = handler
 
     # on_login
     @property
-    def on_login(self):
-        return self.__on_login
+    def on_login(self) -> OptionalEventCallable["LoginEvent"]:
+        return self.__on_login.handler
 
     @on_login.setter
-    def on_login(self, handler: "Optional[Callable[[LoginEvent], None]]"):
-        self.__on_login.subscribe(handler)
+    def on_login(self, handler: OptionalEventCallable["LoginEvent"]):
+        self.__on_login.handler = handler
 
     # on_logout
     @property
-    def on_logout(self):
-        return self.__on_logout
+    def on_logout(self) -> OptionalControlEventCallable:
+        return self.__on_logout.handler
 
     @on_logout.setter
     def on_logout(self, handler: OptionalControlEventCallable):
-        self.__on_logout.subscribe(handler)
+        self.__on_logout.handler = handler
 
     # on_error
     @property
-    def on_error(self):
-        return self.__on_error
+    def on_error(self) -> OptionalControlEventCallable:
+        return self.__on_error.handler
 
     @on_error.setter
     def on_error(self, handler: OptionalControlEventCallable):
-        self.__on_error.subscribe(handler)
+        self.__on_error.handler = handler
 
     # on_scroll
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/scrollable_control.py
+++ b/sdk/python/packages/flet-core/src/flet_core/scrollable_control.py
@@ -114,12 +114,12 @@ class ScrollableControl(Control):
 
     # on_scroll
     @property
-    def on_scroll(self):
-        return self.__on_scroll
+    def on_scroll(self) -> OptionalEventCallable["OnScrollEvent"]:
+        return self.__on_scroll.handler
 
     @on_scroll.setter
     def on_scroll(self, handler: OptionalEventCallable["OnScrollEvent"]):
-        self.__on_scroll.subscribe(handler)
+        self.__on_scroll.handler = handler
         self._set_attr("onScroll", True if handler is not None else None)
 
 

--- a/sdk/python/packages/flet-core/src/flet_core/time_picker.py
+++ b/sdk/python/packages/flet-core/src/flet_core/time_picker.py
@@ -284,11 +284,13 @@ class TimePicker(Control):
 
     # on_entry_mode_change
     @property
-    def on_entry_mode_change(self):
-        return self.__on_entry_mode_change
+    def on_entry_mode_change(
+        self,
+    ) -> OptionalEventCallable[TimePickerEntryModeChangeEvent]:
+        return self.__on_entry_mode_change.handler
 
     @on_entry_mode_change.setter
     def on_entry_mode_change(
-        self, handler: Optional[Callable[[TimePickerEntryModeChangeEvent], None]]
+        self, handler: OptionalEventCallable[TimePickerEntryModeChangeEvent]
     ):
-        self.__on_entry_mode_change.subscribe(handler)
+        self.__on_entry_mode_change.handler = handler


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Refactor the event handler system to replace the subscription model with a direct assignment model, ensuring that each event can have only one handler at a time.

Enhancements:
- Refactor event handler subscription mechanism to allow only one handler per event, replacing the previous subscription model with a direct assignment model.

<!-- Generated by sourcery-ai[bot]: end summary -->