### PR TITLE
fix: setting `SearchBar.value` to an empty string is not respected

### DIFF
--- a/packages/flet/lib/src/controls/search_anchor.dart
+++ b/packages/flet/lib/src/controls/search_anchor.dart
@@ -80,9 +80,7 @@ class _SearchAnchorControlState extends State<SearchAnchorControl> {
 
     debugPrint(widget.control.attrs.toString());
 
-    debugPrint("SearchAnchor build: ${widget.control.id}");
-
-    var value = widget.control.attrString("value");
+    var value = widget.control.attrString("value", "");
     if (value != null && value != _controller.text) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         _controller.text = value;


### PR DESCRIPTION
## Description
Fixes #3871

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the issue where setting `SearchBar.value` to an empty string was not respected by providing a default value in the attribute retrieval.

Bug Fixes:
- Ensure that setting `SearchBar.value` to an empty string is respected by providing a default value in the attribute retrieval.

<!-- Generated by sourcery-ai[bot]: end summary -->