### PR TITLE
fix(regression): rotation of `Icon` has no effect

### DIFF
--- a/sdk/python/packages/flet/src/flet/core/icon.py
+++ b/sdk/python/packages/flet/src/flet/core/icon.py
@@ -130,6 +130,7 @@ class Icon(ConstrainedControl):
         return "icon"
 
     def before_update(self):
+        super().before_update()
         self._set_attr_json("shadows", self.__shadows)
 
     # name


### PR DESCRIPTION
Fixes #4349

## Summary by Sourcery

Bug Fixes:
- Fix the issue where the rotation of the `Icon` component had no effect by ensuring the `before_update` method calls its superclass implementation.