### PR TITLE
fix: 'flet' has no attribute `BottomSheetTheme`

### DIFF
--- a/sdk/python/packages/flet-core/src/flet_core/__init__.py
+++ b/sdk/python/packages/flet-core/src/flet_core/__init__.py
@@ -323,6 +323,7 @@ from flet_core.theme import (
     BadgeTheme,
     BannerTheme,
     BottomAppBarTheme,
+    BottomSheetTheme,
     BottomNavigationBarTheme,
     CardTheme,
     CheckboxTheme,

--- a/sdk/python/packages/flet-core/src/flet_core/theme.py
+++ b/sdk/python/packages/flet-core/src/flet_core/theme.py
@@ -644,9 +644,7 @@ class Theme:
     badge_theme: Optional[BadgeTheme] = None
     banner_theme: Optional[BannerTheme] = None
     bottom_appbar_theme: Optional[BottomAppBarTheme] = None
-    bottom_navigation_bar_theme: Optional[BottomNavigationBarTheme] = field(
-        default=None
-    )
+    bottom_navigation_bar_theme: Optional[BottomNavigationBarTheme] = None
     bottom_sheet_theme: Optional[BottomSheetTheme] = None
     button_theme: Optional[ButtonTheme] = None
     card_theme: Optional[CardTheme] = None
@@ -659,9 +657,8 @@ class Theme:
     divider_theme: Optional[DividerTheme] = None
     # dropdown_menu_theme: Optional[DropdownMenuTheme] = None
     expansion_tile_theme: Optional[ExpansionTileTheme] = None
-    floating_action_button_theme: Optional[FloatingActionButtonTheme] = field(
-        default=None
-    )
+    floating_action_button_theme: Optional[FloatingActionButtonTheme] = None
+    icon_theme: Optional[IconTheme] = None
     list_tile_theme: Optional[ListTileTheme] = None
     navigation_bar_theme: Optional[NavigationBarTheme] = None
     navigation_drawer_theme: Optional[NavigationDrawerTheme] = None


### PR DESCRIPTION
## Description

Fixes #3847

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the attribute error by adding the missing import for `BottomSheetTheme` in the `flet_core` package.

Bug Fixes:
- Fix the missing import of `BottomSheetTheme` in the `flet_core` package, resolving the attribute error.

<!-- Generated by sourcery-ai[bot]: end summary -->