### PR TITLE
feat: wrap `View`s into a background container

### DIFF
--- a/client/macos/Runner/AppDelegate.swift
+++ b/client/macos/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import Cocoa
 import FlutterMacOS
 
-@NSApplicationMain
+@main
 class AppDelegate: FlutterAppDelegate {
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
     return true

--- a/packages/flet/lib/src/controls/canvas.dart
+++ b/packages/flet/lib/src/controls/canvas.dart
@@ -368,9 +368,7 @@ class FletCustomPainter extends CustomPainter {
             parseDouble(elem["width"], 0)!,
             parseDouble(elem["height"], 0)!));
       } else if (type == "rect") {
-        var borderRadius = elem["border_radius"] != null
-            ? borderRadiusFromJSON(elem["border_radius"])
-            : null;
+        var borderRadius = borderRadiusFromJSON(elem["border_radius"]);
         path.addRRect(RRect.fromRectAndCorners(
             Rect.fromLTWH(
                 parseDouble(elem["x"], 0)!,

--- a/packages/flet/lib/src/controls/container.dart
+++ b/packages/flet/lib/src/controls/container.dart
@@ -123,7 +123,8 @@ class ContainerControl extends StatelessWidget with FletStoreMixin {
               borderRadius: borderRadius,
               shape: shape,
               boxShadow: parseBoxShadow(Theme.of(context), control, "shadow"));
-
+      var boxForegroundDecoration = parseBoxDecoration(
+          Theme.of(context), control, "foregroundDecoration", pageArgs);
       Widget? result;
 
       if ((onClick || url != "" || onLongPress || onHover || onTapDown) &&
@@ -190,6 +191,7 @@ class ContainerControl extends StatelessWidget with FletStoreMixin {
                 margin: parseEdgeInsets(control, "margin"),
                 clipBehavior: clipBehavior,
                 decoration: boxDecoration,
+                foregroundDecoration: boxForegroundDecoration,
                 child: ink,
               )
             : AnimatedContainer(
@@ -215,6 +217,7 @@ class ContainerControl extends StatelessWidget with FletStoreMixin {
                 margin: parseEdgeInsets(control, "margin"),
                 alignment: parseAlignment(control, "alignment"),
                 decoration: boxDecoration,
+                foregroundDecoration: boxForegroundDecoration,
                 clipBehavior: clipBehavior,
                 child: child)
             : AnimatedContainer(
@@ -226,6 +229,7 @@ class ContainerControl extends StatelessWidget with FletStoreMixin {
                 margin: parseEdgeInsets(control, "margin"),
                 alignment: parseAlignment(control, "alignment"),
                 decoration: boxDecoration,
+                foregroundDecoration: boxForegroundDecoration,
                 clipBehavior: clipBehavior,
                 onEnd: control.attrBool("onAnimationEnd", false)!
                     ? () {

--- a/packages/flet/lib/src/controls/page.dart
+++ b/packages/flet/lib/src/controls/page.dart
@@ -23,6 +23,7 @@ import '../routing/route_parser.dart';
 import '../routing/route_state.dart';
 import '../routing/router_delegate.dart';
 import '../utils/alignment.dart';
+import '../utils/box.dart';
 import '../utils/buttons.dart';
 import '../utils/desktop.dart';
 import '../utils/edge_insets.dart';
@@ -1131,14 +1132,28 @@ class _ViewControlState extends State<ViewControl> with FletStoreMixin {
                 child: scaffold,
               );
             }
-
-            return Directionality(
+            var result = Directionality(
                 textDirection: textDirection,
                 child: widget.loadingPage != null
                     ? Stack(
                         children: [scaffold, widget.loadingPage!],
                       )
                     : scaffold);
+            return withPageArgs((context, pageArgs) {
+              var backgroundDecoration = parseBoxDecoration(
+                  Theme.of(context), control, "decoration", pageArgs);
+              var foregroundDecoration = parseBoxDecoration(
+                  Theme.of(context), control, "foregroundDecoration", pageArgs);
+              if (backgroundDecoration != null ||
+                  foregroundDecoration != null) {
+                return Container(
+                  decoration: backgroundDecoration,
+                  foregroundDecoration: foregroundDecoration,
+                  child: result,
+                );
+              }
+              return result;
+            });
           });
         });
   }

--- a/packages/flet/lib/src/utils/borders.dart
+++ b/packages/flet/lib/src/utils/borders.dart
@@ -58,7 +58,10 @@ OutlinedBorder? parseOutlinedBorder(Control control, String propName) {
   return outlinedBorderFromJSON(j1);
 }
 
-BorderRadius borderRadiusFromJSON(dynamic json) {
+BorderRadius? borderRadiusFromJSON(dynamic json, [BorderRadius? defaultValue]) {
+  if (json == null) {
+    return defaultValue;
+  }
   if (json is int || json is double) {
     return BorderRadius.all(Radius.circular(parseDouble(json, 0)!));
   }
@@ -102,23 +105,17 @@ OutlinedBorder? outlinedBorderFromJSON(Map<String, dynamic> json) {
   String type = json["type"];
   if (type == "roundedRectangle") {
     return RoundedRectangleBorder(
-        borderRadius: json["radius"] != null
-            ? borderRadiusFromJSON(json["radius"])
-            : BorderRadius.zero);
+        borderRadius: borderRadiusFromJSON(json["radius"], BorderRadius.zero)!);
   } else if (type == "stadium") {
     return const StadiumBorder();
   } else if (type == "circle") {
     return const CircleBorder();
   } else if (type == "beveledRectangle") {
     return BeveledRectangleBorder(
-        borderRadius: json["radius"] != null
-            ? borderRadiusFromJSON(json["radius"])
-            : BorderRadius.zero);
+        borderRadius: borderRadiusFromJSON(json["radius"], BorderRadius.zero)!);
   } else if (type == "continuousRectangle") {
     return ContinuousRectangleBorder(
-        borderRadius: json["radius"] != null
-            ? borderRadiusFromJSON(json["radius"])
-            : BorderRadius.zero);
+        borderRadius: borderRadiusFromJSON(json["radius"], BorderRadius.zero)!);
   }
   return null;
 }

--- a/packages/flet/lib/src/utils/theme.dart
+++ b/packages/flet/lib/src/utils/theme.dart
@@ -292,10 +292,11 @@ TabBarTheme? parseTabBarTheme(ThemeData theme, Map<String, dynamic>? j) {
             j["indicator_border_side"] != null ||
             j["indicator_padding"] != null
         ? UnderlineTabIndicator(
-            borderRadius: j["indicator_border_radius"] != null
-                ? borderRadiusFromJSON(j["indicator_border_radius"])
-                : const BorderRadius.only(
-                    topLeft: Radius.circular(2), topRight: Radius.circular(2)),
+            borderRadius: borderRadiusFromJSON(
+                j["indicator_border_radius"],
+                const BorderRadius.only(
+                    topLeft: Radius.circular(2),
+                    topRight: Radius.circular(2)))!,
             borderSide: borderSideFromJSON(
                     theme, j["indicator_border_side"], indicatorColor) ??
                 BorderSide(

--- a/sdk/python/packages/flet-core/src/flet_core/container.py
+++ b/sdk/python/packages/flet-core/src/flet_core/container.py
@@ -10,6 +10,7 @@ from flet_core.box import (
     BoxShadow,
     BoxShape,
     ColorFilter,
+    BoxDecoration,
     DecorationImage,
 )
 from flet_core.constrained_control import ConstrainedControl
@@ -97,6 +98,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         theme: Optional[Theme] = None,
         theme_mode: Optional[ThemeMode] = None,
         color_filter: Optional[ColorFilter] = None,
+        foreground_decoration: Optional[BoxDecoration] = None,
         on_click: OptionalControlEventCallable = None,
         on_tap_down: OptionalEventCallable["ContainerTapEvent"] = None,
         on_long_press: OptionalControlEventCallable = None,
@@ -202,6 +204,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         self.on_long_press = on_long_press
         self.on_hover = on_hover
         self.image = image
+        self.foreground_decoration = foreground_decoration
 
     def _get_control_name(self):
         return "container"
@@ -220,6 +223,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         self._set_attr_json("theme", self.__theme)
         self._set_attr_json("colorFilter", self.__color_filter)
         self._set_attr_json("image", self.__image)
+        self._set_attr_json("foregroundDecoration", self.__foreground_decoration)
 
     def _get_children(self):
         children = []
@@ -259,6 +263,15 @@ class Container(ConstrainedControl, AdaptiveControl):
     @image.setter
     def image(self, value: Optional[DecorationImage]):
         self.__image = value
+
+    # foreground_decoration
+    @property
+    def foreground_decoration(self) -> Optional[BoxDecoration]:
+        return self.__foreground_decoration
+
+    @foreground_decoration.setter
+    def foreground_decoration(self, value: Optional[BoxDecoration]):
+        self.__foreground_decoration = value
 
     # margin
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/page.py
+++ b/sdk/python/packages/flet-core/src/flet_core/page.py
@@ -27,6 +27,8 @@ from typing import (
 )
 from urllib.parse import urlparse
 
+from flet_core.box import BoxDecoration
+
 try:
     from typing import ParamSpec
 except ImportError:
@@ -1907,6 +1909,24 @@ class Page(AdaptiveControl):
     @end_drawer.setter
     def end_drawer(self, value: Optional[NavigationDrawer]):
         self.__default_view.end_drawer = value
+
+    # decoration
+    @property
+    def decoration(self) -> Optional[BoxDecoration]:
+        return self.__default_view.decoration
+
+    @decoration.setter
+    def decoration(self, value: Optional[BoxDecoration]):
+        self.__default_view.decoration = value
+
+    # foreground_decoration
+    @property
+    def foreground_decoration(self) -> Optional[BoxDecoration]:
+        return self.__default_view.foreground_decoration
+
+    @foreground_decoration.setter
+    def foreground_decoration(self, value: Optional[BoxDecoration]):
+        self.__default_view.foreground_decoration = value
 
     # floating_action_button
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/view.py
+++ b/sdk/python/packages/flet-core/src/flet_core/view.py
@@ -1,9 +1,10 @@
-from typing import List, Optional, Union, Callable, Sequence
+from typing import List, Optional, Union, Sequence
 
-from flet_core import Control
 from flet_core.adaptive_control import AdaptiveControl
 from flet_core.app_bar import AppBar
 from flet_core.bottom_app_bar import BottomAppBar
+from flet_core.box import BoxDecoration
+from flet_core.control import Control
 from flet_core.control import OptionalNumber
 from flet_core.cupertino_app_bar import CupertinoAppBar
 from flet_core.cupertino_navigation_bar import CupertinoNavigationBar
@@ -18,6 +19,7 @@ from flet_core.types import (
     OffsetValue,
     PaddingValue,
     ScrollMode,
+    OptionalEventCallable,
 )
 
 
@@ -50,6 +52,8 @@ class View(ScrollableControl, AdaptiveControl):
         spacing: OptionalNumber = None,
         padding: PaddingValue = None,
         bgcolor: Optional[str] = None,
+        decoration: Optional[BoxDecoration] = None,
+        foreground_decoration: Optional[BoxDecoration] = None,
         #
         # ScrollableControl
         #
@@ -57,7 +61,7 @@ class View(ScrollableControl, AdaptiveControl):
         auto_scroll: Optional[bool] = None,
         fullscreen_dialog: Optional[bool] = None,
         on_scroll_interval: OptionalNumber = None,
-        on_scroll: Optional[Callable[[OnScrollEvent], None]] = None,
+        on_scroll: OptionalEventCallable[OnScrollEvent] = None,
         #
         # AdaptiveControl
         #
@@ -92,6 +96,8 @@ class View(ScrollableControl, AdaptiveControl):
         self.scroll = scroll
         self.auto_scroll = auto_scroll
         self.fullscreen_dialog = fullscreen_dialog
+        self.decoration = decoration
+        self.foreground_decoration = foreground_decoration
 
     def _get_control_name(self):
         return "view"
@@ -105,6 +111,8 @@ class View(ScrollableControl, AdaptiveControl):
             self._set_attr_json(
                 "floatingActionButtonLocation", self.__floating_action_button_location
             )
+        self._set_attr_json("decoration", self.__decoration)
+        self._set_attr_json("foregroundDecoration", self.__foreground_decoration)
 
     def _get_children(self):
         children = []
@@ -271,6 +279,24 @@ class View(ScrollableControl, AdaptiveControl):
     @fullscreen_dialog.setter
     def fullscreen_dialog(self, value: Optional[bool]):
         self._set_attr("fullscreenDialog", value)
+
+    # foreground_decoration
+    @property
+    def foreground_decoration(self) -> Optional[BoxDecoration]:
+        return self.__foreground_decoration
+
+    @foreground_decoration.setter
+    def foreground_decoration(self, value: Optional[BoxDecoration]):
+        self.__foreground_decoration = value
+
+    # decoration
+    @property
+    def decoration(self) -> Optional[BoxDecoration]:
+        return self.__decoration
+
+    @decoration.setter
+    def decoration(self, value: Optional[BoxDecoration]):
+        self.__decoration = value
 
     # Magic methods
     def __contains__(self, item: Control) -> bool:


### PR DESCRIPTION
## Description

Closes #3743 

## Test Code

```python
import flet as ft


def main(page: ft.Page):
    page.horizontal_alignment = ft.CrossAxisAlignment.CENTER
    page.vertical_alignment = ft.MainAxisAlignment.CENTER
    
    page.bgcolor = ft.colors.TRANSPARENT
    page.decoration = ft.BoxDecoration(
        gradient=ft.LinearGradient(
            colors=[ft.colors.RED, ft.colors.BLUE],
            begin=ft.alignment.top_left,
            end=ft.alignment.bottom_right,
            stops=[0.0, 1.0],
        ),
        image=ft.DecorationImage(
            src="https://images.unsplash.com/photo-1547721064-da6cfb341d50",
            fit=ft.ImageFit.COVER,
            opacity=0.2,
        ),
    )

    page.add(ft.Text("Hello, World!", size=55),)


ft.app(main)

```

## Screenshots (if applicable):
![image](https://github.com/user-attachments/assets/2ea52ddc-7762-49bd-8fae-8c75a454bab5)

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add support for background and foreground decorations in View and Container components, enabling more flexible UI designs. Enhance border radius parsing with default values and update macOS client code to use modern Swift attributes.

New Features:
- Introduce background and foreground decoration properties to the View and Container components, allowing for more customizable UI elements.

Enhancements:
- Enhance the borderRadiusFromJSON function to accept a default value, improving flexibility in border radius parsing.
- Update the AppDelegate in the macOS client to use the @main attribute, modernizing the Swift code.

<!-- Generated by sourcery-ai[bot]: end summary -->