### PR TITLE
fix: `Segment` and `NavigationBarDestination` accept only string tooltips

### DIFF
--- a/client/linux/flutter/generated_plugin_registrant.cc
+++ b/client/linux/flutter/generated_plugin_registrant.cc
@@ -10,7 +10,7 @@
 #include <media_kit_libs_linux/media_kit_libs_linux_plugin.h>
 #include <media_kit_video/media_kit_video_plugin.h>
 #include <record_linux/record_linux_plugin.h>
-#include <screen_retriever/screen_retriever_plugin.h>
+#include <screen_retriever_linux/screen_retriever_linux_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 #include <window_manager/window_manager_plugin.h>
 #include <window_to_front/window_to_front_plugin.h>
@@ -28,9 +28,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) record_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "RecordLinuxPlugin");
   record_linux_plugin_register_with_registrar(record_linux_registrar);
-  g_autoptr(FlPluginRegistrar) screen_retriever_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverPlugin");
-  screen_retriever_plugin_register_with_registrar(screen_retriever_registrar);
+  g_autoptr(FlPluginRegistrar) screen_retriever_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverLinuxPlugin");
+  screen_retriever_linux_plugin_register_with_registrar(screen_retriever_linux_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/client/linux/flutter/generated_plugins.cmake
+++ b/client/linux/flutter/generated_plugins.cmake
@@ -7,7 +7,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   media_kit_libs_linux
   media_kit_video
   record_linux
-  screen_retriever
+  screen_retriever_linux
   url_launcher_linux
   window_manager
   window_to_front

--- a/client/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/client/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -14,7 +14,7 @@ import path_provider_foundation
 import record_darwin
 import rive_common
 import screen_brightness_macos
-import screen_retriever
+import screen_retriever_macos
 import shared_preferences_foundation
 import url_launcher_macos
 import wakelock_plus
@@ -31,7 +31,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   RecordPlugin.register(with: registry.registrar(forPlugin: "RecordPlugin"))
   RivePlugin.register(with: registry.registrar(forPlugin: "RivePlugin"))
   ScreenBrightnessMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenBrightnessMacosPlugin"))
-  ScreenRetrieverPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverPlugin"))
+  ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   WakelockPlusMacosPlugin.register(with: registry.registrar(forPlugin: "WakelockPlusMacosPlugin"))

--- a/client/windows/flutter/generated_plugin_registrant.cc
+++ b/client/windows/flutter/generated_plugin_registrant.cc
@@ -14,7 +14,7 @@
 #include <record_windows/record_windows_plugin_c_api.h>
 #include <rive_common/rive_plugin.h>
 #include <screen_brightness_windows/screen_brightness_windows_plugin.h>
-#include <screen_retriever/screen_retriever_plugin.h>
+#include <screen_retriever_windows/screen_retriever_windows_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 #include <window_manager/window_manager_plugin.h>
 #include <window_to_front/window_to_front_plugin.h>
@@ -36,8 +36,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("RivePlugin"));
   ScreenBrightnessWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ScreenBrightnessWindowsPlugin"));
-  ScreenRetrieverPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("ScreenRetrieverPlugin"));
+  ScreenRetrieverWindowsPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("ScreenRetrieverWindowsPluginCApi"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
   WindowManagerPluginRegisterWithRegistrar(

--- a/client/windows/flutter/generated_plugins.cmake
+++ b/client/windows/flutter/generated_plugins.cmake
@@ -11,7 +11,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   record_windows
   rive_common
   screen_brightness_windows
-  screen_retriever
+  screen_retriever_windows
   url_launcher_windows
   window_manager
   window_to_front

--- a/packages/flet/lib/src/controls/barchart.dart
+++ b/packages/flet/lib/src/controls/barchart.dart
@@ -263,8 +263,9 @@ class _BarChartControlState extends State<BarChartControl> {
                   getTooltipItem: (group, groupIndex, rod, rodIndex) {
                     var dp = viewModel.barGroups[groupIndex].barRods[rodIndex];
 
-                    var tooltip = dp.control.attrString("tooltip") ??
-                        dp.control.attrDouble("toY", 0)!.toString();
+                    var tooltip = dp.control.attrString("tooltip") != null
+                        ? jsonDecode(dp.control.attrString("tooltip")!)
+                        : dp.control.attrDouble("toY", 0)!.toString();
                     var tooltipStyle = parseTextStyle(
                         Theme.of(context), dp.control, "tooltipStyle");
                     tooltipStyle ??= const TextStyle();

--- a/packages/flet/lib/src/controls/cupertino_navigation_bar.dart
+++ b/packages/flet/lib/src/controls/cupertino_navigation_bar.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
@@ -71,25 +73,32 @@ class _CupertinoNavigationBarControlState
           items: viewModel.controlViews.map((destView) {
             var label = destView.control.attrString("label", "")!;
             var iconStr = parseIcon(destView.control.attrString("icon"));
-            var iconCtrls = destView.children
-                  .where((c) => c.name == "icon" && c.isVisible);
-                // if no control provided in "icon" property, replace iconCtrls with control provided in icon_content, if any 
-                // the line below needs to be deleted after icon_content is deprecated
-            iconCtrls = iconCtrls.isEmpty? destView.children
-                  .where((c) => c.name == "icon_content" && c.isVisible) : iconCtrls;
+            var iconCtrls =
+                destView.children.where((c) => c.name == "icon" && c.isVisible);
+            // if no control provided in "icon" property, replace iconCtrls with control provided in icon_content, if any
+            // the line below needs to be deleted after icon_content is deprecated
+            iconCtrls = iconCtrls.isEmpty
+                ? destView.children
+                    .where((c) => c.name == "icon_content" && c.isVisible)
+                : iconCtrls;
 
             var selectedIconStr =
                 parseIcon(destView.control.attrString("selectedIcon"));
             var selectedIconCtrls = destView.children
-                  .where((c) => c.name == "selected_icon" && c.isVisible);
-                // if no control provided in "selected_icon" property, replace selectedIconCtrls with control provided in selected_icon_content, if any 
-                // the line below needs to be deleted after selected_icon_content is deprecated
-            selectedIconCtrls = selectedIconCtrls.isEmpty? destView.children
-                  .where((c) => c.name == "selected_icon_content" && c.isVisible): selectedIconCtrls;
+                .where((c) => c.name == "selected_icon" && c.isVisible);
+            // if no control provided in "selected_icon" property, replace selectedIconCtrls with control provided in selected_icon_content, if any
+            // the line below needs to be deleted after selected_icon_content is deprecated
+            selectedIconCtrls = selectedIconCtrls.isEmpty
+                ? destView.children.where(
+                    (c) => c.name == "selected_icon_content" && c.isVisible)
+                : selectedIconCtrls;
 
             var destinationDisabled = disabled || destView.control.isDisabled;
+            var destinationTooltip = destView.control.attrString("tooltip");
             return BottomNavigationBarItem(
-                tooltip: destView.control.attrString("tooltip", "")!,
+                tooltip: !destinationDisabled && destinationTooltip != null
+                    ? jsonDecode(destinationTooltip)
+                    : null,
                 backgroundColor: widget.control.attrColor("bgColor", context),
                 icon: iconCtrls.isNotEmpty
                     ? createControl(destView.control, iconCtrls.first.id,

--- a/packages/flet/lib/src/controls/navigation_bar.dart
+++ b/packages/flet/lib/src/controls/navigation_bar.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 
 import '../flet_control_backend.dart';
@@ -95,31 +97,38 @@ class _NavigationBarControlState extends State<NavigationBarControl>
               var iconStr = parseIcon(destView.control.attrString("icon"));
               var iconCtrls = destView.children
                   .where((c) => c.name == "icon" && c.isVisible);
-              // if no control provided in "icon" property, replace iconCtrls with control provided in icon_content, if any 
+              // if no control provided in "icon" property, replace iconCtrls with control provided in icon_content, if any
               // the line below needs to be deleted after icon_content is deprecated
-              iconCtrls = iconCtrls.isEmpty? destView.children
-                  .where((c) => c.name == "icon_content" && c.isVisible) : iconCtrls;
+              iconCtrls = iconCtrls.isEmpty
+                  ? destView.children
+                      .where((c) => c.name == "icon_content" && c.isVisible)
+                  : iconCtrls;
               var selectedIconStr =
                   parseIcon(destView.control.attrString("selectedIcon"));
               var selectedIconCtrls = destView.children
                   .where((c) => c.name == "selected_icon" && c.isVisible);
-              // if no control provided in "selected_icon" property, replace selectedIconCtrls with control provided in selected_icon_content, if any 
+              // if no control provided in "selected_icon" property, replace selectedIconCtrls with control provided in selected_icon_content, if any
               // the line below needs to be deleted after selected_icon_content is deprecated
-              selectedIconCtrls = selectedIconCtrls.isEmpty? destView.children
-                  .where((c) => c.name == "selected_icon_content" && c.isVisible): selectedIconCtrls;
+              selectedIconCtrls = selectedIconCtrls.isEmpty
+                  ? destView.children.where(
+                      (c) => c.name == "selected_icon_content" && c.isVisible)
+                  : selectedIconCtrls;
               var destinationDisabled = disabled || destView.control.isDisabled;
               var destinationAdaptive = destView.control.isAdaptive ?? adaptive;
+              var destinationTooltip = destView.control.attrString("tooltip");
               return NavigationDestination(
                   enabled: !destinationDisabled,
-                  tooltip: destView.control.attrString("tooltip"),
-                  icon: iconCtrls.isNotEmpty? createControl(destView.control,
-                           iconCtrls.first.id, destinationDisabled,
-                           parentAdaptive: destinationAdaptive): Icon(iconStr),
-                  selectedIcon: selectedIconCtrls.isNotEmpty
-                      ? createControl(
-                          destView.control,
-                          selectedIconCtrls.first.id,
+                  tooltip: !destinationDisabled && destinationTooltip != null
+                      ? jsonDecode(destinationTooltip)
+                      : null,
+                  icon: iconCtrls.isNotEmpty
+                      ? createControl(destView.control, iconCtrls.first.id,
                           destinationDisabled,
+                          parentAdaptive: destinationAdaptive)
+                      : Icon(iconStr),
+                  selectedIcon: selectedIconCtrls.isNotEmpty
+                      ? createControl(destView.control,
+                          selectedIconCtrls.first.id, destinationDisabled,
                           parentAdaptive: destinationAdaptive)
                       : selectedIconStr != null
                           ? Icon(selectedIconStr)

--- a/packages/flet/lib/src/controls/segmented_button.dart
+++ b/packages/flet/lib/src/controls/segmented_button.dart
@@ -120,11 +120,12 @@ class _SegmentedButtonControlState extends State<SegmentedButtonControl>
             var labelCtrls = segmentView.children
                 .where((c) => c.name == "label" && c.isVisible);
             var segmentDisabled = segmentView.control.isDisabled || disabled;
+            var segmentTooltip = segmentView.control.attrString("tooltip");
             return ButtonSegment(
                 value: segmentView.control.attrString("value")!,
                 enabled: !segmentDisabled,
-                tooltip: !segmentDisabled
-                    ? segmentView.control.attrString("tooltip")
+                tooltip: !segmentDisabled && segmentTooltip != null
+                    ? jsonDecode(segmentTooltip)
                     : null,
                 icon: iconCtrls.isNotEmpty
                     ? createControl(segmentView.control, iconCtrls.first.id,

--- a/sdk/python/packages/flet/src/flet/core/navigation_bar.py
+++ b/sdk/python/packages/flet/src/flet/core/navigation_bar.py
@@ -51,7 +51,7 @@ class NavigationBarDestination(AdaptiveControl, Control):
         # Control
         #
         ref: Optional[Ref] = None,
-        tooltip: TooltipValue = None,
+        tooltip: Optional[str] = None,
         disabled: Optional[bool] = None,
         visible: Optional[bool] = None,
         data: Any = None,
@@ -180,6 +180,15 @@ class NavigationBarDestination(AdaptiveControl, Control):
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
         self._set_enum_attr("bgcolor", value, ColorEnums)
+
+    # tooltip
+    @property
+    def tooltip(self) -> Optional[str]:
+        return self._get_attr("tooltip")
+
+    @tooltip.setter
+    def tooltip(self, value: Optional[str]):
+        self._set_attr("tooltip", value)
 
 
 @deprecated(

--- a/sdk/python/packages/flet/src/flet/core/segmented_button.py
+++ b/sdk/python/packages/flet/src/flet/core/segmented_button.py
@@ -31,7 +31,7 @@ class Segment(Control):
         expand_loose: Optional[bool] = None,
         col: Optional[ResponsiveNumber] = None,
         opacity: OptionalNumber = None,
-        tooltip: TooltipValue = None,
+        tooltip: Optional[str] = None,
         badge: Optional[BadgeValue] = None,
         visible: Optional[bool] = None,
         disabled: Optional[bool] = None,
@@ -57,9 +57,6 @@ class Segment(Control):
 
     def _get_control_name(self):
         return "segment"
-
-    def before_update(self):
-        super().before_update()
 
     def _get_children(self):
         children = []
@@ -97,6 +94,15 @@ class Segment(Control):
     @value.setter
     def value(self, value: str):
         self._set_attr("value", value)
+
+    # tooltip
+    @property
+    def tooltip(self) -> Optional[str]:
+        return self._get_attr("tooltip")
+
+    @tooltip.setter
+    def tooltip(self, value: Optional[str]):
+        self._set_attr("tooltip", value)
 
 
 class SegmentedButton(ConstrainedControl):


### PR DESCRIPTION
Fixes #4324

<details><summary>Test Code</summary>
<p>

```python
import flet as ft


def main(page: ft.Page):
    page.horizontal_alignment = ft.CrossAxisAlignment.CENTER
    page.vertical_alignment = ft.MainAxisAlignment.CENTER
    page.navigation_bar = ft.NavigationBar(
        destinations=[
            ft.NavigationBarDestination("one", icon=ft.icons.ADD, tooltip="one"),
            ft.NavigationBarDestination("two", icon=ft.icons.TWO_K, tooltip="two"),
        ],
    )

    page.add(
        ft.SegmentedButton(
            selected={"0"},
            selected_icon=ft.Icon(ft.icons.CHECK),
            segments=[
                ft.Segment(
                    value="0",
                    icon=ft.Icon(ft.icons.LOOKS_ONE),
                    label=ft.Text("I am Text", size=16),
                    tooltip="tooltip from text",
                ),
                ft.Segment(
                    value="2",
                    icon=ft.Icon(ft.icons.LOOKS_3),
                    label=ft.Text(
                        "I am Class",
                        size=16,
                        tooltip=ft.Tooltip(
                            message="tooltip from class",
                            padding=3,
                            border_radius=10,
                            gradient=ft.LinearGradient(
                                colors=[ft.colors.RED, ft.colors.BLUE]
                            ),
                        ),
                    ),
                ),
            ],
        )
    )


ft.app(main)
``` 

</p>
</details> 

## Summary by Sourcery

Fix tooltip handling in `Segment` and `NavigationBarDestination` to accept only string values and update plugin registrations for platform-specific `screen_retriever` plugins.

Bug Fixes:
- Ensure `Segment` and `NavigationBarDestination` components only accept string values for tooltips, preventing potential runtime errors.

Enhancements:
- Refactor tooltip handling in various components to decode JSON strings, improving consistency and reliability.

Chores:
- Update plugin registration for `screen_retriever` to platform-specific plugins across Linux, Windows, and macOS, ensuring correct plugin usage.