### PR TITLE
fix: `'enter-full-screen'` and `'leave-full-screen'` are not defined in `WindowEventType`

### DIFF
--- a/sdk/python/packages/flet-core/src/flet_core/types.py
+++ b/sdk/python/packages/flet-core/src/flet_core/types.py
@@ -37,6 +37,8 @@ class WindowEventType(Enum):
     RESIZED = "resized"
     MOVE = "move"
     MOVED = "moved"
+    LEAVE_FULL_SCREEN = "leave-full-screen"
+    ENTER_FULL_SCREEN = "enter-full-screen"
 
 
 class WebRenderer(Enum):
@@ -401,4 +403,5 @@ Wrapper = Callable[..., Any]
 
 # Protocols
 class SupportsStr(Protocol):
-    def __str__(self) -> str: ...
+    def __str__(self) -> str:
+        ...


### PR DESCRIPTION
## Description

Fixes #3849

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix missing definitions for 'enter-full-screen' and 'leave-full-screen' events in WindowEventType.

Bug Fixes:
- Define 'enter-full-screen' and 'leave-full-screen' in WindowEventType to fix missing event types.

<!-- Generated by sourcery-ai[bot]: end summary -->