### PR TITLE
fix: `SafeArea` object has no attribute `_SafeArea__minimum`

### DIFF
--- a/sdk/python/packages/flet/src/flet/core/circle_avatar.py
+++ b/sdk/python/packages/flet/src/flet/core/circle_avatar.py
@@ -78,8 +78,6 @@ class CircleAvatar(ConstrainedControl):
     def __init__(
         self,
         content: Optional[Control] = None,
-        foreground_image_url: Optional[str] = None,
-        background_image_url: Optional[str] = None,
         foreground_image_src: Optional[str] = None,
         background_image_src: Optional[str] = None,
         color: Optional[ColorValue] = None,
@@ -152,8 +150,6 @@ class CircleAvatar(ConstrainedControl):
             data=data,
         )
 
-        self.foreground_image_url = foreground_image_url
-        self.background_image_url = background_image_url
         self.foreground_image_src = foreground_image_src
         self.background_image_src = background_image_src
         self.radius = radius

--- a/sdk/python/packages/flet/src/flet/core/popup_menu_button.py
+++ b/sdk/python/packages/flet/src/flet/core/popup_menu_button.py
@@ -217,7 +217,6 @@ class PopupMenuButton(ConstrainedControl):
         style: Optional[ButtonStyle] = None,
         popup_animation_style: Optional[AnimationStyle] = None,
         size_constraints: Optional[BoxConstraints] = None,
-        on_cancelled: OptionalControlEventCallable = None,
         on_open: OptionalControlEventCallable = None,
         on_cancel: OptionalControlEventCallable = None,
         on_select: OptionalControlEventCallable = None,

--- a/sdk/python/packages/flet/src/flet/core/safe_area.py
+++ b/sdk/python/packages/flet/src/flet/core/safe_area.py
@@ -27,7 +27,6 @@ class SafeArea(ConstrainedControl, AdaptiveControl):
         right: Optional[bool] = None,
         bottom: Optional[bool] = None,
         maintain_bottom_view_padding: Optional[bool] = None,
-        minimum: PaddingValue = None,
         minimum_padding: PaddingValue = None,
         #
         # ConstrainedControl
@@ -99,7 +98,6 @@ class SafeArea(ConstrainedControl, AdaptiveControl):
         self.right = right
         self.bottom = bottom
         self.maintain_bottom_view_padding = maintain_bottom_view_padding
-        self.minimum = minimum
         self.minimum_padding = minimum_padding
 
     def _get_control_name(self):
@@ -108,7 +106,6 @@ class SafeArea(ConstrainedControl, AdaptiveControl):
     def before_update(self):
         super().before_update()
         assert self.__content.visible, "content must be visible"
-        self._set_attr_json("minimum", self.__minimum)
         self._set_attr_json("minimumPadding", self.__minimum_padding)
 
     def _get_children(self):


### PR DESCRIPTION
Fixes #4499

## Summary by Sourcery

Fix the attribute error in the SafeArea class by removing the unused '_SafeArea__minimum' attribute and clean up unused parameters in CircleAvatar and PopupMenuButton class constructors.

Bug Fixes:
- Remove the unused attribute '_SafeArea__minimum' from the SafeArea class to fix the attribute error.

Enhancements:
- Remove unused parameters 'foreground_image_url' and 'background_image_url' from the CircleAvatar class constructor.
- Remove the unused parameter 'on_cancelled' from the PopupMenuButton class constructor.