### PR TITLE
fix: `LineChartDataPoint.tooltip` with escape characters not being properly rendered

### DIFF
--- a/packages/flet/lib/src/controls/linechart.dart
+++ b/packages/flet/lib/src/controls/linechart.dart
@@ -356,7 +356,9 @@ class _LineChartControlState extends State<LineChartControl> {
                       return touchedSpots.map((spot) {
                         var dp = viewModel.dataSeries[spot.barIndex]
                             .dataPoints[spot.spotIndex];
-                        var tooltip = dp.tooltip ?? dp.y.toString();
+                        var tooltip = dp.tooltip != null
+                            ? jsonDecode(dp.tooltip!)
+                            : dp.y.toString();
                         var tooltipStyle = parseTextStyle(
                             Theme.of(context), dp.control, "tooltipStyle");
                         tooltipStyle ??= const TextStyle();


### PR DESCRIPTION
## Description

Fixes #4049

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the rendering of `LineChartDataPoint.tooltip` with escape characters by decoding the tooltip string before displaying it.

Bug Fixes:
- Fix the issue where `LineChartDataPoint.tooltip` with escape characters was not being properly rendered by decoding the tooltip string.

<!-- Generated by sourcery-ai[bot]: end summary -->