### PR TITLE
sdk: expose flet command on flet-cli instead of flet

### DIFF
--- a/sdk/python/packages/flet-cli/pyproject.toml
+++ b/sdk/python/packages/flet-cli/pyproject.toml
@@ -32,3 +32,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.isort]
 profile = "black"
 float_to_top = true
+
+[tool.poetry.scripts]
+flet = "flet_cli.cli:main"
+

--- a/sdk/python/packages/flet/pyproject.toml
+++ b/sdk/python/packages/flet/pyproject.toml
@@ -33,9 +33,6 @@ cli = ["flet-cli"]
 web = ["flet-web"]
 desktop = ["flet-desktop"]
 
-[tool.poetry.scripts]
-flet = "flet.cli:main"
-
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
- **expose the flet command on flet-cli instead of flet**

## Description
I am trying to [package the latest version of flet in nixpkgs](https://github.com/NixOS/nixpkgs/pull/368599) and there is a cyclic dependency between flet and flet-cli.

The reason, as far as I know, is to basically only expose the flet command.

Why not only expose the flet binary on flet-cli?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

<!-- If this PR fixes an open issue, please link to the issue here. Ex: Fixes #4562 -->

## Test Code

```python
# Test code for the review of this PR
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I signed the CLA.
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass locally with my changes
- [ ] I have made corresponding changes to the [documentation](https://github.com/flet-dev/website) (if applicable)

## Screenshots 

<!-- Add screenshots here if applicable. -->

## Additional details

<!-- Any additional details to be known about this PR. -->

## Summary by Sourcery

Build:
- Move the `flet` command from the `flet` package to the `flet-cli` package.