### PR TITLE
Fix undefined name "Future" --> asyncio.Future

### DIFF
--- a/sdk/python/packages/flet-core/src/flet_core/page.py
+++ b/sdk/python/packages/flet-core/src/flet_core/page.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import json
 import logging

--- a/sdk/python/packages/flet-core/src/flet_core/page.py
+++ b/sdk/python/packages/flet-core/src/flet_core/page.py
@@ -926,7 +926,7 @@ class Page(AdaptiveControl):
         handler: Callable[InputT, Awaitable[RetT]],
         *args: InputT.args,
         **kwargs: InputT.kwargs,
-    ) -> "Future[RetT]":
+    ) -> asyncio.Future[RetT]:
         _session_page.set(self)
         assert asyncio.iscoroutinefunction(handler)
 


### PR DESCRIPTION
% `ruff check --output-format=github --select=E9,F63,F7,F82 --target-version=py39`
```
Error: sdk/python/packages/flet-core/src/flet_core/page.py:926:11: F821 Undefined name `Future`
```
```python
from __future__ import annotations  # Only needed for Python 3.8 which is now EOL.
````

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->


<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #(issue)

## Test Code

```python
# Test code for the review of this PR
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I signed the CLA.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
<!-- - [ ] I have added tests that prove my fix is effective or that my feature works as expected -->

- [ ] New and existing tests pass locally with my changes
- [ ] I have made corresponding changes to the [documentation](https://github.com/flet-dev/website) (if applicable)

## Screenshots (if applicable):

## Additional details

<!-- Add any other context to be known about this PR. -->
