### PR TITLE
Fix unexpected behavior on TextField showing error when errorText is empty

### DIFF
--- a/packages/flet/lib/src/utils/form_field.dart
+++ b/packages/flet/lib/src/utils/form_field.dart
@@ -146,7 +146,9 @@ InputDecoration buildInputDecoration(
           ? createControl(control, counter.id, control.isDisabled,
               parentAdaptive: adaptive)
           : null,
-      errorText: control.attrString("errorText"),
+      errorText: control.attrString("errorText") != ""
+          ? control.attrString("errorText")
+          : null,
       errorStyle: parseTextStyle(Theme.of(context), control, "errorStyle"),
       prefixIcon: prefixIcon != null ? Icon(prefixIcon) : null,
       prefixText: prefixText,

--- a/sdk/python/packages/flet-core/src/flet_core/page.py
+++ b/sdk/python/packages/flet-core/src/flet_core/page.py
@@ -102,8 +102,7 @@ try:
     from flet_runtime.auth.oauth_provider import OAuthProvider
 except ImportError:
 
-    class OAuthProvider:
-        ...
+    class OAuthProvider: ...
 
     class Authorization:
         def __init__(
@@ -112,8 +111,7 @@ except ImportError:
             fetch_user: bool,
             fetch_groups: bool,
             scope: Optional[List[str]] = None,
-        ):
-            ...
+        ): ...
 
 
 AT = TypeVar("AT", bound=Authorization)
@@ -916,7 +914,9 @@ class Page(AdaptiveControl):
                 for name in props:
                     if name != "i":
                         self._index[id]._set_attr(name, props[name], dirty=False)
-                        self.snapshot[id][name] = props[name]
+                        if id in self.__snapshot:
+                            self.snapshot[id][name] = props[name]
+
     def run_task(
         self,
         handler: Callable[InputT, Awaitable[RetT]],

--- a/sdk/python/packages/flet-core/src/flet_core/page.py
+++ b/sdk/python/packages/flet-core/src/flet_core/page.py
@@ -916,7 +916,7 @@ class Page(AdaptiveControl):
                 for name in props:
                     if name != "i":
                         self._index[id]._set_attr(name, props[name], dirty=False)
-
+                        self.snapshot[id][name] = props[name]
     def run_task(
         self,
         handler: Callable[InputT, Awaitable[RetT]],


### PR DESCRIPTION
## Description

When the page is refreshed, the input field is incorrectly marked as an error if `errorText` is set previosly. This happens because `_set_attr_internal` prevents the `errorText` attribute from being set to `None`, resulting in it being set as an empty string, which causes the error border to appear.

This branch incorporate related fix: #3852 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x ] I signed the CLA.
- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ x] My changes generate no new warnings
- [x ] New and existing tests pass locally with my changes
- [ x] I have made corresponding changes to the [documentation](https://github.com/flet-dev/website) (if applicable)

## Screenshots (if applicable):

![image](https://github.com/user-attachments/assets/6ec2b228-8902-4aa5-9bdf-f7c3aebb8d71)
![image](https://github.com/user-attachments/assets/a6ef6a78-1482-4a54-a6e8-159c6e74d1a6)

### after page refresh:

![image](https://github.com/user-attachments/assets/e78b8a81-40e6-4439-bcca-bf0fe7c9dd28)

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the input field error display issue by setting errorText to null when it is empty, preventing the error border from appearing unnecessarily.

Bug Fixes:
- Fix the issue where the input field incorrectly shows an error when the errorText is empty by ensuring errorText is set to null instead of an empty string.

<!-- Generated by sourcery-ai[bot]: end summary -->