### PR TITLE
fix: setting `AppBar.tooltip_opacity` raises `AssertionError` with correct values

### DIFF
--- a/sdk/python/packages/flet/src/flet/core/app_bar.py
+++ b/sdk/python/packages/flet/src/flet/core/app_bar.py
@@ -180,7 +180,7 @@ class AppBar(AdaptiveControl):
     @toolbar_opacity.setter
     def toolbar_opacity(self, value: OptionalNumber):
         assert value is None or (
-            0 >= value >= 1
+            0 <= value <= 1
         ), "toolbar_opacity is out of range (0-1)"
         self._set_attr("toolbarOpacity", value)
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->


<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #(issue)

## Test Code

```python
# Test code for the review of this PR
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I signed the CLA.
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
<!-- - [ ] I have added tests that prove my fix is effective or that my feature works as expected -->

- [ ] New and existing tests pass locally with my changes
- [ ] I have made corresponding changes to the [documentation](https://github.com/flet-dev/website) (if applicable)

## Screenshots (if applicable):

## Additional details

<!-- Add any other context to be known about this PR. -->
