### PR TITLE
Adding Google/Android TV platform support

### DIFF
--- a/packages/flet/lib/src/reducers.dart
+++ b/packages/flet/lib/src/reducers.dart
@@ -3,6 +3,9 @@ import 'dart:convert';
 import 'package:flet/src/utils/browser_context_menu.dart';
 import 'package:flutter/foundation.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:device_info_plus/device_info_plus.dart';
+
+
 
 import 'actions.dart';
 import 'flet_control_backend.dart';
@@ -88,7 +91,19 @@ AppState appReducer(AppState state, dynamic action) {
         debugPrint("Registering web client with route: ${action.route}");
         String pageName = getWebPageName(state.pageUri!);
 
-        getWindowMediaData().then((wmd) {
+        getWindowMediaData().then((wmd) async {
+          String platformValue = defaultTargetPlatform.name.toLowerCase();
+          if (platformValue == "android") {
+            try {
+              DeviceInfoPlugin deviceInfo = DeviceInfoPlugin();
+              AndroidDeviceInfo androidInfo = await deviceInfo.androidInfo;
+              if (androidInfo.systemFeatures.contains('android.software.leanback')) {
+                platformValue = "android_tv";
+              }
+            } on Exception catch (e) {
+              debugPrint(e.toString());
+            }
+          }
           action.server.registerWebClient(
               pageName: pageName,
               pageRoute: action.route,
@@ -101,7 +116,7 @@ AppState appReducer(AppState state, dynamic action) {
               isPWA: isProgressiveWebApp().toString(),
               isWeb: kIsWeb.toString(),
               isDebug: kDebugMode.toString(),
-              platform: defaultTargetPlatform.name.toLowerCase(),
+              platform: platformValue,
               platformBrightness: state.displayBrightness.name.toString(),
               media: json.encode(state.media));
 

--- a/packages/flet/pubspec.yaml
+++ b/packages/flet/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   path: ^1.8.2
   js: ^0.6.5
   fl_chart: ^0.69.0
+  device_info_plus: ^11.2.0
 
 dev_dependencies:
   flutter_test:

--- a/sdk/python/packages/flet/src/flet/core/types.py
+++ b/sdk/python/packages/flet/src/flet/core/types.py
@@ -251,6 +251,7 @@ class ImageRepeat(Enum):
 class PagePlatform(Enum):
     IOS = "ios"
     ANDROID = "android"
+    ANDROID_TV = "android_tv"
     MACOS = "macos"
     WINDOWS = "windows"
     LINUX = "linux"


### PR DESCRIPTION
## Description

Adds Google/Android TV detection ability to page.platform so users can tell if platform is ANDROID or ANDROID_TV.


## Test Code

`print(f"Platform is {page.platform}")
`
## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] I signed the CLA.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes
- [ ] I have made corresponding changes to the [documentation](https://github.com/flet-dev/website) (if applicable)


## Additional details

Flet been working for awhile now on Google/Android TV, leanback support in manifest etc. This makes it easier for users to tell if they on android or android_tv by checking page.platform now.

## Summary by Sourcery

Introduce Google/Android TV platform detection to the page.platform property, enabling users to distinguish between ANDROID and ANDROID_TV platforms. Update documentation to include this new feature.

New Features:
- Add detection for Google/Android TV platform in the page.platform property, allowing differentiation between ANDROID and ANDROID_TV.

Documentation:
- Update documentation to reflect the new platform detection feature for Google/Android TV.