### PR TITLE
fix: regression in `Markdown.code_theme` when using `MarkdownCodeTheme` enum

### DIFF
--- a/sdk/python/packages/flet/src/flet/core/markdown.py
+++ b/sdk/python/packages/flet/src/flet/core/markdown.py
@@ -400,7 +400,12 @@ class Markdown(ConstrainedControl):
         self._set_attr_json("codeStyle", self.__code_style)
         self._set_attr_json("codeStyleSheet", self.__code_style_sheet)
         self._set_attr_json("mdStyleSheet", self.__md_style_sheet)
-        self._set_attr_json("codeTheme", self.__code_theme)
+        self._set_attr_json(
+            "codeTheme",
+            self.__code_theme.value
+            if isinstance(self.__code_theme, MarkdownCodeTheme)
+            else self.__code_theme,
+        )
 
     def _get_children(self):
         if self.__img_error_content is not None:

--- a/sdk/python/packages/flet/src/flet/core/markdown.py
+++ b/sdk/python/packages/flet/src/flet/core/markdown.py
@@ -488,11 +488,13 @@ class Markdown(ConstrainedControl):
 
     # code_theme
     @property
-    def code_theme(self) -> Optional[MarkdownCodeTheme]:
+    def code_theme(self) -> Optional[Union[MarkdownCodeTheme, MarkdownCustomCodeTheme]]:
         return self.__code_theme
 
     @code_theme.setter
-    def code_theme(self, value: Optional[MarkdownCodeTheme]):
+    def code_theme(
+        self, value: Optional[Union[MarkdownCodeTheme, MarkdownCustomCodeTheme]]
+    ):
         self.__code_theme = value
 
     # code_style


### PR DESCRIPTION
Fixes #4372

## Summary by Sourcery

Bug Fixes:
- Fix a regression in the `Markdown.code_theme` property to correctly handle instances of the `MarkdownCodeTheme` enum.