### PR TITLE
fix:`ControlState` should be resolved based on user-defined order

### DIFF
--- a/packages/flet/lib/src/utils/material_state.dart
+++ b/packages/flet/lib/src/utils/material_state.dart
@@ -1,3 +1,4 @@
+import 'dart:collection';
 import 'package:flutter/material.dart';
 
 WidgetStateProperty<T?>? getWidgetStateProperty<T>(
@@ -8,43 +9,42 @@ WidgetStateProperty<T?>? getWidgetStateProperty<T>(
   }
   var j = jsonDictValue;
   if (j is! Map<String, dynamic>) {
-    j = {"": j};
+    j = {"default": j};
   }
   return WidgetStateFromJSON(j, converterFromJson, defaultValue);
 }
 
 class WidgetStateFromJSON<T> extends WidgetStateProperty<T?> {
-  late final Map<String, T> _states;
+  late final LinkedHashMap<String, T> _states;
   late final T? _defaultValue;
 
   WidgetStateFromJSON(Map<String, dynamic>? jsonDictValue,
       T Function(dynamic) converterFromJson, T? defaultValue) {
     _defaultValue = defaultValue;
-    _states = {};
-    if (jsonDictValue != null) {
-      jsonDictValue.forEach((stateStr, jv) {
-        stateStr.split(",").map((s) => s.trim().toLowerCase()).forEach((state) {
-          _states[state] = converterFromJson(jv);
-        });
-      });
-    }
+
+    // preserve user-defined order
+    _states = LinkedHashMap<String, T>.from(
+      jsonDictValue?.map((key, value) {
+            var normalizedKey = key.trim().toLowerCase();
+            // "" is now deprecated; use "default" instead
+            if (normalizedKey == "") normalizedKey = "default";
+            return MapEntry(normalizedKey, converterFromJson(value));
+          }) ??
+          {},
+    );
   }
 
   @override
   T? resolve(Set<WidgetState> states) {
-    //debugPrint("WidgetStateFromJSON states: $states, _states: $_states");
-    // find specific state
-    for (var state in states) {
-      if (_states.containsKey(state.name)) {
-        return _states[state.name]!;
+    // Resolve using user-defined order in _states
+    for (var stateName in _states.keys) {
+      if (stateName == "default") continue; // Skip "default"; handled last
+      if (states.any((state) => state.name == stateName)) {
+        return _states[stateName];
       }
     }
 
-    // catch-all value
-    if (_states.containsKey("")) {
-      return _states[""];
-    }
-
-    return _defaultValue;
+    // Default state
+    return _states["default"] ?? _defaultValue;
   }
 }

--- a/sdk/python/packages/flet/src/flet/core/types.py
+++ b/sdk/python/packages/flet/src/flet/core/types.py
@@ -136,7 +136,7 @@ class ControlState(Enum):
     SCROLLED_UNDER = "scrolledUnder"
     DISABLED = "disabled"
     ERROR = "error"
-    DEFAULT = ""
+    DEFAULT = "default"
 
 
 class MainAxisAlignment(Enum):

--- a/sdk/python/packages/flet/tests/test_datatable.py
+++ b/sdk/python/packages/flet/tests/test_datatable.py
@@ -1,5 +1,6 @@
-import flet as ft
 from flet.core.protocol import Command
+
+import flet as ft
 
 
 def test_datatable_instance_no_attrs_set():
@@ -38,7 +39,7 @@ def test_datarow_color_literal_material_state_as_string():
             indent=0,
             name=None,
             values=["datarow"],
-            attrs={"color": '{"":"yellow"}'},
+            attrs={"color": '{"default":"yellow"}'},
             commands=[],
         ),
         Command(indent=2, name=None, values=["datacell"], attrs={}, commands=[]),
@@ -51,7 +52,11 @@ def test_datarow_color_literal_material_state_as_string():
 def test_datarow_color_multiple_material_states_as_strings():
     r = ft.DataRow(
         cells=[ft.DataCell(content=ft.Text("Cell"))],
-        color={"selected": "red", "hovered": "blue", "": "yellow"},
+        color={
+            ft.ControlState.SELECTED: "red",
+            ft.ControlState.HOVERED: "blue",
+            ft.ControlState.DEFAULT: "yellow",
+        },
     )
     assert isinstance(r, ft.Control)
     assert r._build_add_commands() == [
@@ -59,7 +64,7 @@ def test_datarow_color_multiple_material_states_as_strings():
             indent=0,
             name=None,
             values=["datarow"],
-            attrs={"color": '{"selected":"red","hovered":"blue","":"yellow"}'},
+            attrs={"color": '{"selected":"red","hovered":"blue","default":"yellow"}'},
             commands=[],
         ),
         Command(indent=2, name=None, values=["datacell"], attrs={}, commands=[]),
@@ -84,7 +89,7 @@ def test_datarow_color_multiple_material_states():
             indent=0,
             name=None,
             values=["datarow"],
-            attrs={"color": '{"selected":"red","hovered":"blue","":"yellow"}'},
+            attrs={"color": '{"selected":"red","hovered":"blue","default":"yellow"}'},
             commands=[],
         ),
         Command(indent=2, name=None, values=["datacell"], attrs={}, commands=[]),


### PR DESCRIPTION
Fixes #4409

## Test Code

```python
import flet as ft


def main(page: ft.Page):
    page.horizontal_alignment = ft.CrossAxisAlignment.CENTER
    page.vertical_alignment = ft.MainAxisAlignment.CENTER
    button = ft.TextButton(
        "Test Button",
        style=ft.ButtonStyle(
            bgcolor={
                ft.ControlState.DEFAULT: ft.colors.with_opacity(0.786, "ffffff"),
                 ft.ControlState.PRESSED: ft.colors.BLUE,
                ft.ControlState.HOVERED: ft.colors.GREEN,
            }
        ),
    )
    page.add(button)


ft.app(main)
```