### PR TITLE
TextField: suffix_icon, prefix_icon and icon can be Control or str

### DIFF
--- a/packages/flet/lib/src/controls/dropdown.dart
+++ b/packages/flet/lib/src/controls/dropdown.dart
@@ -147,8 +147,14 @@ class _DropdownControlState extends State<DropdownControl> with FletStoreMixin {
 
       var prefixControls = itemsView.controlViews
           .where((c) => c.control.name == "prefix" && c.control.isVisible);
+      var prefixIconControls =
+          widget.children.where((c) => c.name == "prefixIcon" && c.isVisible);
       var suffixControls = itemsView.controlViews
           .where((c) => c.control.name == "suffix" && c.control.isVisible);
+      var suffixIconControls =
+          widget.children.where((c) => c.name == "suffixIcon" && c.isVisible);
+      var iconControls =
+          widget.children.where((c) => c.name == "icon" && c.isVisible);
       var counterControls = itemsView.controlViews
           .where((c) => c.control.name == "counter" && c.control.isVisible);
 
@@ -189,8 +195,11 @@ class _DropdownControlState extends State<DropdownControl> with FletStoreMixin {
         decoration: buildInputDecoration(context, widget.control,
             prefix:
                 prefixControls.isNotEmpty ? prefixControls.first.control : null,
+            prefixIcon: prefixIconControls.isNotEmpty ? prefixIconControls.first : null,
             suffix:
                 suffixControls.isNotEmpty ? suffixControls.first.control : null,
+            suffixIcon: suffixIconControls.isNotEmpty ? suffixIconControls.first : null,
+            icon: iconControls.isNotEmpty ? iconControls.first : null,
             counter: counterControls.isNotEmpty
                 ? counterControls.first.control
                 : null,

--- a/packages/flet/lib/src/controls/textfield.dart
+++ b/packages/flet/lib/src/controls/textfield.dart
@@ -129,6 +129,8 @@ class _TextFieldControlState extends State<TextFieldControl>
           widget.children.where((c) => c.name == "suffix" && c.isVisible);
       var suffixIconControls =
           widget.children.where((c) => c.name == "suffixIcon" && c.isVisible);
+      var iconControls =
+          widget.children.where((c) => c.name == "icon" && c.isVisible);
       var counterControls =
           widget.children.where((c) => c.name == "counter" && c.isVisible);
 
@@ -231,6 +233,7 @@ class _TextFieldControlState extends State<TextFieldControl>
               prefixIcon: prefixIconControls.isNotEmpty ? prefixIconControls.first : null,
               suffix: suffixControls.isNotEmpty ? suffixControls.first : null,
               suffixIcon: suffixIconControls.isNotEmpty ? suffixIconControls.first : null,
+              icon: iconControls.isNotEmpty ? iconControls.first : null,
               counter:
                   counterControls.isNotEmpty ? counterControls.first : null,
               customSuffix: revealPasswordIcon,

--- a/packages/flet/lib/src/controls/textfield.dart
+++ b/packages/flet/lib/src/controls/textfield.dart
@@ -125,6 +125,8 @@ class _TextFieldControlState extends State<TextFieldControl>
           widget.children.where((c) => c.name == "prefix" && c.isVisible);
       var suffixControls =
           widget.children.where((c) => c.name == "suffix" && c.isVisible);
+      var suffixIconControls =
+          widget.children.where((c) => c.name == "suffixIcon" && c.isVisible);
       var counterControls =
           widget.children.where((c) => c.name == "counter" && c.isVisible);
 
@@ -225,6 +227,7 @@ class _TextFieldControlState extends State<TextFieldControl>
           decoration: buildInputDecoration(context, widget.control,
               prefix: prefixControls.isNotEmpty ? prefixControls.first : null,
               suffix: suffixControls.isNotEmpty ? suffixControls.first : null,
+              suffixIcon: suffixIconControls.isNotEmpty ? suffixIconControls.first : null,
               counter:
                   counterControls.isNotEmpty ? counterControls.first : null,
               customSuffix: revealPasswordIcon,

--- a/packages/flet/lib/src/controls/textfield.dart
+++ b/packages/flet/lib/src/controls/textfield.dart
@@ -123,6 +123,8 @@ class _TextFieldControlState extends State<TextFieldControl>
 
       var prefixControls =
           widget.children.where((c) => c.name == "prefix" && c.isVisible);
+      var prefixIconControls =
+          widget.children.where((c) => c.name == "prefixIcon" && c.isVisible);
       var suffixControls =
           widget.children.where((c) => c.name == "suffix" && c.isVisible);
       var suffixIconControls =
@@ -226,6 +228,7 @@ class _TextFieldControlState extends State<TextFieldControl>
               : null,
           decoration: buildInputDecoration(context, widget.control,
               prefix: prefixControls.isNotEmpty ? prefixControls.first : null,
+              prefixIcon: prefixIconControls.isNotEmpty ? prefixIconControls.first : null,
               suffix: suffixControls.isNotEmpty ? suffixControls.first : null,
               suffixIcon: suffixIconControls.isNotEmpty ? suffixIconControls.first : null,
               counter:

--- a/packages/flet/lib/src/utils/form_field.dart
+++ b/packages/flet/lib/src/utils/form_field.dart
@@ -54,6 +54,7 @@ InputDecoration buildInputDecoration(
     BuildContext context,
     Control control,
     {Control? prefix,
+    Control? prefixIcon,
     Control? suffix,
     Control? suffixIcon,
     Control? counter,
@@ -68,7 +69,7 @@ InputDecoration buildInputDecoration(
   )!;
   var icon = parseIcon(control.attrString("icon"));
 
-  var prefixIcon = parseIcon(control.attrString("prefixIcon"));
+  var prefixIconStr = parseIcon(control.attrString("prefixIcon"));
   var prefixText = control.attrString("prefixText");
   var suffixIconStr = parseIcon(control.attrString("suffixIcon"));
   var suffixText = control.attrString("suffixText");
@@ -151,7 +152,11 @@ InputDecoration buildInputDecoration(
           ? control.attrString("errorText")
           : null,
       errorStyle: parseTextStyle(Theme.of(context), control, "errorStyle"),
-      prefixIcon: prefixIcon != null ? Icon(prefixIcon) : null,
+      //prefixIcon: prefixIcon != null ? Icon(prefixIcon) : null,
+      prefixIcon: prefixIcon != null
+          ? createControl(control, prefixIcon.id, control.isDisabled,
+              parentAdaptive: adaptive)
+          : prefixIconStr !=null? Icon(prefixIconStr): null,
       prefixText: prefixText,
       prefixStyle: parseTextStyle(Theme.of(context), control, "prefixStyle"),
       prefix: prefix != null

--- a/packages/flet/lib/src/utils/form_field.dart
+++ b/packages/flet/lib/src/utils/form_field.dart
@@ -136,7 +136,6 @@ InputDecoration buildInputDecoration(
       enabledBorder: border,
       focusedBorder: focusedBorder,
       hoverColor: hoverColor,
-      //icon: icon != null ? Icon(icon) : null,
       icon: icon != null
           ? createControl(control, icon.id, control.isDisabled,
               parentAdaptive: adaptive)
@@ -157,7 +156,6 @@ InputDecoration buildInputDecoration(
           ? control.attrString("errorText")
           : null,
       errorStyle: parseTextStyle(Theme.of(context), control, "errorStyle"),
-      //prefixIcon: prefixIcon != null ? Icon(prefixIcon) : null,
       prefixIcon: prefixIcon != null
           ? createControl(control, prefixIcon.id, control.isDisabled,
               parentAdaptive: adaptive)
@@ -172,7 +170,6 @@ InputDecoration buildInputDecoration(
           ? createControl(control, suffix.id, control.isDisabled,
               parentAdaptive: adaptive)
           : null,
-      // suffixIcon: suffixIcon != null ? Icon(suffixIcon) : customSuffix,
       suffixIcon: suffixIcon != null
           ? createControl(control, suffixIcon.id, control.isDisabled,
               parentAdaptive: adaptive)

--- a/packages/flet/lib/src/utils/form_field.dart
+++ b/packages/flet/lib/src/utils/form_field.dart
@@ -70,7 +70,7 @@ InputDecoration buildInputDecoration(
 
   var prefixIcon = parseIcon(control.attrString("prefixIcon"));
   var prefixText = control.attrString("prefixText");
-  //var suffixIcon = parseIcon(control.attrString("suffixIcon"));
+  var suffixIconStr = parseIcon(control.attrString("suffixIcon"));
   var suffixText = control.attrString("suffixText");
 
   var bgcolor = control.attrColor("bgcolor", context);
@@ -166,7 +166,7 @@ InputDecoration buildInputDecoration(
       suffixIcon: suffixIcon != null
           ? createControl(control, suffixIcon.id, control.isDisabled,
               parentAdaptive: adaptive)
-          : customSuffix,
+          : suffixIconStr !=null? Icon(suffixIconStr): customSuffix,
       suffixText: suffixText,
       suffixStyle: parseTextStyle(Theme.of(context), control, "suffixStyle"),
       );

--- a/packages/flet/lib/src/utils/form_field.dart
+++ b/packages/flet/lib/src/utils/form_field.dart
@@ -57,6 +57,7 @@ InputDecoration buildInputDecoration(
     Control? prefixIcon,
     Control? suffix,
     Control? suffixIcon,
+    Control? icon,
     Control? counter,
     Widget? customSuffix,
     bool focused = false,
@@ -67,7 +68,7 @@ InputDecoration buildInputDecoration(
     control.attrString("border"),
     FormFieldInputBorder.outline,
   )!;
-  var icon = parseIcon(control.attrString("icon"));
+  var iconStr = parseIcon(control.attrString("icon"));
 
   var prefixIconStr = parseIcon(control.attrString("prefixIcon"));
   var prefixText = control.attrString("prefixText");
@@ -135,7 +136,11 @@ InputDecoration buildInputDecoration(
       enabledBorder: border,
       focusedBorder: focusedBorder,
       hoverColor: hoverColor,
-      icon: icon != null ? Icon(icon) : null,
+      //icon: icon != null ? Icon(icon) : null,
+      icon: icon != null
+          ? createControl(control, icon.id, control.isDisabled,
+              parentAdaptive: adaptive)
+          : iconStr !=null? Icon(iconStr): null,
       filled: control.attrBool("filled", false)!,
       fillColor: fillColor ?? (focused ? focusedBgcolor ?? bgcolor : bgcolor),
       hintText: control.attrString("hintText"),

--- a/packages/flet/lib/src/utils/form_field.dart
+++ b/packages/flet/lib/src/utils/form_field.dart
@@ -55,6 +55,7 @@ InputDecoration buildInputDecoration(
     Control control,
     {Control? prefix,
     Control? suffix,
+    Control? suffixIcon,
     Control? counter,
     Widget? customSuffix,
     bool focused = false,
@@ -69,7 +70,7 @@ InputDecoration buildInputDecoration(
 
   var prefixIcon = parseIcon(control.attrString("prefixIcon"));
   var prefixText = control.attrString("prefixText");
-  var suffixIcon = parseIcon(control.attrString("suffixIcon"));
+  //var suffixIcon = parseIcon(control.attrString("suffixIcon"));
   var suffixText = control.attrString("suffixText");
 
   var bgcolor = control.attrColor("bgcolor", context);
@@ -161,9 +162,14 @@ InputDecoration buildInputDecoration(
           ? createControl(control, suffix.id, control.isDisabled,
               parentAdaptive: adaptive)
           : null,
-      suffixIcon: suffixIcon != null ? Icon(suffixIcon) : customSuffix,
+      // suffixIcon: suffixIcon != null ? Icon(suffixIcon) : customSuffix,
+      suffixIcon: suffixIcon != null
+          ? createControl(control, suffixIcon.id, control.isDisabled,
+              parentAdaptive: adaptive)
+          : customSuffix,
       suffixText: suffixText,
-      suffixStyle: parseTextStyle(Theme.of(context), control, "suffixStyle"));
+      suffixStyle: parseTextStyle(Theme.of(context), control, "suffixStyle"),
+      );
 }
 
 OverlayVisibilityMode parseVisibilityMode(String type) {

--- a/sdk/python/packages/flet-core/src/flet_core/dropdown.py
+++ b/sdk/python/packages/flet-core/src/flet_core/dropdown.py
@@ -18,7 +18,7 @@ from flet_core.types import (
     OptionalControlEventCallable,
 )
 from flet_core.utils import deprecated
-
+from flet_core.form_field_control import IconValue
 
 class Option(Control):
     def __init__(
@@ -181,7 +181,7 @@ class Dropdown(FormFieldControl):
         text_style: Optional[TextStyle] = None,
         label: Optional[str] = None,
         label_style: Optional[TextStyle] = None,
-        icon: Optional[str] = None,
+        icon: IconValue = None,
         border: Optional[InputBorder] = None,
         color: Optional[str] = None,
         bgcolor: Optional[str] = None,
@@ -206,11 +206,11 @@ class Dropdown(FormFieldControl):
         error_text: Optional[str] = None,
         error_style: Optional[TextStyle] = None,
         prefix: Optional[Control] = None,
-        prefix_icon: Optional[str] = None,
+        prefix_icon: IconValue = None,
         prefix_text: Optional[str] = None,
         prefix_style: Optional[TextStyle] = None,
         suffix: Optional[Control] = None,
-        suffix_icon: Optional[str] = None,
+        suffix_icon: IconValue = None,
         suffix_text: Optional[str] = None,
         suffix_style: Optional[TextStyle] = None,
         #

--- a/sdk/python/packages/flet-core/src/flet_core/dropdown.py
+++ b/sdk/python/packages/flet-core/src/flet_core/dropdown.py
@@ -18,7 +18,7 @@ from flet_core.types import (
     OptionalControlEventCallable,
 )
 from flet_core.utils import deprecated
-from flet_core.form_field_control import IconValue
+from flet_core.form_field_control import IconValueOrControl
 
 class Option(Control):
     def __init__(
@@ -181,7 +181,7 @@ class Dropdown(FormFieldControl):
         text_style: Optional[TextStyle] = None,
         label: Optional[str] = None,
         label_style: Optional[TextStyle] = None,
-        icon: IconValue = None,
+        icon: Optional[IconValueOrControl] = None,
         border: Optional[InputBorder] = None,
         color: Optional[str] = None,
         bgcolor: Optional[str] = None,
@@ -206,11 +206,11 @@ class Dropdown(FormFieldControl):
         error_text: Optional[str] = None,
         error_style: Optional[TextStyle] = None,
         prefix: Optional[Control] = None,
-        prefix_icon: IconValue = None,
+        prefix_icon: Optional[IconValueOrControl] = None,
         prefix_text: Optional[str] = None,
         prefix_style: Optional[TextStyle] = None,
         suffix: Optional[Control] = None,
-        suffix_icon: IconValue = None,
+        suffix_icon: Optional[IconValueOrControl] = None,
         suffix_text: Optional[str] = None,
         suffix_style: Optional[TextStyle] = None,
         #

--- a/sdk/python/packages/flet-core/src/flet_core/form_field_control.py
+++ b/sdk/python/packages/flet-core/src/flet_core/form_field_control.py
@@ -24,7 +24,7 @@ try:
 except ImportError:
     from typing_extensions import Literal
 
-IconValue = Optional[Union[str, Control]]
+IconValueOrControl = Union[str, Control]
 
 class InputBorder(Enum):
     NONE = "none"
@@ -40,7 +40,7 @@ class FormFieldControl(ConstrainedControl):
         text_vertical_align: Union[VerticalAlignment, OptionalNumber] = None,
         label: Optional[str] = None,
         label_style: Optional[TextStyle] = None,
-        icon: IconValue = None,
+        icon: Optional[IconValueOrControl] = None,
         border: Optional[InputBorder] = None,
         color: Optional[str] = None,
         bgcolor: Optional[str] = None,
@@ -66,11 +66,11 @@ class FormFieldControl(ConstrainedControl):
         error_text: Optional[str] = None,
         error_style: Optional[TextStyle] = None,
         prefix: Optional[Control] = None,
-        prefix_icon: IconValue = None,
+        prefix_icon: Optional[IconValueOrControl] = None,
         prefix_text: Optional[str] = None,
         prefix_style: Optional[TextStyle] = None,
         suffix: Optional[Control] = None,
-        suffix_icon: IconValue = None,
+        suffix_icon: Optional[IconValueOrControl] = None,
         suffix_text: Optional[str] = None,
         suffix_style: Optional[TextStyle] = None,
         rtl: Optional[bool] = None,
@@ -255,11 +255,11 @@ class FormFieldControl(ConstrainedControl):
 
     # icon
     @property
-    def icon(self) -> IconValue:
+    def icon(self) -> Optional[IconValueOrControl]:
         return self.__icon
 
     @icon.setter
-    def icon(self, value: IconValue):
+    def icon(self, value: Optional[IconValueOrControl]):
         self.__icon = value
 
     # border
@@ -484,11 +484,11 @@ class FormFieldControl(ConstrainedControl):
 
     # prefix_icon
     @property
-    def prefix_icon(self) -> IconValue:
+    def prefix_icon(self) -> Optional[IconValueOrControl]:
         return self.__prefix_icon
 
     @prefix_icon.setter
-    def prefix_icon(self, value: IconValue):
+    def prefix_icon(self, value: Optional[IconValueOrControl]):
         self.__prefix_icon = value
 
     # prefix_text
@@ -520,11 +520,11 @@ class FormFieldControl(ConstrainedControl):
     
     # suffix_icon
     @property
-    def suffix_icon(self) -> IconValue:
+    def suffix_icon(self) -> Optional[IconValueOrControl]:
         return self.__suffix_icon
 
     @suffix_icon.setter
-    def suffix_icon(self, value: IconValue):
+    def suffix_icon(self, value: Optional[IconValueOrControl]):
         self.__suffix_icon = value
 
     # suffix_text

--- a/sdk/python/packages/flet-core/src/flet_core/form_field_control.py
+++ b/sdk/python/packages/flet-core/src/flet_core/form_field_control.py
@@ -68,7 +68,8 @@ class FormFieldControl(ConstrainedControl):
         prefix_text: Optional[str] = None,
         prefix_style: Optional[TextStyle] = None,
         suffix: Optional[Control] = None,
-        suffix_icon: Optional[str] = None,
+        # suffix_icon: Optional[str] = None,
+        suffix_icon: Optional[Control] = None,
         suffix_text: Optional[str] = None,
         suffix_style: Optional[TextStyle] = None,
         rtl: Optional[bool] = None,
@@ -195,6 +196,9 @@ class FormFieldControl(ConstrainedControl):
         if isinstance(self.__suffix, Control):
             self.__suffix._set_attr_internal("n", "suffix")
             children.append(self.__suffix)
+        if isinstance(self.__suffix_icon, Control):
+            self.__suffix_icon._set_attr_internal("n", "suffixIcon")
+            children.append(self.__suffix_icon)
         if isinstance(self.__counter, Control):
             self.__counter._set_attr_internal("n", "counter")
             children.append(self.__counter)
@@ -500,15 +504,24 @@ class FormFieldControl(ConstrainedControl):
     @suffix.setter
     def suffix(self, value: Optional[Control]):
         self.__suffix = value
-
+    
     # suffix_icon
     @property
-    def suffix_icon(self) -> Optional[str]:
-        return self._get_attr("suffixIcon")
+    def suffix_icon(self) -> Optional[Control]:
+        return self.__suffix_icon
 
     @suffix_icon.setter
-    def suffix_icon(self, value: Optional[str]):
-        self._set_attr("suffixIcon", value)
+    def suffix_icon(self, value: Optional[Control]):
+        self.__suffix_icon = value
+
+    # # suffix_icon
+    # @property
+    # def suffix_icon(self) -> Optional[str]:
+    #     return self._get_attr("suffixIcon")
+
+    # @suffix_icon.setter
+    # def suffix_icon(self, value: Optional[str]):
+    #     self._set_attr("suffixIcon", value)
 
     # suffix_text
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/form_field_control.py
+++ b/sdk/python/packages/flet-core/src/flet_core/form_field_control.py
@@ -40,7 +40,8 @@ class FormFieldControl(ConstrainedControl):
         text_vertical_align: Union[VerticalAlignment, OptionalNumber] = None,
         label: Optional[str] = None,
         label_style: Optional[TextStyle] = None,
-        icon: Optional[str] = None,
+        # icon: Optional[str] = None,
+        icon: IconValue = None,
         border: Optional[InputBorder] = None,
         color: Optional[str] = None,
         bgcolor: Optional[str] = None,
@@ -194,6 +195,8 @@ class FormFieldControl(ConstrainedControl):
             self._set_attr("suffixIcon", self.__suffix_icon)
         if isinstance(self.__prefix_icon, str):
             self._set_attr("prefixIcon", self.__prefix_icon)
+        if isinstance(self.__icon, str):
+            self._set_attr("icon", self.__icon)
 
     def _get_children(self):
         children = []
@@ -209,6 +212,9 @@ class FormFieldControl(ConstrainedControl):
         if isinstance(self.__prefix_icon, Control):
             self.__prefix_icon._set_attr_internal("n", "prefixIcon")
             children.append(self.__prefix_icon)
+        if isinstance(self.__icon, Control):
+            self.__icon._set_attr_internal("n", "icon")
+            children.append(self.__icon)
         if isinstance(self.__counter, Control):
             self.__counter._set_attr_internal("n", "counter")
             children.append(self.__counter)
@@ -250,14 +256,23 @@ class FormFieldControl(ConstrainedControl):
     def label_style(self, value: Optional[TextStyle]):
         self.__label_style = value
 
+    # # icon
+    # @property
+    # def icon(self) -> Optional[str]:
+    #     return self._get_attr("icon")
+
+    # @icon.setter
+    # def icon(self, value: Optional[str]):
+    #     self._set_attr("icon", value)
+
     # icon
     @property
-    def icon(self) -> Optional[str]:
-        return self._get_attr("icon")
+    def icon(self) -> IconValue:
+        return self.__icon
 
     @icon.setter
-    def icon(self, value: Optional[str]):
-        self._set_attr("icon", value)
+    def icon(self, value: IconValue):
+        self.__icon = value
 
     # border
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/form_field_control.py
+++ b/sdk/python/packages/flet-core/src/flet_core/form_field_control.py
@@ -3,6 +3,7 @@ from typing import Any, Optional, Union
 
 from flet_core.constrained_control import ConstrainedControl
 from flet_core.control import Control, OptionalNumber
+from flet_core.icon import Icon
 from flet_core.ref import Ref
 from flet_core.text_style import TextStyle
 from flet_core.tooltip import TooltipValue
@@ -23,6 +24,7 @@ try:
 except ImportError:
     from typing_extensions import Literal
 
+IconValue = Optional[Union[str, Control]]
 
 class InputBorder(Enum):
     NONE = "none"
@@ -69,7 +71,7 @@ class FormFieldControl(ConstrainedControl):
         prefix_style: Optional[TextStyle] = None,
         suffix: Optional[Control] = None,
         # suffix_icon: Optional[str] = None,
-        suffix_icon: Optional[Control] = None,
+        suffix_icon: IconValue = None,
         suffix_text: Optional[str] = None,
         suffix_style: Optional[TextStyle] = None,
         rtl: Optional[bool] = None,
@@ -187,6 +189,8 @@ class FormFieldControl(ConstrainedControl):
         self._set_attr_json("errorStyle", self.__error_style)
         self._set_attr_json("prefixStyle", self.__prefix_style)
         self._set_attr_json("suffixStyle", self.__suffix_style)
+        if isinstance(self.__suffix_icon, str):
+            self._set_attr("suffixIcon", self.__suffix_icon)
 
     def _get_children(self):
         children = []
@@ -507,13 +511,15 @@ class FormFieldControl(ConstrainedControl):
     
     # suffix_icon
     @property
-    def suffix_icon(self) -> Optional[Control]:
+    def suffix_icon(self) -> IconValue:
         return self.__suffix_icon
 
-    @suffix_icon.setter
-    def suffix_icon(self, value: Optional[Control]):
-        self.__suffix_icon = value
 
+
+    @suffix_icon.setter
+    def suffix_icon(self, value: IconValue):
+        self.__suffix_icon = value
+        
     # # suffix_icon
     # @property
     # def suffix_icon(self) -> Optional[str]:

--- a/sdk/python/packages/flet-core/src/flet_core/form_field_control.py
+++ b/sdk/python/packages/flet-core/src/flet_core/form_field_control.py
@@ -66,7 +66,8 @@ class FormFieldControl(ConstrainedControl):
         error_text: Optional[str] = None,
         error_style: Optional[TextStyle] = None,
         prefix: Optional[Control] = None,
-        prefix_icon: Optional[str] = None,
+        # prefix_icon: Optional[str] = None,
+        prefix_icon: IconValue = None,
         prefix_text: Optional[str] = None,
         prefix_style: Optional[TextStyle] = None,
         suffix: Optional[Control] = None,
@@ -191,6 +192,8 @@ class FormFieldControl(ConstrainedControl):
         self._set_attr_json("suffixStyle", self.__suffix_style)
         if isinstance(self.__suffix_icon, str):
             self._set_attr("suffixIcon", self.__suffix_icon)
+        if isinstance(self.__prefix_icon, str):
+            self._set_attr("prefixIcon", self.__prefix_icon)
 
     def _get_children(self):
         children = []
@@ -203,6 +206,9 @@ class FormFieldControl(ConstrainedControl):
         if isinstance(self.__suffix_icon, Control):
             self.__suffix_icon._set_attr_internal("n", "suffixIcon")
             children.append(self.__suffix_icon)
+        if isinstance(self.__prefix_icon, Control):
+            self.__prefix_icon._set_attr_internal("n", "prefixIcon")
+            children.append(self.__prefix_icon)
         if isinstance(self.__counter, Control):
             self.__counter._set_attr_internal("n", "counter")
             children.append(self.__counter)
@@ -475,12 +481,21 @@ class FormFieldControl(ConstrainedControl):
 
     # prefix_icon
     @property
-    def prefix_icon(self) -> Optional[str]:
-        return self._get_attr("prefixIcon")
+    def prefix_icon(self) -> IconValue:
+        return self.__prefix_icon
 
     @prefix_icon.setter
-    def prefix_icon(self, value: Optional[str]):
-        self._set_attr("prefixIcon", value)
+    def prefix_icon(self, value: IconValue):
+        self.__prefix_icon = value
+
+    # # prefix_icon
+    # @property
+    # def prefix_icon(self) -> Optional[str]:
+    #     return self._get_attr("prefixIcon")
+
+    # @prefix_icon.setter
+    # def prefix_icon(self, value: Optional[str]):
+    #     self._set_attr("prefixIcon", value)
 
     # prefix_text
     @property
@@ -513,8 +528,6 @@ class FormFieldControl(ConstrainedControl):
     @property
     def suffix_icon(self) -> IconValue:
         return self.__suffix_icon
-
-
 
     @suffix_icon.setter
     def suffix_icon(self, value: IconValue):

--- a/sdk/python/packages/flet-core/src/flet_core/form_field_control.py
+++ b/sdk/python/packages/flet-core/src/flet_core/form_field_control.py
@@ -40,7 +40,6 @@ class FormFieldControl(ConstrainedControl):
         text_vertical_align: Union[VerticalAlignment, OptionalNumber] = None,
         label: Optional[str] = None,
         label_style: Optional[TextStyle] = None,
-        # icon: Optional[str] = None,
         icon: IconValue = None,
         border: Optional[InputBorder] = None,
         color: Optional[str] = None,
@@ -67,12 +66,10 @@ class FormFieldControl(ConstrainedControl):
         error_text: Optional[str] = None,
         error_style: Optional[TextStyle] = None,
         prefix: Optional[Control] = None,
-        # prefix_icon: Optional[str] = None,
         prefix_icon: IconValue = None,
         prefix_text: Optional[str] = None,
         prefix_style: Optional[TextStyle] = None,
         suffix: Optional[Control] = None,
-        # suffix_icon: Optional[str] = None,
         suffix_icon: IconValue = None,
         suffix_text: Optional[str] = None,
         suffix_style: Optional[TextStyle] = None,
@@ -255,15 +252,6 @@ class FormFieldControl(ConstrainedControl):
     @label_style.setter
     def label_style(self, value: Optional[TextStyle]):
         self.__label_style = value
-
-    # # icon
-    # @property
-    # def icon(self) -> Optional[str]:
-    #     return self._get_attr("icon")
-
-    # @icon.setter
-    # def icon(self, value: Optional[str]):
-    #     self._set_attr("icon", value)
 
     # icon
     @property
@@ -503,15 +491,6 @@ class FormFieldControl(ConstrainedControl):
     def prefix_icon(self, value: IconValue):
         self.__prefix_icon = value
 
-    # # prefix_icon
-    # @property
-    # def prefix_icon(self) -> Optional[str]:
-    #     return self._get_attr("prefixIcon")
-
-    # @prefix_icon.setter
-    # def prefix_icon(self, value: Optional[str]):
-    #     self._set_attr("prefixIcon", value)
-
     # prefix_text
     @property
     def prefix_text(self) -> Optional[str]:
@@ -547,15 +526,6 @@ class FormFieldControl(ConstrainedControl):
     @suffix_icon.setter
     def suffix_icon(self, value: IconValue):
         self.__suffix_icon = value
-        
-    # # suffix_icon
-    # @property
-    # def suffix_icon(self) -> Optional[str]:
-    #     return self._get_attr("suffixIcon")
-
-    # @suffix_icon.setter
-    # def suffix_icon(self, value: Optional[str]):
-    #     self._set_attr("suffixIcon", value)
 
     # suffix_text
     @property

--- a/sdk/python/packages/flet-core/src/flet_core/textfield.py
+++ b/sdk/python/packages/flet-core/src/flet_core/textfield.py
@@ -23,6 +23,7 @@ from flet_core.types import (
     OptionalControlEventCallable,
 )
 from flet_core.utils import deprecated
+from flet_core.form_field_control import IconValue
 
 try:
     from typing import Literal
@@ -140,7 +141,7 @@ class TextField(FormFieldControl, AdaptiveControl):
         text_vertical_align: Union[VerticalAlignment, OptionalNumber] = None,
         label: Optional[str] = None,
         label_style: Optional[TextStyle] = None,
-        icon: Optional[str] = None,
+        icon: IconValue = None,
         border: Optional[InputBorder] = None,
         color: Optional[str] = None,
         bgcolor: Optional[str] = None,
@@ -166,11 +167,11 @@ class TextField(FormFieldControl, AdaptiveControl):
         error_text: Optional[str] = None,
         error_style: Optional[TextStyle] = None,
         prefix: Optional[Control] = None,
-        prefix_icon: Optional[str] = None,
+        prefix_icon: IconValue = None,
         prefix_text: Optional[str] = None,
         prefix_style: Optional[TextStyle] = None,
         suffix: Optional[Control] = None,
-        suffix_icon: Optional[str] = None,
+        suffix_icon: IconValue = None,
         suffix_text: Optional[str] = None,
         suffix_style: Optional[TextStyle] = None,
         #

--- a/sdk/python/packages/flet-core/src/flet_core/textfield.py
+++ b/sdk/python/packages/flet-core/src/flet_core/textfield.py
@@ -23,7 +23,7 @@ from flet_core.types import (
     OptionalControlEventCallable,
 )
 from flet_core.utils import deprecated
-from flet_core.form_field_control import IconValue
+from flet_core.form_field_control import IconValueOrControl
 
 try:
     from typing import Literal
@@ -141,7 +141,7 @@ class TextField(FormFieldControl, AdaptiveControl):
         text_vertical_align: Union[VerticalAlignment, OptionalNumber] = None,
         label: Optional[str] = None,
         label_style: Optional[TextStyle] = None,
-        icon: IconValue = None,
+        icon: Optional[IconValueOrControl] = None,
         border: Optional[InputBorder] = None,
         color: Optional[str] = None,
         bgcolor: Optional[str] = None,
@@ -167,11 +167,11 @@ class TextField(FormFieldControl, AdaptiveControl):
         error_text: Optional[str] = None,
         error_style: Optional[TextStyle] = None,
         prefix: Optional[Control] = None,
-        prefix_icon: IconValue = None,
+        prefix_icon: Optional[IconValueOrControl] = None,
         prefix_text: Optional[str] = None,
         prefix_style: Optional[TextStyle] = None,
         suffix: Optional[Control] = None,
-        suffix_icon: IconValue = None,
+        suffix_icon: Optional[IconValueOrControl] = None,
         suffix_text: Optional[str] = None,
         suffix_style: Optional[TextStyle] = None,
         #


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
Properties `suffix_icon`, `prefix_icon` and `icon` now accept both strings (icon name) and Controls.

<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #4161 

The alignment of suffix and suffix_icon is still different but that's how it is done in Flutter. Now control can be placed into suffix_icon or suffix or both and user can choose which layout better for their app.

## Test Code

```python
import flet as ft

def main(page: ft.Page):
       
    txtfield1 = ft.TextField(
        width=400,
        value='Default value',
        #text_size=10,
        icon=ft.icons.ARROW_DROP_DOWN,
        prefix_icon=ft.icons.ARROW_DROP_DOWN,
        prefix = ft.Icon(ft.icons.ARROW_DROP_DOWN),
        bgcolor=ft.colors.AMBER_100,
        text_vertical_align=ft.VerticalAlignment.CENTER,
        suffix_icon = ft.icons.ARROW_DROP_DOWN,
        suffix = ft.Icon(ft.icons.ARROW_DROP_DOWN),
    )

    txtfield2 = ft.TextField(
        width=400,
        value='Default value',
        #text_size=10,
        icon=ft.Container(bgcolor=ft.colors.RED, height=10, width=10),
        prefix_icon=ft.Container(bgcolor=ft.colors.RED, height=10, width=10),
        prefix = ft.Container(bgcolor=ft.colors.RED, height=10, width=10),
        bgcolor=ft.colors.AMBER_100,
        text_vertical_align=ft.VerticalAlignment.CENTER,
        suffix_icon = ft.Container(bgcolor=ft.colors.RED, height=10, width=10),
        suffix = ft.Container(bgcolor=ft.colors.RED, height=10, width=10),
    )


    page.add(ft.Row([txtfield1, txtfield2]))

ft.app(target=main)
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## Checklist:

- [ ] I signed the CLA.
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
<!-- - [ ] I have added tests that prove my fix is effective or that my feature works as expected -->

- [ ] New and existing tests pass locally with my changes
- [ ] I have made corresponding changes to the [documentation](https://github.com/flet-dev/website) (if applicable)

## Screenshots (if applicable):

## Additional details

<!-- Add any other context to be known about this PR. -->
