### PR TITLE
fix for `flet.map`, which was not available after building app

### DIFF
--- a/sdk/python/packages/flet-embed/src/flet/map/__init__.py
+++ b/sdk/python/packages/flet-embed/src/flet/map/__init__.py
@@ -1,0 +1,1 @@
+from flet_core.map import *


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->


<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #3633

## Test Code

```python
# code from https://flet.dev/docs/controls/map
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I signed the CLA.
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
<!-- - [ ] I have added tests that prove my fix is effective or that my feature works as expected -->

- [ ] New and existing tests pass locally with my changes
- [ ] I have made corresponding changes to the [documentation](https://github.com/flet-dev/website) (if applicable)

## Screenshots (if applicable):

## Additional details

I tried to build an app, but every time I tried, a fresh version of flet was downloaded, but in theory it should work