### PR TITLE
feat: Add `{value_length}`, `{max_length}`, and `{symbols_left}` placeholders to `TextField.counter_text`

### DIFF
--- a/packages/flet/lib/src/controls/textfield.dart
+++ b/packages/flet/lib/src/controls/textfield.dart
@@ -208,6 +208,8 @@ class _TextFieldControlState extends State<TextFieldControl>
       }
       var fitParentSize = widget.control.attrBool("fitParentSize", false)!;
 
+      var maxLength = widget.control.attrInt("maxLength");
+
       Widget textField = TextFormField(
           style: textStyle,
           autofocus: autofocus,
@@ -234,6 +236,8 @@ class _TextFieldControlState extends State<TextFieldControl>
               helper: helperCtrl.isNotEmpty ? helperCtrl.first : null,
               label: labelCtrl.isNotEmpty ? labelCtrl.first : null,
               customSuffix: revealPasswordIcon,
+              valueLength: _value.length,
+              maxLength: maxLength,
               focused: _focused,
               disabled: disabled,
               adaptive: adaptive),
@@ -261,7 +265,7 @@ class _TextFieldControlState extends State<TextFieldControl>
               widget.control.attrString("textAlign"), TextAlign.start)!,
           minLines: fitParentSize ? null : minLines,
           maxLines: fitParentSize ? null : maxLines,
-          maxLength: widget.control.attrInt("maxLength"),
+          maxLength: maxLength,
           readOnly: widget.control.attrBool("readOnly", false)!,
           inputFormatters: inputFormatters.isNotEmpty ? inputFormatters : null,
           obscureText: password && !_revealPassword,

--- a/packages/flet/lib/src/utils/form_field.dart
+++ b/packages/flet/lib/src/utils/form_field.dart
@@ -66,6 +66,8 @@ InputDecoration buildInputDecoration(BuildContext context, Control control,
     Control? helper,
     Control? label,
     Widget? customSuffix,
+    int? valueLength,
+    int? maxLength,
     bool focused = false,
     bool disabled = false,
     bool? adaptive}) {
@@ -97,6 +99,13 @@ InputDecoration buildInputDecoration(BuildContext context, Control control,
   var focusedBorderColor = control.attrColor("focusedBorderColor", context);
   var borderWidth = control.attrDouble("borderWidth");
   var focusedBorderWidth = control.attrDouble("focusedBorderWidth");
+
+  var counterText = control
+      .attrString("counterText", "")
+      ?.replaceAll("{value_length}", valueLength.toString())
+      .replaceAll("{max_length}", maxLength?.toString() ?? "None")
+      .replaceAll("{symbols_left}",
+          "${maxLength == null ? 'None' : (maxLength - (valueLength ?? 0))}");
 
   InputBorder? border;
   if (inputBorder == FormFieldInputBorder.underline) {
@@ -163,7 +172,7 @@ InputDecoration buildInputDecoration(BuildContext context, Control control,
       hintStyle: parseTextStyle(Theme.of(context), control, "hintStyle"),
       helperText: control.attrString("helperText"),
       helperStyle: parseTextStyle(Theme.of(context), control, "helperStyle"),
-      counterText: control.attrString("counterText"),
+      counterText: counterText,
       counterStyle: parseTextStyle(Theme.of(context), control, "counterStyle"),
       counter: counter != null
           ? createControl(control, counter.id, control.isDisabled,

--- a/sdk/python/packages/flet/src/flet/core/dropdown.py
+++ b/sdk/python/packages/flet/src/flet/core/dropdown.py
@@ -362,6 +362,7 @@ class Dropdown(FormFieldControl):
         self.max_menu_height = max_menu_height
         self.select_icon_size = select_icon_size or icon_size
         self.select_icon_enabled_color = select_icon_enabled_color or icon_enabled_color
+        self.icon_disabled_color = icon_disabled_color
         self.select_icon_disabled_color = (
             select_icon_disabled_color or icon_disabled_color
         )


### PR DESCRIPTION
Closes #1534

## Test Code

```python
import flet as ft


def main(page: ft.Page):
    page.add(
        ft.TextField(
            hint_text="Custom counter text",
            counter_text="{value_length} chars / {max_length} max chars / {symbols_left} symbols left",
            max_length=10,
        ),
        ft.TextField(
            hint_text="Counter text isn't shown by default anymore",
            max_length=20,
        ),
    )


ft.app(main)
```

## Summary by Sourcery

Add new placeholders to `TextField.counter_text` for dynamic character count display, enhancing the user interface with real-time feedback on text input length.

New Features:
- Introduce placeholders `{value_length}`, `{max_length}`, and `{symbols_left}` in `TextField.counter_text` to dynamically display character count information.

Enhancements:
- Modify `buildInputDecoration` to support dynamic counter text with new placeholders.