### PR TITLE
fix: `Dropdown.max_menu_height` is not respected

### DIFF
--- a/sdk/python/packages/flet-core/src/flet_core/dropdown.py
+++ b/sdk/python/packages/flet-core/src/flet_core/dropdown.py
@@ -444,14 +444,14 @@ class Dropdown(FormFieldControl):
         ), "item_height must be greater than or equal to 48.0"
         self._set_attr("itemHeight", value)
 
-    # menu_max_height
+    # max_menu_height
     @property
-    def menu_max_height(self) -> OptionalNumber:
-        return self._get_attr("menuMaxHeight", data_type="float")
+    def max_menu_height(self) -> OptionalNumber:
+        return self._get_attr("maxMenuHeight", data_type="float")
 
-    @menu_max_height.setter
-    def menu_max_height(self, value: OptionalNumber):
-        self._set_attr("menuMaxHeight", value)
+    @max_menu_height.setter
+    def max_menu_height(self, value: OptionalNumber):
+        self._set_attr("maxMenuHeight", value)
 
     # icon_size
     @property


### PR DESCRIPTION
## Description

Fixes #3966

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Correct the attribute name for `Dropdown.max_menu_height` to ensure it is properly respected in the code.

Bug Fixes:
- Fix the issue where `Dropdown.max_menu_height` was not being respected by correcting the attribute name in the getter and setter methods.

<!-- Generated by sourcery-ai[bot]: end summary -->