### PR TITLE
fix: `Snackbar.margin` has no effect when set to a `Margin` object

### DIFF
--- a/packages/flet/lib/src/controls/snack_bar.dart
+++ b/packages/flet/lib/src/controls/snack_bar.dart
@@ -66,11 +66,14 @@ class _SnackBarControlState extends State<SnackBarControl> {
     var width = widget.control.attrDouble("width");
     var margin = parseEdgeInsets(widget.control, "margin");
 
-    // required to avoid assertion errors
+    // if behavior is not floating, ignore margin and width
     if (behavior != SnackBarBehavior.floating) {
       margin = null;
       width = null;
     }
+
+    // if width is provided, margin is ignored (both can't be used together)
+    margin = (width != null && margin != null) ? null : margin;
 
     return SnackBar(
         behavior: behavior,

--- a/sdk/python/packages/flet-core/src/flet_core/snack_bar.py
+++ b/sdk/python/packages/flet-core/src/flet_core/snack_bar.py
@@ -3,7 +3,6 @@ from typing import Any, Optional
 
 from flet_core.buttons import OutlinedBorder
 from flet_core.control import Control, OptionalNumber
-from flet_core.padding import Padding
 from flet_core.ref import Ref
 from flet_core.types import (
     MarginValue,
@@ -134,9 +133,7 @@ class SnackBar(Control):
         super().before_update()
         self._set_attr_json("shape", self.__shape)
         self._set_attr_json("padding", self.__padding)
-        if isinstance(self.__margin, (int, float, Padding)) and not self.width:
-            # margin and width cannot be set together - if width is set, margin is ignored
-            self._set_attr_json("margin", self.__margin)
+        self._set_attr_json("margin", self.__margin)
 
     # open
     @property


### PR DESCRIPTION
## Description

Fixes #3830

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the issue with `Snackbar.margin` not being effective when set to a `Margin` object by adjusting the logic to ensure margin is applied only when width is not set.

Bug Fixes:
- Fix the issue where `Snackbar.margin` had no effect when set to a `Margin` object by ensuring margin is correctly applied when width is not set.

<!-- Generated by sourcery-ai[bot]: end summary -->