### PR TITLE
Fix Rive not updating

### DIFF
--- a/packages/flet_rive/pubspec.yaml
+++ b/packages/flet_rive/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
 
   collection: ^1.16.0
-  rive: ^0.13.20
+  rive: 0.13.20
 
   flet:
     path: ../flet/

--- a/packages/flet_rive/pubspec.yaml
+++ b/packages/flet_rive/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
 
   collection: ^1.16.0
-  rive: 0.13.17
+  rive: ^0.13.20
 
   flet:
     path: ../flet/


### PR DESCRIPTION
## Description

Quick rive pubspec fix, there was no "^" on rive's pubspec line, so could break it on future flutter versions. I think without 0.13.20 it does break flutter 3.27+ if I remember right.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I signed the CLA.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes
- [x] I have made corresponding changes to the [documentation](https://github.com/flet-dev/website) (if applicable)

## Summary by Sourcery

Bug Fixes:
- Fix the Rive dependency version in the pubspec.yaml to ensure compatibility with future Flutter versions by using a caret (^) to allow for non-breaking updates.