### PR TITLE
fix: Display informative message when `date` has wrong format

### DIFF
--- a/packages/flet/lib/src/models/control.dart
+++ b/packages/flet/lib/src/models/control.dart
@@ -98,7 +98,11 @@ class Control extends Equatable {
     if (value == null) {
       return defValue;
     }
-    return DateTime.parse(value);
+    try {
+      return DateTime.parse(value);
+    } catch (e) {
+      return null;
+    }
   }
 
   TimeOfDay? attrTime(String name, [TimeOfDay? defValue]) {

--- a/sdk/python/packages/flet-core/src/flet_core/cupertino_date_picker.py
+++ b/sdk/python/packages/flet-core/src/flet_core/cupertino_date_picker.py
@@ -14,6 +14,7 @@ from flet_core.types import (
     ScaleValue,
     OptionalControlEventCallable,
 )
+from flet_core.utils.datetime import datetime_to_string
 
 
 class CupertinoDatePickerMode(Enum):
@@ -42,8 +43,8 @@ class CupertinoDatePicker(ConstrainedControl):
     def __init__(
         self,
         value: Optional[datetime] = None,
-        first_date: Optional[datetime] = None,
-        last_date: Optional[datetime] = None,
+        first_date: Optional[Union[datetime, str]] = None,
+        last_date: Optional[Union[datetime, str]] = None,
         bgcolor: Optional[str] = None,
         minute_interval: Optional[int] = None,
         minimum_year: Optional[int] = None,
@@ -152,9 +153,7 @@ class CupertinoDatePicker(ConstrainedControl):
 
     @first_date.setter
     def first_date(self, value: Optional[Union[datetime, str]]):
-        if isinstance(value, (date, datetime)):
-            value = value.isoformat()
-        self._set_attr("firstDate", value)
+        self._set_attr("firstDate", datetime_to_string(value))
 
     # last_date
     @property
@@ -166,9 +165,7 @@ class CupertinoDatePicker(ConstrainedControl):
 
     @last_date.setter
     def last_date(self, value: Optional[Union[datetime, str]]):
-        if isinstance(value, (date, datetime)):
-            value = value.isoformat()
-        self._set_attr("lastDate", value)
+        self._set_attr("lastDate", datetime_to_string(value))
 
     # bgcolor
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/date_picker.py
+++ b/sdk/python/packages/flet-core/src/flet_core/date_picker.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import datetime
 from enum import Enum
 from typing import Any, Optional, Union
 
@@ -14,6 +14,7 @@ from flet_core.types import (
     OptionalControlEventCallable,
 )
 from flet_core.utils import deprecated
+from flet_core.utils.datetime import datetime_to_string
 
 try:
     from typing import Literal
@@ -87,10 +88,10 @@ class DatePicker(Control):
     def __init__(
         self,
         open: bool = False,
-        value: Optional[datetime] = None,
-        first_date: Optional[datetime] = None,
-        last_date: Optional[datetime] = None,
-        current_date: Optional[datetime] = None,
+        value: Optional[Union[datetime, str]] = None,
+        first_date: Optional[Union[datetime, str]] = None,
+        last_date: Optional[Union[datetime, str]] = None,
+        current_date: Optional[Union[datetime, str]] = None,
         keyboard_type: Optional[KeyboardType] = None,
         date_picker_mode: Optional[DatePickerMode] = None,
         date_picker_entry_mode: Optional[DatePickerEntryMode] = None,
@@ -202,9 +203,7 @@ class DatePicker(Control):
 
     @value.setter
     def value(self, value: Optional[Union[datetime, str]]):
-        if isinstance(value, (date, datetime)):
-            value = value.isoformat()
-        self._set_attr("value", value)
+        self._set_attr("value", datetime_to_string(value))
 
     # first_date
     @property
@@ -216,9 +215,7 @@ class DatePicker(Control):
 
     @first_date.setter
     def first_date(self, value: Optional[Union[datetime, str]]):
-        if isinstance(value, (date, datetime)):
-            value = value.isoformat()
-        self._set_attr("firstDate", value)
+        self._set_attr("firstDate", datetime_to_string(value))
 
     # last_date
     @property
@@ -230,9 +227,7 @@ class DatePicker(Control):
 
     @last_date.setter
     def last_date(self, value: Optional[Union[datetime, str]]):
-        if isinstance(value, (date, datetime)):
-            value = value.isoformat()
-        self._set_attr("lastDate", value)
+        self._set_attr("lastDate", datetime_to_string(value))
 
     # current_date
     @property
@@ -244,9 +239,7 @@ class DatePicker(Control):
 
     @current_date.setter
     def current_date(self, value: Optional[Union[datetime, str]]):
-        if isinstance(value, (date, datetime)):
-            value = value.isoformat()
-        self._set_attr("currentDate", value)
+        self._set_attr("currentDate", datetime_to_string(value))
 
     # field_hint_text
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/time_picker.py
+++ b/sdk/python/packages/flet-core/src/flet_core/time_picker.py
@@ -176,11 +176,9 @@ class TimePicker(Control):
     # value
     @property
     def value(self) -> Optional[time]:
-        value_string = self._get_attr(
-            "value", def_value=None
-        )  # value_string in comes in format 'HH:MM'
+        value_string = self._get_attr("value", def_value=None)
         if value_string:
-            splitted = value_string.split(":")
+            splitted = value_string.split(":")  # value_string comes in format 'HH:MM'
             return time(hour=int(splitted[0]), minute=int(splitted[1]))
         else:
             return None

--- a/sdk/python/packages/flet-core/src/flet_core/utils/datetime.py
+++ b/sdk/python/packages/flet-core/src/flet_core/utils/datetime.py
@@ -1,0 +1,30 @@
+import re
+from datetime import datetime, date
+from typing import Optional, Union
+
+
+def has_valid_datetime_format(value: str) -> bool:
+    """
+    Checks if the given string has a valid datetime format.
+    Returns True if that's the case and False otherwise.
+    """
+    regex_format = (
+        r"^([+-]?\d{4,6})-?(\d\d)-?(\d\d)"
+        r"(?:[ T](\d\d)(?::?(\d\d)(?::?(\d\d)(?:[.,](\d+))?)?)?"
+        r"( ?[zZ]| ?([-+])(\d\d)(?::?(\d\d))?)?)?$"
+    )
+    return re.match(regex_format, value) is not None
+
+
+def datetime_to_string(value: Optional[Union[datetime, str]]) -> Optional[str]:
+    """
+    Converts a datetime or date object to an ISO 8601 string.
+    If the input is already a string, it checks if the string has a valid datetime format.
+    """
+    if isinstance(value, (date, datetime)):
+        return value.isoformat()
+    assert value is None or has_valid_datetime_format(
+        value
+    ), f"{value} has an invalid format"
+
+    return value


### PR DESCRIPTION
## Description
Closes #4017
