### PR TITLE
fix: `Switch`'s `height` and `width` properties not respected when `label` is set

### DIFF
--- a/packages/flet/lib/src/controls/switch.dart
+++ b/packages/flet/lib/src/controls/switch.dart
@@ -152,16 +152,25 @@ class _SwitchControlState extends State<SwitchControl> with FletStoreMixin {
             : MouseRegion(
                 cursor: SystemMouseCursors.click,
                 child: Text(label, style: labelStyle));
+
         result = MergeSemantics(
-            child: GestureDetector(
-                onTap: !disabled
-                    ? () {
-                        _onChange(!_value);
-                      }
-                    : null,
-                child: labelPosition == LabelPosition.right
-                    ? Row(children: [s, labelWidget])
-                    : Row(children: [labelWidget, s])));
+          child: GestureDetector(
+            onTap: !disabled
+                ? () {
+                    _onChange(!_value);
+                  }
+                : null,
+            child: labelPosition == LabelPosition.right
+                ? Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [result, labelWidget],
+                  )
+                : Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [labelWidget, result],
+                  ),
+          ),
+        );
       }
 
       return constrainedControl(context, result, widget.parent, widget.control);


### PR DESCRIPTION
## Description

Fixes #3997

Continuation of https://github.com/flet-dev/flet/pull/3670

## Test Code
```py
import flet as ft


def main(page: ft.Page):
    page.add(
        ft.Switch(
            label="Switch 50",
            value=True,
            on_change=lambda e: print(e.value),
            height=50,
        ),
        ft.Switch(
            label="Switch 100",
            value=True,
            on_change=lambda e: print(e.value),
            height=100,
            label_position=ft.LabelPosition.LEFT,
        ),
    )


ft.app(target=main)
```


<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the issue where the `Switch` component's `height` and `width` properties were not respected when a `label` was set, ensuring proper layout and functionality.

Bug Fixes:
- Ensure the `Switch` component respects the `height` and `width` properties when a `label` is set.

<!-- Generated by sourcery-ai[bot]: end summary -->