### PR TITLE
customized style for SegmentedButton also need wrap

### DIFF
--- a/sdk/python/packages/flet/src/flet/core/segmented_button.py
+++ b/sdk/python/packages/flet/src/flet/core/segmented_button.py
@@ -205,9 +205,10 @@ class SegmentedButton(ConstrainedControl):
         ), "allow_multiple_selection must be True for selected to have more than one item"
         if self.__style is None:
             self.__style = ButtonStyle()
-            self.__style.side = self._wrap_attr_dict(self.__style.side)
-            self.__style.shape = self._wrap_attr_dict(self.__style.shape)
-            self.__style.padding = self._wrap_attr_dict(self.__style.padding)
+
+        self.__style.side = self._wrap_attr_dict(self.__style.side)
+        self.__style.shape = self._wrap_attr_dict(self.__style.shape)
+        self.__style.padding = self._wrap_attr_dict(self.__style.padding)
         self._set_attr_json("style", self.__style)
 
     def _get_children(self):

--- a/sdk/python/packages/flet/src/flet/core/segmented_button.py
+++ b/sdk/python/packages/flet/src/flet/core/segmented_button.py
@@ -203,13 +203,11 @@ class SegmentedButton(ConstrainedControl):
         assert (
             len(self.selected) < 2 or self.allow_multiple_selection
         ), "allow_multiple_selection must be True for selected to have more than one item"
-        if self.__style is None:
-            self.__style = ButtonStyle()
-
-        self.__style.side = self._wrap_attr_dict(self.__style.side)
-        self.__style.shape = self._wrap_attr_dict(self.__style.shape)
-        self.__style.padding = self._wrap_attr_dict(self.__style.padding)
-        self._set_attr_json("style", self.__style)
+        style = self.__style or ButtonStyle()
+        style.side = self._wrap_attr_dict(style.side)
+        style.shape = self._wrap_attr_dict(style.shape)
+        style.padding = self._wrap_attr_dict(style.padding)
+        self._set_attr_json("style", style)
 
     def _get_children(self):
         for segment in self.segments:


### PR DESCRIPTION
## Description
User customized style passed to SegmentedButton also need wrap, or it raise errors.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->


<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #4313 


## Screenshots (if applicable):
![image](https://github.com/user-attachments/assets/b49c83cc-095b-492e-b2f5-dd097a0ec1b9)
![image](https://github.com/user-attachments/assets/fd2e9d4f-0049-4a78-baff-82ca1e703aca)

## Summary by Sourcery

Bug Fixes:
- Ensure user-customized styles in SegmentedButton are wrapped to prevent errors.