### PR TITLE
Access the `assets` dir easily

### DIFF
--- a/sdk/python/packages/flet/src/flet/app.py
+++ b/sdk/python/packages/flet/src/flet/app.py
@@ -385,3 +385,27 @@ def __get_upload_dir_path(upload_dir: Optional[str], relative_to_cwd=False):
                 .resolve()
             )
     return upload_dir
+
+
+def assets_dir_path(
+    *files, assets_dir: Optional[str] = "assets", relative_to_cwd: bool = False
+) -> str:
+    if assets_dir:
+        if not Path(assets_dir).is_absolute():
+            if "_MEI" in __file__:
+                # support for "onefile" PyInstaller
+                assets_dir = str(
+                    Path(__file__).parent.parent.joinpath(assets_dir).resolve()
+                )
+            else:
+                assets_dir = str(
+                    Path(os.getcwd() if relative_to_cwd else get_current_script_dir())
+                    .joinpath(assets_dir)
+                    .resolve()
+                )
+
+    env_assets_dir = os.getenv("FLET_ASSETS_DIR")
+    if env_assets_dir:
+        assets_dir = env_assets_dir
+    return os.path.join(assets_dir, *files)
+


### PR DESCRIPTION
- Added the `assets_dir_path` method to be available for a developer to work with `assets`

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

<!-- If this PR fixes an open issue, please link to the issue here. Ex: Fixes #4562 -->
Fixes #3083

## Test Code

```python
import base64

import flet as ft


def lottie_base64(name: str) -> str:
    with open(ft.assets_dir_path("animations", name), "rb") as fr:
        return base64.b64encode(fr.read()).decode()


def main(page: ft.Page) -> None:
    page.title = "Test assets_dir_path"
    page.window.width = page.window.height = 600

    page.add(
        ft.Lottie(src_base64=lottie_base64("no_internet.json"), fit=ft.ImageFit.COVER)
    )

if __name__ == "__main__":
    ft.app(main)

```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] I signed the CLA.
- [x] My code follows the style guidelines of this project

## Screenshots 

<!-- Add screenshots here if applicable. -->

## Additional details

<!-- Any additional details to be known about this PR. -->

## Tested on
[x] Linux
[] Windows
[] MacOS

## Summary by Sourcery

New Features:
- Introduce the `assets_dir_path` method in the `flet.app` module to provide convenient access to the assets directory.