### PR TITLE
fix: broken `Dismissible.dismiss_direction`

### DIFF
--- a/packages/flet/lib/src/controls/dismissible.dart
+++ b/packages/flet/lib/src/controls/dismissible.dart
@@ -56,7 +56,7 @@ class _DismissibleControlState extends State<DismissibleControl> {
         parseDismissThresholds(widget.control, "dismissThresholds");
 
     DismissDirection direction = parseDismissDirection(
-        widget.control.attrString("direction"), DismissDirection.horizontal)!;
+        widget.control.attrString("dismissDirection"), DismissDirection.horizontal)!;
 
     widget.backend.subscribeMethods(widget.control.id,
         (methodName, args) async {

--- a/sdk/python/packages/flet/src/flet/core/dismissible.py
+++ b/sdk/python/packages/flet/src/flet/core/dismissible.py
@@ -19,7 +19,6 @@ from flet.core.types import (
     RotateValue,
     ScaleValue,
 )
-from flet.utils import deprecated
 
 
 class Dismissible(ConstrainedControl, AdaptiveControl):


### PR DESCRIPTION
Fixes #4553

## Summary by Sourcery

Fix the broken dismiss direction functionality in the Dismissible control by correcting the attribute name and clean up unused imports.

Bug Fixes:
- Correct the attribute name from 'direction' to 'dismissDirection' in the Dismissible control to fix the issue with dismiss direction.

Enhancements:
- Remove the unused import of 'deprecated' from the flet.utils module in the Dismissible class.