### PR TITLE
fix(regression): Setting `Image.src.base64` returns `ErrorControl`

### DIFF
--- a/packages/flet/lib/src/utils/box.dart
+++ b/packages/flet/lib/src/utils/box.dart
@@ -229,6 +229,7 @@ Widget buildImage({
             gaplessPlayback: gaplessPlayback ?? true,
             semanticLabel: semanticsLabel);
       }
+      return image;
     } catch (ex) {
       return ErrorControl("Error decoding base64: ${ex.toString()}");
     }
@@ -308,8 +309,7 @@ Widget buildImage({
         }
       }
     }
-
     return image;
   }
-  return const ErrorControl("Either src or src_base64 must be specified.");
+  return const ErrorControl("A valid src or src_base64 must be specified.");
 }


### PR DESCRIPTION
## Description

Fixes #3909

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the regression that caused setting `Image.src.base64` to return an error by ensuring the image is returned upon successful decoding.

Bug Fixes:
- Fix the issue where setting `Image.src.base64` incorrectly returns `ErrorControl` by ensuring the image is returned when successfully decoded.

<!-- Generated by sourcery-ai[bot]: end summary -->