### PR TITLE
fix: `Video.jump_to()` fails with negative indexes

### DIFF
--- a/sdk/python/packages/flet/src/flet/core/video.py
+++ b/sdk/python/packages/flet/src/flet/core/video.py
@@ -269,11 +269,17 @@ class Video(ConstrainedControl):
         await self.invoke_method_async("seek", {"position": str(position_milliseconds)})
 
     def jump_to(self, media_index: int):
-        assert self.__playlist[media_index], "index out of range"
+        assert self.__playlist[media_index], "media_index is out of range"
+        if media_index < 0:
+            # dart doesn't support negative indexes
+            media_index = len(self.__playlist) + media_index
         self.invoke_method("jump_to", {"media_index": str(media_index)})
 
     async def jump_to_async(self, media_index: int):
-        assert self.__playlist[media_index], "index out of range"
+        assert self.__playlist[media_index], "media_index is out of range"
+        if media_index < 0:
+            # dart doesn't support negative indexes
+            media_index = len(self.__playlist) + media_index
         await self.invoke_method_async("jump_to", {"media_index": str(media_index)})
 
     def playlist_add(self, media: VideoMedia):

--- a/sdk/python/packages/flet/src/flet/core/video.py
+++ b/sdk/python/packages/flet/src/flet/core/video.py
@@ -265,6 +265,11 @@ class Video(ConstrainedControl):
     def seek(self, position_milliseconds: int):
         self.invoke_method("seek", {"position": str(position_milliseconds)})
 
+    @deprecated(
+        reason="Use seek() method instead.",
+        version="0.25.0",
+        delete_version="0.28.0",
+    )
     async def seek_async(self, position_milliseconds: int):
         await self.invoke_method_async("seek", {"position": str(position_milliseconds)})
 
@@ -275,6 +280,11 @@ class Video(ConstrainedControl):
             media_index = len(self.__playlist) + media_index
         self.invoke_method("jump_to", {"media_index": str(media_index)})
 
+    @deprecated(
+        reason="Use jump_to() method instead.",
+        version="0.25.0",
+        delete_version="0.28.0",
+    )
     async def jump_to_async(self, media_index: int):
         assert self.__playlist[media_index], "media_index is out of range"
         if media_index < 0:


### PR DESCRIPTION
## Summary by Sourcery

Fix the `Video.jump_to` method to correctly handle negative indexes by converting them to positive equivalents and deprecate the `seek_async` and `jump_to_async` methods.

Bug Fixes:
- Fix the `Video.jump_to` method to handle negative indexes by converting them to positive equivalents.

Enhancements:
- Deprecate the `seek_async` and `jump_to_async` methods in favor of their synchronous counterparts, with a planned removal in version 0.28.0.