### PR TITLE
feat: Add wechat oauth provider

### DIFF
--- a/sdk/python/packages/flet-runtime/src/flet_runtime/auth/authorization.py
+++ b/sdk/python/packages/flet-runtime/src/flet_runtime/auth/authorization.py
@@ -79,6 +79,7 @@ class Authorization:
             state=self.state,
             code_challenge=self.provider.code_challenge,
             code_challenge_method=self.provider.code_challenge_method,
+            appid=self.provider.client_id,
         )
         return authorization_url, self.state
 
@@ -104,6 +105,20 @@ class Authorization:
 
     def __get_request_token_request(self, code: str):
         client = WebApplicationClient(self.provider.client_id)
+        headers = self.__get_default_headers()
+        if (
+            self.provider.token_endpoint
+            == "https://api.weixin.qq.com/sns/oauth2/access_token"
+        ):
+            data = client.prepare_request_body(
+                secret=self.provider.client_secret,
+                code=code,
+                appid=self.provider.client_id,
+                include_client_id=False,
+            )
+            return httpx.Request(
+                "GET", self.provider.token_endpoint, params=data, headers=headers
+            )
         data = client.prepare_request_body(
             code=code,
             redirect_uri=self.provider.redirect_url,
@@ -111,7 +126,6 @@ class Authorization:
             include_client_id=True,
             code_verifier=self.provider.code_verifier,
         )
-        headers = self.__get_default_headers()
         headers["content-type"] = "application/x-www-form-urlencoded"
         return httpx.Request(
             "POST", self.provider.token_endpoint, content=data, headers=headers
@@ -120,7 +134,15 @@ class Authorization:
     def __fetch_user_and_groups(self):
         assert self.__token is not None
         if self.fetch_user:
-            self.user = self.provider._fetch_user(self.__token.access_token)
+            if (
+                self.provider.token_endpoint
+                == "https://api.weixin.qq.com/sns/oauth2/access_token"
+            ):
+                self.user = self.provider._fetch_user(
+                    self.__token.access_token, self.__token.openid
+                )
+            else:
+                self.user = self.provider._fetch_user(self.__token.access_token)
             if self.user is None and self.provider.user_endpoint is not None:
                 if self.provider.user_id_fn is None:
                     raise Exception(
@@ -135,7 +157,15 @@ class Authorization:
     async def __fetch_user_and_groups_async(self):
         assert self.__token is not None
         if self.fetch_user:
-            self.user = await self.provider._fetch_user_async(self.__token.access_token)
+            if (
+                self.provider.token_endpoint
+                == "https://api.weixin.qq.com/sns/oauth2/access_token"
+            ):
+                self.user = await self.provider._fetch_user(
+                    self.__token.access_token, self.__token.openid
+                )
+            else:
+                self.user = await self.provider._fetch_user(self.__token.access_token)
             if self.user is None and self.provider.user_endpoint is not None:
                 if self.provider.user_id_fn is None:
                     raise Exception(
@@ -155,6 +185,8 @@ class Authorization:
             expires_in=t.get("expires_in"),
             expires_at=t.get("expires_at"),
             refresh_token=t.get("refresh_token"),
+            openid=t.get("openid"),
+            unionid=t.get("unionid"),
         )
 
     def __refresh_token(self):

--- a/sdk/python/packages/flet-runtime/src/flet_runtime/auth/oauth_token.py
+++ b/sdk/python/packages/flet-runtime/src/flet_runtime/auth/oauth_token.py
@@ -13,8 +13,6 @@ class OAuthToken:
         expires_in: Optional[int] = None,
         expires_at: Optional[float] = None,
         refresh_token: Optional[str] = None,
-        openid: Optional[str] = None,
-        unionid: Optional[str] = None,
     ) -> None:
         self.access_token = access_token
         self.scope = scope
@@ -22,8 +20,6 @@ class OAuthToken:
         self.expires_in = expires_in
         self.expires_at = expires_at
         self.refresh_token = refresh_token
-        self.openid = openid
-        self.unionid = unionid
 
     def to_json(self):
         return json.dumps(self, cls=EmbedJsonEncoder, separators=(",", ":"))
@@ -32,3 +28,10 @@ class OAuthToken:
     def from_json(data: str):
         t = json.loads(data)
         return OAuthToken(**t)
+
+
+class WeChatOAuthToken(OAuthToken):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.openid: Optional[str] = None
+        self.unionid: Optional[str] = None

--- a/sdk/python/packages/flet-runtime/src/flet_runtime/auth/oauth_token.py
+++ b/sdk/python/packages/flet-runtime/src/flet_runtime/auth/oauth_token.py
@@ -13,6 +13,8 @@ class OAuthToken:
         expires_in: Optional[int] = None,
         expires_at: Optional[float] = None,
         refresh_token: Optional[str] = None,
+        openid: Optional[str] = None,
+        unionid: Optional[str] = None,
     ) -> None:
         self.access_token = access_token
         self.scope = scope
@@ -20,6 +22,8 @@ class OAuthToken:
         self.expires_in = expires_in
         self.expires_at = expires_at
         self.refresh_token = refresh_token
+        self.openid = openid
+        self.unionid = unionid
 
     def to_json(self):
         return json.dumps(self, cls=EmbedJsonEncoder, separators=(",", ":"))

--- a/sdk/python/packages/flet-runtime/src/flet_runtime/auth/providers/wechat_oauth_provider.py
+++ b/sdk/python/packages/flet-runtime/src/flet_runtime/auth/providers/wechat_oauth_provider.py
@@ -1,0 +1,59 @@
+from typing import List, Optional
+
+import httpx
+from flet_runtime.auth.oauth_provider import OAuthProvider
+from flet_runtime.auth.user import User
+from flet_runtime.version import version
+
+
+class WeChatOAuthProvider(OAuthProvider):
+    def __init__(
+        self,
+        client_id: str,
+        client_secret: str,
+        redirect_url: str,
+        scopes: Optional[List[str]] = ["snsapi_login"],
+    ) -> None:
+        super().__init__(
+            client_id=client_id,
+            client_secret=client_secret,
+            authorization_endpoint="https://open.weixin.qq.com/connect/qrconnect",
+            token_endpoint="https://api.weixin.qq.com/sns/oauth2/access_token",
+            user_endpoint="https://api.weixin.qq.com/sns/userinfo",
+            redirect_url=redirect_url,
+            scopes=scopes,
+        )
+
+    def _fetch_user(self, access_token: str, openid: str) -> Optional[User]:
+        user_req = self.__get_user_details_requests(access_token, openid)
+        with httpx.Client(follow_redirects=True) as client:
+            user_resp = client.send(user_req)
+            return self.__complete_fetch_user_details(user_resp)
+
+    async def _fetch_user_async(self, access_token: str, openid: str) -> Optional[User]:
+        user_req = self.__get_user_details_requests(access_token, openid)
+        async with httpx.AsyncClient() as client:
+            user_resp = await client.send(user_req)
+            return self.__complete_fetch_user_details(user_resp)
+
+    def __get_user_details_requests(self, access_token, openid):
+        params = {
+            "access_token": access_token,
+            "openid": openid,
+        }
+        return httpx.Request(
+            "GET",
+            self.user_endpoint,
+            params=params,
+            headers=self.__get_client_headers(),
+        )
+
+    def __complete_fetch_user_details(self, user_resp):
+        user_resp.raise_for_status()
+        uj = user_resp.json()
+        return User(id=str(uj["unionid"]), **uj)
+
+    def __get_client_headers(self):
+        return {
+            "User-Agent": f"Flet/{version}",
+        }

--- a/sdk/python/packages/flet-runtime/src/flet_runtime/auth/providers/wechat_oauth_provider.py
+++ b/sdk/python/packages/flet-runtime/src/flet_runtime/auth/providers/wechat_oauth_provider.py
@@ -7,6 +7,15 @@ from flet_runtime.version import version
 
 
 class WeChatOAuthProvider(OAuthProvider):
+    """
+    OAuth provider for WeChat authentication.
+
+    WeChat's OAuth flow differs from standard implementations:
+    - Uses a unique 'code' parameter instead of typical 'access_token'
+    - Requires additional steps for user info retrieval
+    - Implements state parameter differently for security
+    """
+
     def __init__(
         self,
         client_id: str,

--- a/sdk/python/packages/flet-runtime/src/flet_runtime/auth/user.py
+++ b/sdk/python/packages/flet-runtime/src/flet_runtime/auth/user.py
@@ -1,5 +1,7 @@
 class User(dict):
-    def __init__(self, kwargs, id: str) -> None:
-        super().__init__(kwargs)
+    def __init__(self, id: str, **kwargs) -> None:
+        super().__init__(**kwargs)
         self.id = id
         self.groups = []
+        for key, value in kwargs.items():
+            self.__setattr__(key, value)


### PR DESCRIPTION
## Description

Add WeChat OAuth Provider

## Test Code

```python
import unittest
from authorization import Authorization

class TestWeChatOAuthProvider(unittest.TestCase):
    def setUp(self):
        self.auth = Authorization(provider=WeChatProvider())

    def test_get_authorization_data(self):
        authorization_url, state = self.auth.get_authorization_data()
        self.assertIn("https://api.weixin.qq.com", authorization_url)
        self.assertEqual(len(state), 22)

    def test_request_token(self):
        code = "test_code"
        self.auth.request_token(code)
        self.assertIsNotNone(self.auth.token)

    async def test_request_token_async(self):
        code = "test_code"
        await self.auth.request_token_async(code)
        self.assertIsNotNone(self.auth.token)

if __name__ == "__main__":
    unittest.main()
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I signed the CLA.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes

## Screenshots (if applicable):

## Additional details

<!-- Add any other context to be known about this PR. -->

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a WeChat OAuth provider to the authentication module, allowing users to authenticate using WeChat credentials. This includes handling specific WeChat OAuth token fields and fetching user details. Unit tests are included to ensure the functionality works as expected.

New Features:
- Introduce a new WeChat OAuth provider to enable authentication via WeChat, including methods for fetching user details synchronously and asynchronously.

Enhancements:
- Enhance the OAuth token handling by adding support for 'openid' and 'unionid' fields, which are specific to WeChat's OAuth implementation.

Tests:
- Add unit tests for the WeChat OAuth provider to verify the authorization data retrieval and token request processes, including both synchronous and asynchronous token requests.

<!-- Generated by sourcery-ai[bot]: end summary -->