### PR TITLE
fix broken `Map.center_on()` and default animations

### DIFF
--- a/packages/flet_map/lib/src/map.dart
+++ b/packages/flet_map/lib/src/map.dart
@@ -54,8 +54,10 @@ class _MapControlState extends State<MapControl>
         .where((c) => c.isVisible && (acceptedChildrenTypes.contains(c.type)))
         .toList();
 
-    Curve? defaultAnimationCurve;
-    Duration? defaultAnimationDuration;
+    Curve? defaultAnimationCurve =
+        parseCurve(widget.control.attrString("animationCurve"));
+    Duration? defaultAnimationDuration =
+        parseDuration(widget.control, "animationDuration");
     var configuration = parseConfiguration(
         widget.control, widget.backend, context, const MapOptions())!;
 
@@ -76,7 +78,7 @@ class _MapControlState extends State<MapControl>
             if (degree != null) {
               _animatedMapController.animatedRotateFrom(
                 degree,
-                curve: parseCurve(args["curve"]) ?? defaultAnimationCurve,
+                curve: parseCurve(args["curve"], defaultAnimationCurve),
               );
             }
           case "reset_rotation":

--- a/sdk/python/packages/flet/src/flet/core/map/map.py
+++ b/sdk/python/packages/flet/src/flet/core/map/map.py
@@ -366,7 +366,7 @@ class Map(ConstrainedControl):
         animation_duration: DurationValue = None,
     ):
         self.invoke_method(
-            "animate_to",
+            "center_on",
             arguments={
                 "lat": str(point.latitude) if point else None,
                 "long": str(point.longitude) if point else None,


### PR DESCRIPTION
## Summary by Sourcery

Fix the `Map.center_on()` method and set default animation parameters by parsing them from widget control attributes.

Bug Fixes:
- Fix the broken `Map.center_on()` method by correcting the method invocation from `animate_to` to `center_on`.

Enhancements:
- Set default animation curve and duration by parsing attributes from the widget control.