### PR TITLE
fix: wrong imports in `flet-cli/hook-flet.py`

### DIFF
--- a/sdk/python/packages/flet-cli/src/flet_cli/__pyinstaller/hook-flet.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/__pyinstaller/hook-flet.py
@@ -1,7 +1,7 @@
 import os
 
-import flet.__pyinstaller.config as hook_config
-from flet.__pyinstaller.utils import get_flet_bin_path
+import flet_cli.__pyinstaller.config as hook_config
+from flet_cli.__pyinstaller.utils import get_flet_bin_path
 
 bin_path = hook_config.temp_bin_dir
 if not bin_path:


### PR DESCRIPTION
Closes #4447

## Summary by Sourcery

Bug Fixes:
- Correct wrong import paths in `flet-cli/hook-flet.py` to use `flet_cli` instead of `flet`.