### PR TITLE
feat: implement `Window.ignore_mouse_events`

### DIFF
--- a/packages/flet/lib/src/controls/page.dart
+++ b/packages/flet/lib/src/controls/page.dart
@@ -167,6 +167,7 @@ class _PageControlState extends State<PageControl> with FletStoreMixin {
   bool? _windowTitleBarHidden;
   bool? _windowSkipTaskBar;
   double? _windowProgressBar;
+  bool? _windowIgnoreMouseEvents;
   final _navigatorKey = GlobalKey<NavigatorState>();
   late final RouteState _routeState;
   late final SimpleRouterDelegate _routerDelegate;
@@ -338,6 +339,8 @@ class _PageControlState extends State<PageControl> with FletStoreMixin {
     var windowSkipTaskBar = widget.control.attrBool("windowSkipTaskBar");
     var windowFrameless = widget.control.attrBool("windowFrameless");
     var windowProgressBar = widget.control.attrDouble("windowProgressBar");
+    var windowIgnoreMouseEvents =
+        widget.control.attrBool("windowIgnoreMouseEvents");
 
     updateWindow(PageArgsModel? pageArgs) async {
       try {
@@ -579,6 +582,13 @@ class _PageControlState extends State<PageControl> with FletStoreMixin {
         // window waitUntilReadyToShow
         if (windowWaitUntilReadyToShow == true) {
           await waitUntilReadyToShow();
+        }
+
+        // windowIgnoreMouseEvents
+        if (windowIgnoreMouseEvents != null &&
+            windowIgnoreMouseEvents != _windowIgnoreMouseEvents) {
+          await setIgnoreMouseEvents(windowIgnoreMouseEvents);
+          _windowIgnoreMouseEvents = windowIgnoreMouseEvents;
         }
       } catch (e) {
         debugPrint("ERROR updating window: $e");

--- a/packages/flet/lib/src/utils/desktop.dart
+++ b/packages/flet/lib/src/utils/desktop.dart
@@ -283,6 +283,13 @@ Future isFocused() async {
   }
 }
 
+Future setIgnoreMouseEvents(bool ignore) async {
+  if (isDesktopPlatform()) {
+    debugPrint("setIgnoreMouseEvents($ignore)");
+    await windowManager.setIgnoreMouseEvents(ignore);
+  }
+}
+
 Future<WindowMediaData> getWindowMediaData() async {
   var m = WindowMediaData();
   if (isDesktopPlatform()) {

--- a/sdk/python/packages/flet/src/flet/core/page.py
+++ b/sdk/python/packages/flet/src/flet/core/page.py
@@ -476,6 +476,17 @@ class Window:
     def icon(self, value: Optional[str]):
         self.page._set_attr("windowIcon", value)
 
+    # ignore_mouse_events
+    @property
+    def ignore_mouse_events(self) -> bool:
+        return self.page._get_attr(
+            "windowIgnoreMouseEvents", data_type="bool", def_value=False
+        )
+
+    @ignore_mouse_events.setter
+    def ignore_mouse_events(self, value: Optional[bool]):
+        self.page._set_attr("windowIgnoreMouseEvents", value)
+
     # Methods
     def destroy(self):
         self.page._set_attr("windowDestroy", True)


### PR DESCRIPTION
Resolves #1438

## Test Code
```python
import flet as ft


def main(page: ft.Page):
    def on_keyboard(e: ft.KeyboardEvent):
        if e.key == "Escape":
            page.window.ignore_mouse_events = not page.window.ignore_mouse_events
            s.value = page.window.ignore_mouse_events
            page.update()

    def handle_switch_change(e: ft.ControlEvent):
        page.window.ignore_mouse_events = s.value
        page.update()

    page.on_keyboard_event = on_keyboard
    page.add(
        s := ft.Switch(
            "Ignore Mouse Events",
            on_change=handle_switch_change,
        ),
        ft.Text("Press Escape when the window has focus to toggle switch"),
    )


ft.app(main)
```

## Summary by Sourcery

New Features:
- Introduce the `ignore_mouse_events` property to the `Window` class, allowing users to enable or disable mouse event handling for the window.