### PR TITLE
fix: remove `DatePicker` assertions

### DIFF
--- a/sdk/python/packages/flet/src/flet/core/date_picker.py
+++ b/sdk/python/packages/flet/src/flet/core/date_picker.py
@@ -175,21 +175,6 @@ class DatePicker(Control):
 
     def before_update(self):
         super().before_update()
-        assert (
-            self.__first_date is None
-            or self.__last_date is None
-            or self.__first_date <= self.__last_date
-        ), "last_date must be on or after first_date"
-        assert (
-            self.__first_date is None
-            or self.__current_date is None
-            or self.__first_date <= self.__current_date
-        ), "current_date must be on or after first_date"
-        assert (
-            self.__last_date is None
-            or self.__current_date is None
-            or self.__last_date >= self.__current_date
-        ), "last_date must be on or after current_date"
 
     @deprecated(
         reason="Use Page.open() method instead.",

--- a/sdk/python/packages/flet/src/flet/core/date_picker.py
+++ b/sdk/python/packages/flet/src/flet/core/date_picker.py
@@ -173,9 +173,6 @@ class DatePicker(Control):
     def _get_control_name(self):
         return "datepicker"
 
-    def before_update(self):
-        super().before_update()
-
     @deprecated(
         reason="Use Page.open() method instead.",
         version="0.23.0",


### PR DESCRIPTION
Resolves #4418

## Summary by Sourcery

Bug Fixes:
- Remove assertions in the DatePicker component that enforced date order constraints.