### PR TITLE
Flet 0.25.0 fixes - part 1

### DIFF
--- a/sdk/python/packages/flet-cli/src/flet_cli/commands/build.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/commands/build.py
@@ -225,6 +225,13 @@ class Command(BaseCommand):
             required=False,
         )
         parser.add_argument(
+            "--clear-cache",
+            dest="clear_cache",
+            action="store_true",
+            default=None,
+            help="clear build cache",
+        )
+        parser.add_argument(
             "--project",
             dest="project_name",
             help="project name for executable or bundle",
@@ -836,6 +843,10 @@ class Command(BaseCommand):
             )
 
             # create Flutter project from a template
+            if options.clear_cache and self.flutter_dir.exists():
+                if self.verbose > 1:
+                    console.log(f"Deleting {self.flutter_dir}")
+                shutil.rmtree(self.flutter_dir, ignore_errors=True)
             self.flutter_dir.mkdir(parents=True, exist_ok=True)
             self.status.update(
                 f"[bold blue]Creating Flutter bootstrap project from {template_url} with ref {template_ref} {self.emojis['loading']}... ",

--- a/sdk/python/packages/flet-cli/src/flet_cli/commands/build.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/commands/build.py
@@ -922,18 +922,10 @@ class Command(BaseCommand):
                     "flutter_launcher_icons/image_path_android",
                     [android_icon, default_icon],
                 )
-                adaptive_icon_background = (
-                    options.android_adaptive_icon_background
-                    or get_pyproject("tool.flet.android.adaptive_icon_background")
-                    or "#ffffff"
-                )
                 fallback_image(
                     "flutter_launcher_icons/adaptive_icon_foreground",
                     [android_icon, default_icon],
                 )
-                pubspec["flutter_launcher_icons"][
-                    "adaptive_icon_background"
-                ] = adaptive_icon_background
                 fallback_image(
                     "flutter_launcher_icons/web/image_path", [web_icon, default_icon]
                 )
@@ -1053,6 +1045,15 @@ class Command(BaseCommand):
                     pubspec["flutter_native_splash"]["android_12"][
                         "color_dark"
                     ] = splash_dark_color
+
+            adaptive_icon_background = (
+                options.android_adaptive_icon_background
+                or get_pyproject("tool.flet.android.adaptive_icon_background")
+            )
+            if adaptive_icon_background:
+                pubspec["flutter_launcher_icons"][
+                    "adaptive_icon_background"
+                ] = adaptive_icon_background
 
             # enable/disable splashes
             pubspec["flutter_native_splash"]["web"] = (

--- a/sdk/python/packages/flet-cli/src/flet_cli/commands/create.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/commands/create.py
@@ -22,6 +22,8 @@ class Command(BaseCommand):
         parser.add_argument(
             "output_directory",
             type=str,
+            default=".",
+            nargs="?",
             help="project output directory",
         )
         parser.add_argument(
@@ -47,8 +49,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--package-manager",
             dest="package_manager",
-            choices=["", "uv", "poetry"],
-            default="",
+            choices=["uv", "poetry"],
             help="Python project package manager",
             required=False,
         )

--- a/sdk/python/packages/flet-cli/src/flet_cli/utils/merge.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/utils/merge.py
@@ -1,14 +1,7 @@
 def merge_dict(a: dict, b: dict, path=[]):
     for key in b:
-        if key in a:
-            if isinstance(a[key], dict) and isinstance(b[key], dict):
-                merge_dict(a[key], b[key], path + [str(key)])
-            elif a[key] != b[key]:
-                raise Exception(
-                    "Cannot merge {}: {} and {}".format(
-                        ".".join(path + [str(key)]), a[key], b[key]
-                    )
-                )
+        if key in a and isinstance(a[key], dict) and isinstance(b[key], dict):
+            merge_dict(a[key], b[key], path + [str(key)])
         else:
             a[key] = b[key]
     return a

--- a/sdk/python/packages/flet/src/flet/core/map/marker_layer.py
+++ b/sdk/python/packages/flet/src/flet/core/map/marker_layer.py
@@ -2,7 +2,7 @@ from typing import Any, List, Optional
 
 from flet.core.alignment import Alignment
 from flet.core.control import Control, OptionalNumber
-from flet.core.map import MapLatitudeLongitude
+from flet.core.map.map_configuration import MapLatitudeLongitude
 from flet.core.map.map_layer import MapLayer
 from flet.core.ref import Ref
 

--- a/sdk/python/packages/flet/src/flet/utils/pip.py
+++ b/sdk/python/packages/flet/src/flet/utils/pip.py
@@ -33,7 +33,7 @@ def ensure_flet_desktop_package_installed():
 
         assert (
             not flet_desktop.version.version
-            or flet_desktop.version.version == flet.version
+            or flet_desktop.version.version == flet.version.version
         )
     except:
         install_flet_package("flet-desktop")
@@ -44,7 +44,10 @@ def ensure_flet_web_package_installed():
         import flet.version
         import flet_web.version
 
-        assert not flet_web.version.version or flet_web.version.version == flet.version
+        assert (
+            not flet_web.version.version
+            or flet_web.version.version == flet.version.version
+        )
     except:
         install_flet_package("flet-web")
 
@@ -54,6 +57,9 @@ def ensure_flet_cli_package_installed():
         import flet.version
         import flet_cli.version
 
-        assert not flet_cli.version.version or flet_cli.version.version == flet.version
+        assert (
+            not flet_cli.version.version
+            or flet_cli.version.version == flet.version.version
+        )
     except:
         install_flet_package("flet-cli")


### PR DESCRIPTION
## Summary by Sourcery

Enhance the build command with new arguments for cache clearing and Android meta-data, refactor the merge_dict function for simplicity, and fix version comparison logic in package installation functions.

New Features:
- Add support for clearing build cache with a new '--clear-cache' argument in the build command.
- Introduce '--android-meta-data' argument to add app meta-data entries to AndroidManifest.xml.

Bug Fixes:
- Fix version comparison logic in ensure_flet_desktop_package_installed, ensure_flet_web_package_installed, and ensure_flet_cli_package_installed functions to correctly compare version strings.

Enhancements:
- Refactor the merge_dict function to simplify the merging logic by removing exception handling for conflicting keys.
- Allow specifying a default output directory in the create command.