### PR TITLE
fix: EntryModeChangeEvent for DatePicker and TimePicker

### DIFF
--- a/sdk/python/packages/flet/src/flet/core/date_picker.py
+++ b/sdk/python/packages/flet/src/flet/core/date_picker.py
@@ -142,7 +142,7 @@ class DatePicker(Control):
         )
 
         self.__on_entry_mode_change = EventHandler(
-            lambda e: DatePickerEntryModeChangeEvent(e.data)
+            lambda e: DatePickerEntryModeChangeEvent(e)
         )
         self._add_event_handler(
             "entryModeChange", self.__on_entry_mode_change.get_handler()

--- a/sdk/python/packages/flet/src/flet/core/time_picker.py
+++ b/sdk/python/packages/flet/src/flet/core/time_picker.py
@@ -128,7 +128,7 @@ class TimePicker(Control):
         )
 
         self.__on_entry_mode_change = EventHandler(
-            lambda e: TimePickerEntryModeChangeEvent(e.data)
+            lambda e: TimePickerEntryModeChangeEvent(e)
         )
         self._add_event_handler(
             "entryModeChange", self.__on_entry_mode_change.get_handler()


### PR DESCRIPTION
Fixes #4437

## Summary by Sourcery

Bug Fixes:
- Correct the instantiation of EntryModeChangeEvent for DatePicker and TimePicker by passing the entire event object instead of just the event data.