### PR TITLE
fix for `window.icon` from Python side

### DIFF
--- a/sdk/python/packages/flet-core/src/flet_core/page.py
+++ b/sdk/python/packages/flet-core/src/flet_core/page.py
@@ -4,6 +4,7 @@ import logging
 import threading
 import time
 import uuid
+import pathlib
 from asyncio import AbstractEventLoop
 from concurrent.futures import ThreadPoolExecutor, Future
 from contextvars import ContextVar
@@ -473,7 +474,7 @@ class Window:
 
     @icon.setter
     def icon(self, value: Optional[str]):
-        self.page._set_attr("windowIcon", value)
+        self.page._set_attr("windowIcon", str(pathlib.Path(value).resolve()).replace("\\", "/"))
 
     # Methods
     def destroy(self):

--- a/sdk/python/packages/flet-core/src/flet_core/page.py
+++ b/sdk/python/packages/flet-core/src/flet_core/page.py
@@ -470,10 +470,14 @@ class Window:
     # icon
     @property
     def icon(self) -> Optional[str]:
-        return self.page._get_attr("windowIcon")
+        try:
+            return self.page._icon
+        except AttributeError:
+            return None
 
     @icon.setter
     def icon(self, value: Optional[str]):
+        self.page._icon = value
         self.page._set_attr("windowIcon", str(next((p.resolve() for p in [pathlib.Path(value), pathlib.Path(f"assets/{value}")] if p.resolve().exists()), None)).replace("\\", "/"))
 
     # Methods

--- a/sdk/python/packages/flet-core/src/flet_core/page.py
+++ b/sdk/python/packages/flet-core/src/flet_core/page.py
@@ -470,11 +470,8 @@ class Window:
     # icon
     @property
     def icon(self) -> Optional[str]:
-        try:
-            return self.page._icon
-        except AttributeError:
-            return None
-
+        return getattr(self.page, '_icon', None)
+        
     @icon.setter
     def icon(self, value: Optional[str]):
         self.page._icon = value

--- a/sdk/python/packages/flet-core/src/flet_core/page.py
+++ b/sdk/python/packages/flet-core/src/flet_core/page.py
@@ -474,7 +474,7 @@ class Window:
 
     @icon.setter
     def icon(self, value: Optional[str]):
-        self.page._set_attr("windowIcon", str(pathlib.Path(value).resolve()).replace("\\", "/"))
+        self.page._set_attr("windowIcon", str(next((p.resolve() for p in [pathlib.Path(value), pathlib.Path(f"assets/{value}")] if p.resolve().exists()), None)).replace("\\", "/"))
 
     # Methods
     def destroy(self):


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
This PR fixes issue with `window.icon` property don't working if relative path is provided

<!-- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/flet-dev/flet/issues/3438

## Test Code

```python
import flet as ft

def main(page: ft.Page):
    page.window.icon = "assets/icon.ico"
    page.update()

ft.app(target=main)
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I signed the CLA.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
<!-- - [ ] I have added tests that prove my fix is effective or that my feature works as expected -->

- [ ] New and existing tests pass locally with my changes
- [ ] I have made corresponding changes to the [documentation](https://github.com/flet-dev/website) (if applicable)

## Screenshots (if applicable):

## Additional details

<!-- Add any other context to be known about this PR. -->

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the `window.icon` property to correctly handle relative paths by resolving them to absolute paths.

Bug Fixes:
- Fix the issue with the `window.icon` property not working when a relative path is provided by resolving the path correctly.

<!-- Generated by sourcery-ai[bot]: end summary -->