### PR TITLE
Add `flet` if no dependencies provided for `flet publish` command

### DIFF
--- a/sdk/python/packages/flet-cli/src/flet_cli/commands/publish.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/commands/publish.py
@@ -113,6 +113,7 @@ class Command(BaseCommand):
         )
 
     def handle(self, options: argparse.Namespace) -> None:
+        import flet.version
         from flet.utils.pip import ensure_flet_web_package_installed
 
         ensure_flet_web_package_installed()
@@ -196,6 +197,9 @@ class Command(BaseCommand):
                     )
                 )
                 print(f"{reqs_filename} dependencies: {deps}")
+
+        if len(deps) == 0:
+            deps = [f"flet=={flet.version.version}"]
 
         temp_reqs_txt = Path(tempfile.gettempdir()).joinpath(random_string(10))
         with open(temp_reqs_txt, "w") as f:

--- a/sdk/python/packages/flet/src/flet/cli.py
+++ b/sdk/python/packages/flet/src/flet/cli.py
@@ -1,7 +1,6 @@
 import subprocess
 import sys
 
-import flet.version
 from flet.utils.pip import ensure_flet_cli_package_installed
 
 


### PR DESCRIPTION
Fix #4493

## Summary by Sourcery

Bug Fixes:
- Ensure the `flet publish` command includes `flet` as a dependency if no other dependencies are provided.