### PR TITLE
add dividerless attribute to expansion tile

### DIFF
--- a/packages/flet/lib/src/controls/expansion_tile.dart
+++ b/packages/flet/lib/src/controls/expansion_tile.dart
@@ -57,6 +57,7 @@ class ExpansionTileControl extends StatelessWidget {
     var collapsedBgColor = control.attrColor("collapsedBgColor", context);
     var collapsedIconColor = control.attrColor("collapsedIconColor", context);
     var collapsedTextColor = control.attrColor("collapsedTextColor", context);
+    var dividerless = control.attrBool("dividerless", false);
 
     var affinity = parseListTileControlAffinity(
         control.attrString("affinity"), ListTileControlAffinity.platform)!;
@@ -81,6 +82,7 @@ class ExpansionTileControl extends StatelessWidget {
           }
         : null;
 
+    Widget dividerlessTile;
     Widget tile = ExpansionTile(
       controlAffinity: affinity,
       childrenPadding: parseEdgeInsets(control, "controlsPadding"),
@@ -126,6 +128,18 @@ class ExpansionTileControl extends StatelessWidget {
           .toList(),
     );
 
-    return constrainedControl(context, tile, parent, control);
+    if (dividerless != null && dividerless) {
+      debugPrint("dividerless attribute found!");
+      dividerlessTile = Theme(
+        data: ThemeData().copyWith(dividerColor: Colors.transparent),
+        child:tile
+      );
+    }
+    else {
+      debugPrint("no dividerless attribute...");
+      dividerlessTile = tile;
+    }
+
+    return constrainedControl(context, dividerlessTile, parent, control);
   }
 }

--- a/sdk/python/packages/flet/src/flet/core/expansion_tile.py
+++ b/sdk/python/packages/flet/src/flet/core/expansion_tile.py
@@ -105,6 +105,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
         # AdaptiveControl
         #
         adaptive: Optional[bool] = None,
+        dividerless: Optional[bool] = None
     ):
         ConstrainedControl.__init__(
             self,
@@ -167,6 +168,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
         self.visual_density = visual_density
         self.show_trailing_icon = show_trailing_icon
         self.min_tile_height = min_tile_height
+        self.dividerless=dividerless
 
     def _get_control_name(self):
         return "expansiontile"
@@ -345,6 +347,15 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
     def initially_expanded(self, value: Optional[bool]):
         self._set_attr("initiallyExpanded", value)
 
+    # dividerless
+    @property
+    def dividerless(self) -> bool:
+        return self._get_attr("dividerless", data_type="bool", def_value=False)
+
+    @dividerless.setter
+    def dividerless(self, value: Optional[bool]):
+        self._set_attr("dividerless", value)
+        
     # shape
     @property
     def shape(self) -> Optional[OutlinedBorder]:


### PR DESCRIPTION
## Description

Add `dividerless` (boolean) attribute to ExpansionTile to allow for transparent dividers between tiles. 
 
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #4303 

## Test Code

```python
import flet as ft


def main(page: ft.Page):
    page.spacing = 0
    page.padding = 0

    def handle_expansion_tile_change(e):
        page.open(
            ft.SnackBar(
                ft.Text(f"ExpansionTile was {'expanded' if e.data=='true' else 'collapsed'}"),
                duration=1000,
            )
        )
        if e.control.trailing:
            e.control.trailing.name = (
                ft.icons.ARROW_DROP_DOWN
                if e.control.trailing.name == ft.icons.ARROW_DROP_DOWN_CIRCLE
                else ft.icons.ARROW_DROP_DOWN_CIRCLE
            )
            page.update()

    page.add(
        ft.ExpansionTile(
            title=ft.Text("ExpansionTile 1"),
            subtitle=ft.Text("Trailing expansion arrow icon"),
            affinity=ft.TileAffinity.PLATFORM,
            maintain_state=True,
            collapsed_text_color=ft.colors.RED,
            text_color=ft.colors.RED,
            controls=[ft.ListTile(title=ft.Text("This is sub-tile number 1"))],
            dividerless=True
        ),
        ft.ExpansionTile(
            title=ft.Text("ExpansionTile 2"),
            subtitle=ft.Text("Custom expansion arrow icon"),
            trailing=ft.Icon(ft.icons.ARROW_DROP_DOWN),
            collapsed_text_color=ft.colors.GREEN,
            text_color=ft.colors.GREEN,
            on_change=handle_expansion_tile_change,
            controls=[ft.ListTile(title=ft.Text("This is sub-tile number 2"))],
            dividerless=True
        ),
        ft.ExpansionTile(
            title=ft.Text("ExpansionTile 3"),
            subtitle=ft.Text("Leading expansion arrow icon"),
            affinity=ft.TileAffinity.LEADING,
            initially_expanded=True,
            collapsed_text_color=ft.colors.BLUE,
            text_color=ft.colors.BLUE,
            controls=[
                ft.ListTile(title=ft.Text("This is sub-tile number 3")),
                ft.ListTile(title=ft.Text("This is sub-tile number 4")),
                ft.ListTile(title=ft.Text("This is sub-tile number 5")),
            ],
            dividerless=True
        ),
    )


ft.app(main)
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] I signed the CLA.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
<!-- - [ ] I have added tests that prove my fix is effective or that my feature works as expected -->

- [x] New and existing tests pass locally with my changes
- [ ] I have made corresponding changes to the [documentation](https://github.com/flet-dev/website) (if applicable)

## Screenshots (if applicable):
<img width="745" alt="dividerless" src="https://github.com/user-attachments/assets/5fd80460-80d4-464e-8bfa-303b339bbaad">

## Additional details

<!-- Add any other context to be known about this PR. -->

## Summary by Sourcery

Add a 'dividerless' attribute to the ExpansionTile component to enable transparent dividers between tiles, enhancing customization options.

New Features:
- Introduce a 'dividerless' boolean attribute to the ExpansionTile component, allowing for transparent dividers between tiles.

Documentation:
- Update documentation to include information about the new 'dividerless' attribute for the ExpansionTile component.