### PR TITLE
fix: `TextField` freezes on Linux Mint

### DIFF
--- a/packages/flet/lib/src/controls/textfield.dart
+++ b/packages/flet/lib/src/controls/textfield.dart
@@ -1,3 +1,4 @@
+import 'package:flet/src/utils/platform.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -317,6 +318,10 @@ class _TextFieldControlState extends State<TextFieldControl>
                 cursorColor: cursorColor, selectionColor: selectionColor),
             child: textField);
       }
+
+      // linux workaround for https://github.com/flet-dev/flet/issues/3934
+      textField =
+          isLinuxDesktop() ? ExcludeSemantics(child: textField) : textField;
 
       if (widget.control.attrInt("expand", 0)! > 0) {
         return constrainedControl(


### PR DESCRIPTION
Fixes #3934

## Summary by Sourcery

Bug Fixes:
- Fix the freezing issue of the `TextField` component on Linux Mint by applying a workaround that excludes semantics for Linux desktop platforms.