### PR TITLE
fix: `page.window.icon` doesnt work with relative paths to icons 

### DIFF
--- a/packages/flet/lib/src/controls/page.dart
+++ b/packages/flet/lib/src/controls/page.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:collection/collection.dart';
 import 'package:equatable/equatable.dart';
+import 'package:flet/src/models/page_args_model.dart';
 import 'package:flet/src/utils/locale.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
@@ -336,7 +337,7 @@ class _PageControlState extends State<PageControl> with FletStoreMixin {
     var windowFrameless = widget.control.attrBool("windowFrameless");
     var windowProgressBar = widget.control.attrDouble("windowProgressBar");
 
-    updateWindow() async {
+    updateWindow(PageArgsModel? pageArgs) async {
       try {
         // windowTitle
         if (_windowTitle != windowTitle) {
@@ -453,7 +454,13 @@ class _PageControlState extends State<PageControl> with FletStoreMixin {
 
         // windowIcon
         if (windowIcon != null && windowIcon != _windowIcon) {
-          await setWindowIcon(windowIcon);
+          if (pageArgs == null) {
+            await setWindowIcon(windowIcon);
+          } else {
+            var iconAssetSrc =
+                getAssetSrc(windowIcon, pageArgs.pageUri!, pageArgs.assetsDir);
+            await setWindowIcon(iconAssetSrc.path);
+          }
           _windowIcon = windowIcon;
         }
 
@@ -576,9 +583,8 @@ class _PageControlState extends State<PageControl> with FletStoreMixin {
       }
     }
 
-    updateWindow();
-
     return withPageArgs((context, pageArgs) {
+      updateWindow(pageArgs);
       debugPrint("Page fonts build: ${widget.control.id}");
 
       // load custom fonts


### PR DESCRIPTION
## Description

Fixes #3438

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the handling of `page.window.icon` to support relative paths by updating the window icon logic to consider page arguments and asset directories.

Bug Fixes:
- Fix the issue where `page.window.icon` does not work with relative paths by adjusting the logic to handle asset sources based on page arguments.

<!-- Generated by sourcery-ai[bot]: end summary -->