### PR TITLE
fix: `NavigationBarDestination.disabled` has no visual effect

### DIFF
--- a/packages/flet/lib/src/controls/navigation_bar.dart
+++ b/packages/flet/lib/src/controls/navigation_bar.dart
@@ -6,6 +6,7 @@ import '../utils/borders.dart';
 import '../utils/colors.dart';
 import '../utils/icons.dart';
 import '../utils/others.dart';
+import '../utils/time.dart';
 import 'create_control.dart';
 import 'cupertino_navigation_bar.dart';
 import 'flet_store_mixin.dart';
@@ -49,8 +50,7 @@ class _NavigationBarControlState extends State<NavigationBarControl>
     debugPrint("NavigationBarControl build: ${widget.control.id}");
 
     return withPagePlatform((context, platform) {
-      bool? adaptive =
-          widget.control.attrBool("adaptive") ?? widget.parentAdaptive;
+      bool? adaptive = widget.control.isAdaptive ?? widget.parentAdaptive;
       if (adaptive == true &&
           (platform == TargetPlatform.iOS ||
               platform == TargetPlatform.macOS)) {
@@ -68,22 +68,16 @@ class _NavigationBarControlState extends State<NavigationBarControl>
       if (_selectedIndex != selectedIndex) {
         _selectedIndex = selectedIndex;
       }
-      var animationDuration = widget.control.attrInt("animationDuration");
-
-      NavigationDestinationLabelBehavior? labelBehavior =
-          parseNavigationDestinationLabelBehavior(
-              widget.control.attrString("labelBehavior"));
-
       var navBar = withControls(
           widget.children
               .where((c) => c.isVisible && c.name == null)
               .map((c) => c.id), (content, viewModel) {
         return NavigationBar(
-            labelBehavior: labelBehavior,
+            labelBehavior: parseNavigationDestinationLabelBehavior(
+                widget.control.attrString("labelBehavior")),
             height: widget.control.attrDouble("height"),
-            animationDuration: animationDuration != null
-                ? Duration(milliseconds: animationDuration)
-                : null,
+            animationDuration:
+                parseDuration(widget.control, "animationDuration"),
             elevation: widget.control.attrDouble("elevation"),
             shadowColor: widget.control.attrColor("shadowColor", context),
             surfaceTintColor:
@@ -95,31 +89,32 @@ class _NavigationBarControlState extends State<NavigationBarControl>
                 parseOutlinedBorder(widget.control, "indicatorShape"),
             backgroundColor: widget.control.attrColor("bgColor", context),
             selectedIndex: _selectedIndex,
-            onDestinationSelected: _destinationChanged,
+            onDestinationSelected: disabled ? null : _destinationChanged,
             destinations: viewModel.controlViews.map((destView) {
               var label = destView.control.attrString("label", "")!;
-
               var icon = parseIcon(destView.control.attrString("icon"));
               var iconContentCtrls = destView.children
                   .where((c) => c.name == "icon_content" && c.isVisible);
-
               var selectedIcon =
                   parseIcon(destView.control.attrString("selectedIcon"));
               var selectedIconContentCtrls = destView.children.where(
                   (c) => c.name == "selected_icon_content" && c.isVisible);
-
+              var destinationDisabled = disabled || destView.control.isDisabled;
+              var destinationAdaptive = destView.control.isAdaptive ?? adaptive;
               return NavigationDestination(
-                  enabled: !disabled || !destView.control.isDisabled,
-                  tooltip: destView.control.attrString("tooltip", "")!,
+                  enabled: !destinationDisabled,
+                  tooltip: destView.control.attrString("tooltip"),
                   icon: iconContentCtrls.isNotEmpty
-                      ? createControl(
-                          destView.control, iconContentCtrls.first.id, disabled,
-                          parentAdaptive: adaptive)
+                      ? createControl(destView.control,
+                          iconContentCtrls.first.id, destinationDisabled,
+                          parentAdaptive: destinationAdaptive)
                       : Icon(icon),
                   selectedIcon: selectedIconContentCtrls.isNotEmpty
-                      ? createControl(destView.control,
-                          selectedIconContentCtrls.first.id, disabled,
-                          parentAdaptive: adaptive)
+                      ? createControl(
+                          destView.control,
+                          selectedIconContentCtrls.first.id,
+                          destinationDisabled,
+                          parentAdaptive: destinationAdaptive)
                       : selectedIcon != null
                           ? Icon(selectedIcon)
                           : null,

--- a/packages/flet/lib/src/controls/navigation_bar.dart
+++ b/packages/flet/lib/src/controls/navigation_bar.dart
@@ -103,7 +103,7 @@ class _NavigationBarControlState extends State<NavigationBarControl>
               var destinationAdaptive = destView.control.isAdaptive ?? adaptive;
               return NavigationDestination(
                   enabled: !destinationDisabled,
-                  tooltip: destView.control.attrString("tooltip"),
+                  tooltip: destView.control.attrString("tooltip") ?? "",
                   icon: iconContentCtrls.isNotEmpty
                       ? createControl(destView.control,
                           iconContentCtrls.first.id, destinationDisabled,

--- a/packages/flet/lib/src/models/control.dart
+++ b/packages/flet/lib/src/models/control.dart
@@ -46,6 +46,10 @@ class Control extends Equatable {
     return attrBool("disabled", false)!;
   }
 
+  bool? get isAdaptive {
+    return attrBool("adaptive");
+  }
+
   bool get isVisible {
     return attrBool("visible", true)!;
   }


### PR DESCRIPTION
## Description
Fixes #4029

## Test Code
```py
import flet as ft


def main(page: ft.Page):

    page.title = "NavigationBar Example"

    def handle_disable_change(e):
        page.navigation_bar.disabled = e.control.value
        page.update()

    def handle_adaptive_change(e):
        page.navigation_bar.adaptive = e.control.value
        page.update()

    page.navigation_bar = ft.NavigationBar(
        destinations=[
            ft.NavigationBarDestination(icon=ft.icons.EXPLORE, label="Explore"),
            ft.NavigationBarDestination(icon=ft.icons.COMMUTE, label="Commute"),
            ft.NavigationBarDestination(
                icon=ft.icons.BOOKMARK_BORDER,
                selected_icon=ft.icons.BOOKMARK,
                label="Explore",
            ),
        ],
    )
    page.add(
        ft.Switch("Disable", value=False, on_change=handle_disable_change),
        ft.Switch("Adaptive", value=False, on_change=handle_adaptive_change),
    )


ft.app(main)
```

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the visual effect of the `disabled` state in `NavigationBarDestination` and refactor the handling of adaptive and disabled states in navigation bar controls.

Bug Fixes:
- Fix the issue where `NavigationBarDestination.disabled` had no visual effect by ensuring that the disabled state is properly handled in the navigation bar controls.

Enhancements:
- Refactor the handling of adaptive and disabled states in navigation bar controls to improve code clarity and maintainability.

<!-- Generated by sourcery-ai[bot]: end summary -->