### PR TITLE
fix: `Tooltip` displays wrong message when used with `IconButton`, `FloatingActionButton` and `PopupMenuButton`

### DIFF
--- a/packages/flet/lib/src/controls/create_control.dart
+++ b/packages/flet/lib/src/controls/create_control.dart
@@ -1089,11 +1089,7 @@ Widget _opacity(
 Widget _tooltip(
     Widget widget, ThemeData theme, Control? parent, Control control) {
   var tooltip = parseTooltip(control, "tooltip", widget, theme);
-  return tooltip != null &&
-          !["iconbutton", "floatingactionbutton", "popupmenubutton"]
-              .contains(control.type)
-      ? tooltip
-      : widget;
+  return tooltip != null ? tooltip : widget;
 }
 
 Widget _aspectRatio(Widget widget, Control? parent, Control control) {

--- a/packages/flet/lib/src/controls/floating_action_button.dart
+++ b/packages/flet/lib/src/controls/floating_action_button.dart
@@ -50,7 +50,6 @@ class FloatingActionButtonControl extends StatelessWidget {
         parseClip(control.attrString("clipBehavior"), Clip.none)!;
     var contentCtrls =
         children.where((c) => c.name == "content" && c.isVisible);
-    var tooltip = control.attrString("tooltip");
     bool autofocus = control.attrBool("autofocus", false)!;
     bool mini = control.attrBool("mini", false)!;
     bool? enableFeedback = control.attrBool("enableFeedback");
@@ -91,7 +90,6 @@ class FloatingActionButtonControl extends StatelessWidget {
           enableFeedback: enableFeedback,
           clipBehavior: clipBehavior,
           focusColor: focusColor,
-          tooltip: tooltip,
           shape: shape,
           mini: mini,
           child: createControl(control, contentCtrls.first.id, disabled,
@@ -114,7 +112,6 @@ class FloatingActionButtonControl extends StatelessWidget {
           enableFeedback: enableFeedback,
           clipBehavior: clipBehavior,
           focusColor: focusColor,
-          tooltip: tooltip,
           shape: shape,
           mini: mini,
           child: Icon(icon));
@@ -136,7 +133,6 @@ class FloatingActionButtonControl extends StatelessWidget {
         enableFeedback: enableFeedback,
         clipBehavior: clipBehavior,
         focusColor: focusColor,
-        tooltip: tooltip,
         shape: shape,
         mini: mini,
         child: Text(text),
@@ -161,7 +157,6 @@ class FloatingActionButtonControl extends StatelessWidget {
         enableFeedback: enableFeedback,
         clipBehavior: clipBehavior,
         focusColor: focusColor,
-        tooltip: tooltip,
         shape: shape,
       );
     } else {

--- a/packages/flet/lib/src/controls/icon_button.dart
+++ b/packages/flet/lib/src/controls/icon_button.dart
@@ -94,7 +94,6 @@ class _IconButtonControlState extends State<IconButtonControl>
       double? splashRadius = widget.control.attrDouble("splashRadius");
       var padding = parseEdgeInsets(widget.control, "padding");
       var alignment = parseAlignment(widget.control, "alignment");
-      var tooltip = widget.control.attrString("tooltip");
       var contentCtrls =
           widget.children.where((c) => c.name == "content" && c.isVisible);
       bool autofocus = widget.control.attrBool("autofocus", false)!;
@@ -155,7 +154,6 @@ class _IconButtonControlState extends State<IconButtonControl>
             iconSize: iconSize,
             mouseCursor: mouseCursor,
             visualDensity: visualDensity,
-            tooltip: tooltip,
             style: style,
             isSelected: selected,
             selectedIcon: selectedIcon != null
@@ -180,7 +178,6 @@ class _IconButtonControlState extends State<IconButtonControl>
             mouseCursor: mouseCursor,
             visualDensity: visualDensity,
             style: style,
-            tooltip: tooltip,
             isSelected: selected,
             selectedIcon: selectedIcon != null
                 ? Icon(selectedIcon, color: selectedIconColor)

--- a/packages/flet/lib/src/controls/popup_menu_button.dart
+++ b/packages/flet/lib/src/controls/popup_menu_button.dart
@@ -30,7 +30,6 @@ class PopupMenuButtonControl extends StatelessWidget with FletStoreMixin {
     debugPrint("PopupMenuButton build: ${control.id}");
 
     var icon = parseIcon(control.attrString("icon"));
-    var tooltip = control.attrString("tooltip", "")!;
     var iconSize = control.attrDouble("iconSize");
     var splashRadius = control.attrDouble("splashRadius");
     var elevation = control.attrDouble("elevation");
@@ -62,8 +61,8 @@ class PopupMenuButtonControl extends StatelessWidget with FletStoreMixin {
             .map((c) => c.id), (content, viewModel) {
       return PopupMenuButton<String>(
           enabled: !disabled,
+          tooltip: null,
           icon: icon != null ? Icon(icon) : null,
-          tooltip: tooltip,
           iconSize: iconSize,
           splashRadius: splashRadius,
           shadowColor: shadowColor,
@@ -144,10 +143,12 @@ class PopupMenuButtonControl extends StatelessWidget with FletStoreMixin {
               }).toList(),
           child: child);
     });
-
+    debugPrint('SHOW: ${control.attrString("tooltip", "") != ""}');
     return constrainedControl(
         context,
-        TooltipVisibility(visible: tooltip != "", child: popupButton),
+        TooltipVisibility(
+            visible: control.attrString("tooltip") == null,
+            child: popupButton),
         parent,
         control);
   }


### PR DESCRIPTION
## Description

Fixes #3920

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix tooltip display issues by removing incorrect tooltip assignments from `IconButton`, `FloatingActionButton`, and `PopupMenuButton` components.

Bug Fixes:
- Fix the issue where the `Tooltip` displays the wrong message when used with `IconButton`, `FloatingActionButton`, and `PopupMenuButton` by removing incorrect tooltip assignments.

<!-- Generated by sourcery-ai[bot]: end summary -->