### PR TITLE
fix: `CupertinoTextField` doesn't autofill on web 

### DIFF
--- a/packages/flet/lib/src/controls/cupertino_textfield.dart
+++ b/packages/flet/lib/src/controls/cupertino_textfield.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 
 import '../flet_control_backend.dart';
 import '../models/control.dart';
+import '../utils/autofill.dart';
 import '../utils/borders.dart';
 import '../utils/box.dart';
 import '../utils/edge_insets.dart';
@@ -309,6 +310,7 @@ class _CupertinoTextFieldControlState extends State<CupertinoTextFieldControl>
           padding: parseEdgeInsets(
               widget.control, "padding", const EdgeInsets.all(7.0))!,
           scribbleEnabled: widget.control.attrBool("enableScribble", true)!,
+          autofillHints: parseAutofillHints(widget.control, "autofillHints"),
           scrollPadding: parseEdgeInsets(
               widget.control, "scrollPadding", const EdgeInsets.all(20.0))!,
           obscuringCharacter:


### PR DESCRIPTION
## Description

Fixes #4102

## Summary by Sourcery

Fix the autofill functionality for `CupertinoTextField` on web by incorporating autofill hints.

Bug Fixes:
- Fix the issue where `CupertinoTextField` does not autofill on web by adding support for autofill hints.