### PR TITLE
fix: Setting `CheckBox.border_side.stroke_align` to an Enum fails

### DIFF
--- a/sdk/python/packages/flet/src/flet/core/border.py
+++ b/sdk/python/packages/flet/src/flet/core/border.py
@@ -1,11 +1,11 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum
 from typing import Optional, Union
 
 from flet.core.types import ColorValue, OptionalNumber
 
 
-class BorderSideStrokeAlign(Enum):
+class BorderSideStrokeAlign(float, Enum):
     INSIDE = -1.0
     CENTER = 0.0
     OUTSIDE = 1.0
@@ -14,16 +14,16 @@ class BorderSideStrokeAlign(Enum):
 @dataclass
 class BorderSide:
     width: OptionalNumber
-    color: Optional[ColorValue] = field(default=None)
-    stroke_align: Union[BorderSideStrokeAlign, OptionalNumber] = field(default=None)
+    color: Optional[ColorValue] = None
+    stroke_align: Union[BorderSideStrokeAlign, OptionalNumber] = None
 
 
 @dataclass
 class Border:
-    top: Optional[BorderSide] = field(default=None)
-    right: Optional[BorderSide] = field(default=None)
-    bottom: Optional[BorderSide] = field(default=None)
-    left: Optional[BorderSide] = field(default=None)
+    top: Optional[BorderSide] = None
+    right: Optional[BorderSide] = None
+    bottom: Optional[BorderSide] = None
+    left: Optional[BorderSide] = None
 
 
 def all(width: Optional[float] = None, color: Optional[ColorValue] = None) -> Border:

--- a/sdk/python/packages/flet/src/flet/core/chip.py
+++ b/sdk/python/packages/flet/src/flet/core/chip.py
@@ -210,6 +210,7 @@ class Chip(ConstrainedControl):
         self._set_attr_json("labelStyle", self.__label_style)
         self._set_attr_json("padding", self.__padding)
         self._set_attr_json("shape", self.__shape)
+        self._set_attr_json("borderSide", self.__border_side)
         self._set_attr_json("color", self.__color, wrap_attr_dict=True)
 
     def _get_children(self):


### PR DESCRIPTION
Fixes #4491

## Summary by Sourcery

Fix the Enum assignment issue in `CheckBox.border_side.stroke_align` by updating the `BorderSideStrokeAlign` class and simplify default value assignments in related dataclasses.

Bug Fixes:
- Fix the issue where setting `CheckBox.border_side.stroke_align` to an Enum fails by modifying the `BorderSideStrokeAlign` class to inherit from `float` and `Enum`.

Enhancements:
- Remove the use of `field(default=None)` in `BorderSide` and `Border` dataclasses, simplifying the default value assignment.