### PR TITLE
Prepare Flet 0.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Flet changelog
 
+# 0.24.1
+
+* FIXED: `Tooltip` displays wrong message when used with `IconButton`, `FloatingActionButton` and `PopupMenuButton` ([#3922](https://github.com/flet-dev/flet/issues/3922))
+* FIXED: `Image.src.base64` ([#3919](https://github.com/flet-dev/flet/issues/3919))
+
 # 0.24.0
 
 * NEW: `Placeholder` Control ([#3646](https://github.com/flet-dev/flet/issues/3646))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,3 +180,18 @@ You will be able to see the debugging outputs of the flet client in this termina
     ```bash
     poetry run flet run -w -p 8550 playground/<your-main.py>
     ```
+
+## Releasing Flet
+
+* Create a new `prepare-{version}` branch in [flet-dev/flet](https://github.com/flet-dev/flet) repository.
+* For every package in `packages/flet*` directory:
+  * Update package version to `{version}` in `pubspec.yaml`.
+  * Add `# {version}` with new/changed/fixed items into `CHANGELOG.md`. Only `packages/flet/CHANGELOG.md` should contain real items; other packages could have just a stub.
+* Copy `# {version}` section from `packages/flet/CHANGELOG.md` to the root `CHANGELOG.md`.
+* Open terminal in `client` directory and run `flutter pub get` to update Flet dependency versions in `client/pubspec.lock`.
+* Create a new `{version}` branch in [flet-dev/flet-app-templates](https://github.com/flet-dev/flet-app-templates) repository from a previously released `{current-version}` branch.
+* Create a new `{version}` branch in [flet-dev/flet-build-template](https://github.com/flet-dev/flet-build-template) repository from a previously released `{current-version}` branch.
+* Create `Prepare Flet {version}` PR to merge into `main` branch.
+* In `Build Flet package for Flutter` job of [Flet CI build](https://ci.appveyor.com/project/flet-dev/flet) make sure analysis report of every `flet*` Flutter package has only 1 issue "Publishable packages can't have 'path' dependencies.".
+* Merge `Prepare Flet {version}` PR.
+* Create and push new `v{version}` tag (with `v` prefix).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,3 +195,4 @@ You will be able to see the debugging outputs of the flet client in this termina
 * In `Build Flet package for Flutter` job of [Flet CI build](https://ci.appveyor.com/project/flet-dev/flet) make sure analysis report of every `flet*` Flutter package has only 1 issue "Publishable packages can't have 'path' dependencies.".
 * Merge `Prepare Flet {version}` PR.
 * Create and push new `v{version}` tag (with `v` prefix).
+* Update release notes at `https://github.com/flet-dev/flet/releases/tag/v{version}`.

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -231,77 +231,77 @@ packages:
       path: "../packages/flet"
       relative: true
     source: path
-    version: "0.24.0"
+    version: "0.24.1"
   flet_audio:
     dependency: "direct main"
     description:
       path: "../packages/flet_audio"
       relative: true
     source: path
-    version: "0.24.0"
+    version: "0.24.1"
   flet_audio_recorder:
     dependency: "direct main"
     description:
       path: "../packages/flet_audio_recorder"
       relative: true
     source: path
-    version: "0.24.0"
+    version: "0.24.1"
   flet_flashlight:
     dependency: "direct main"
     description:
       path: "../packages/flet_flashlight"
       relative: true
     source: path
-    version: "0.24.0"
+    version: "0.24.1"
   flet_geolocator:
     dependency: "direct main"
     description:
       path: "../packages/flet_geolocator"
       relative: true
     source: path
-    version: "0.24.0"
+    version: "0.24.1"
   flet_lottie:
     dependency: "direct main"
     description:
       path: "../packages/flet_lottie"
       relative: true
     source: path
-    version: "0.24.0"
+    version: "0.24.1"
   flet_map:
     dependency: "direct main"
     description:
       path: "../packages/flet_map"
       relative: true
     source: path
-    version: "0.24.0"
+    version: "0.24.1"
   flet_permission_handler:
     dependency: "direct main"
     description:
       path: "../packages/flet_permission_handler"
       relative: true
     source: path
-    version: "0.24.0"
+    version: "0.24.1"
   flet_rive:
     dependency: "direct main"
     description:
       path: "../packages/flet_rive"
       relative: true
     source: path
-    version: "0.24.0"
+    version: "0.24.1"
   flet_video:
     dependency: "direct main"
     description:
       path: "../packages/flet_video"
       relative: true
     source: path
-    version: "0.24.0"
+    version: "0.24.1"
   flet_webview:
     dependency: "direct main"
     description:
       path: "../packages/flet_webview"
       relative: true
     source: path
-    version: "0.24.0"
+    version: "0.24.1"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/packages/flet/CHANGELOG.md
+++ b/packages/flet/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.24.1
+
+* FIXED: `Tooltip` displays wrong message when used with `IconButton`, `FloatingActionButton` and `PopupMenuButton` ([#3922](https://github.com/flet-dev/flet/issues/3922))
+* FIXED: `Image.src.base64` ([#3919](https://github.com/flet-dev/flet/issues/3919))
+
 # 0.24.0
 
 * NEW: `Placeholder` Control ([#3646](https://github.com/flet-dev/flet/issues/3646))

--- a/packages/flet/pubspec.yaml
+++ b/packages/flet/pubspec.yaml
@@ -2,7 +2,7 @@ name: flet
 description: Write entire Flutter app in Python or add server-driven UI experience into existing Flutter app.
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/flet/packages/flet
-version: 0.24.0
+version: 0.24.1
 
 # This package supports all platforms listed below.
 platforms:

--- a/packages/flet_audio/CHANGELOG.md
+++ b/packages/flet_audio/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.24.1
+
+Version follows parent `flet` package.
+
 # 0.24.0
 
 Version follows parent `flet` package.

--- a/packages/flet_audio/pubspec.yaml
+++ b/packages/flet_audio/pubspec.yaml
@@ -2,7 +2,7 @@ name: flet_audio
 description: Flet Audio control
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/flet/packages/flet_audio
-version: 0.24.0
+version: 0.24.1
 
 environment:
   sdk: '>=3.2.3 <4.0.0'

--- a/packages/flet_audio_recorder/CHANGELOG.md
+++ b/packages/flet_audio_recorder/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.24.1
+
+Version follows parent `flet` package.
+
 # 0.24.0
 
 Version follows parent `flet` package.

--- a/packages/flet_audio_recorder/pubspec.yaml
+++ b/packages/flet_audio_recorder/pubspec.yaml
@@ -2,7 +2,7 @@ name: flet_audio_recorder
 description: Flet AudioRecorder control
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/flet/packages/flet_audio_recorder
-version: 0.24.0
+version: 0.24.1
 
 environment:
   sdk: '>=3.2.3 <4.0.0'

--- a/packages/flet_flashlight/CHANGELOG.md
+++ b/packages/flet_flashlight/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.24.1
+
+Version follows parent `flet` package.
+
 # 0.24.0
 
 Version follows parent `flet` package.

--- a/packages/flet_flashlight/pubspec.yaml
+++ b/packages/flet_flashlight/pubspec.yaml
@@ -2,7 +2,7 @@ name: flet_flashlight
 description: Flet Flashlight control
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/flet/packages/flet_flashlight
-version: 0.24.0
+version: 0.24.1
 
 
 environment:

--- a/packages/flet_geolocator/CHANGELOG.md
+++ b/packages/flet_geolocator/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.24.1
+
+Version follows parent `flet` package.
+
 # 0.24.0
 
 Version follows parent `flet` package.

--- a/packages/flet_geolocator/pubspec.yaml
+++ b/packages/flet_geolocator/pubspec.yaml
@@ -2,7 +2,7 @@ name: flet_geolocator
 description: Flet Geolocator control
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/flet/packages/flet_geolocator
-version: 0.24.0
+version: 0.24.1
 
 environment:
   sdk: '>=3.2.3 <4.0.0'

--- a/packages/flet_lottie/CHANGELOG.md
+++ b/packages/flet_lottie/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.24.1
+
+Version follows parent `flet` package.
+
 # 0.24.0
 
 Version follows parent `flet` package.

--- a/packages/flet_lottie/pubspec.yaml
+++ b/packages/flet_lottie/pubspec.yaml
@@ -2,7 +2,7 @@ name: flet_lottie
 description: Flet Lottie control
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/flet/packages/flet_lottie
-version: 0.24.0
+version: 0.24.1
 
 environment:
   sdk: '>=3.2.3 <4.0.0'

--- a/packages/flet_map/CHANGELOG.md
+++ b/packages/flet_map/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.24.1
+
+Version follows parent `flet` package.
+
 # 0.24.0
 
 Version follows parent `flet` package.

--- a/packages/flet_map/pubspec.yaml
+++ b/packages/flet_map/pubspec.yaml
@@ -2,7 +2,7 @@ name: flet_map
 description: Flet Map control
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/flet/packages/flet_map
-version: 0.24.0
+version: 0.24.1
 
 environment:
   sdk: '>=3.2.3 <4.0.0'

--- a/packages/flet_permission_handler/CHANGELOG.md
+++ b/packages/flet_permission_handler/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.24.1
+
+Version follows parent `flet` package.
+
 # 0.24.0
 
 Version follows parent `flet` package.

--- a/packages/flet_permission_handler/pubspec.yaml
+++ b/packages/flet_permission_handler/pubspec.yaml
@@ -2,7 +2,7 @@ name: flet_permission_handler
 description: Flet PermissionHandler control
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/flet/packages/flet_permission_handler
-version: 0.24.0
+version: 0.24.1
 
 environment:
   sdk: '>=3.2.3 <4.0.0'

--- a/packages/flet_rive/CHANGELOG.md
+++ b/packages/flet_rive/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.24.1
+
+Version follows parent `flet` package.
+
 # 0.24.0
 
 Version follows parent `flet` package.

--- a/packages/flet_rive/pubspec.yaml
+++ b/packages/flet_rive/pubspec.yaml
@@ -2,7 +2,7 @@ name: flet_rive
 description: Flet Rive control
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/flet/packages/flet_rive
-version: 0.24.0
+version: 0.24.1
 
 environment:
   sdk: '>=3.2.3 <4.0.0'

--- a/packages/flet_video/CHANGELOG.md
+++ b/packages/flet_video/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.24.1
+
+Version follows parent `flet` package.
+
 # 0.24.0
 
 Version follows parent `flet` package.

--- a/packages/flet_video/pubspec.yaml
+++ b/packages/flet_video/pubspec.yaml
@@ -2,7 +2,7 @@ name: flet_video
 description: Flet Video control
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/flet/packages/flet_video
-version: 0.24.0
+version: 0.24.1
 
 environment:
   sdk: '>=3.2.3 <4.0.0'

--- a/packages/flet_webview/CHANGELOG.md
+++ b/packages/flet_webview/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.24.1
+
+Version follows parent `flet` package.
+
 # 0.24.0
 
 Version follows parent `flet` package.

--- a/packages/flet_webview/pubspec.yaml
+++ b/packages/flet_webview/pubspec.yaml
@@ -2,7 +2,7 @@ name: flet_webview
 description: Flet WebView control
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/flet/packages/flet_webview
-version: 0.24.0
+version: 0.24.1
 
 environment:
   sdk: '>=3.2.3 <4.0.0'


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Prepare for the release of Flet version 0.24.1 by updating version numbers, fixing bugs related to Tooltip and Image.src.base64, and adding documentation for the release process.

Bug Fixes:
- Fix Tooltip displaying the wrong message when used with IconButton, FloatingActionButton, and PopupMenuButton.
- Fix issue with Image.src.base64.

Documentation:
- Add a new section in CONTRIBUTING.md detailing the steps for releasing a new version of Flet.

Chores:
- Update version numbers to 0.24.1 in pubspec.yaml files across multiple packages to align with the parent Flet package.

<!-- Generated by sourcery-ai[bot]: end summary -->