### PR TITLE
Improve the handling of Enums

### DIFF
--- a/sdk/python/packages/flet/src/flet/core/ads/native.py
+++ b/sdk/python/packages/flet/src/flet/core/ads/native.py
@@ -1,20 +1,20 @@
 import dataclasses
-from enum import Enum
 from typing import Any, Optional, Union
 
 from flet.core.ads.base_ad import BaseAd
 from flet.core.animation import AnimationValue
 from flet.core.control import OptionalNumber
+from flet.core.enumerations import ExtendedEnum
 from flet.core.ref import Ref
 from flet.core.types import OffsetValue, ResponsiveNumber, RotateValue, ScaleValue
 
 
-class NativeAdTemplateType(Enum):
+class NativeAdTemplateType(ExtendedEnum):
     SMALL = "small"
     MEDIUM = "medium"
 
 
-class NativeTemplateFontStyle(Enum):
+class NativeTemplateFontStyle(ExtendedEnum):
     NORMAL = "normal"
     BOLD = "bold"
     ITALIC = "italic"

--- a/sdk/python/packages/flet/src/flet/core/alert_dialog.py
+++ b/sdk/python/packages/flet/src/flet/core/alert_dialog.py
@@ -8,7 +8,6 @@ from flet.core.ref import Ref
 from flet.core.text_style import TextStyle
 from flet.core.types import (
     ClipBehavior,
-    ColorEnums,
     ColorValue,
     MainAxisAlignment,
     OptionalControlEventCallable,
@@ -197,7 +196,7 @@ class AlertDialog(AdaptiveControl):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgcolor", value, ColorEnums)
+        self._set_attr("bgcolor", value)
 
     # shadow_color
     @property
@@ -207,7 +206,7 @@ class AlertDialog(AdaptiveControl):
     @shadow_color.setter
     def shadow_color(self, value: Optional[ColorValue]):
         self.__shadow_color = value
-        self._set_enum_attr("shadowColor", value, ColorEnums)
+        self._set_attr("shadowColor", value)
 
     # barrier_color
     @property
@@ -217,7 +216,7 @@ class AlertDialog(AdaptiveControl):
     @barrier_color.setter
     def barrier_color(self, value: Optional[ColorValue]):
         self.__barrier_color = value
-        self._set_enum_attr("barrierColor", value, ColorEnums)
+        self._set_attr("barrierColor", value)
 
     # surface_tint_color
     @property
@@ -227,7 +226,7 @@ class AlertDialog(AdaptiveControl):
     @surface_tint_color.setter
     def surface_tint_color(self, value: Optional[ColorValue]):
         self.__surface_tint_color = value
-        self._set_enum_attr("surfaceTintColor", value, ColorEnums)
+        self._set_attr("surfaceTintColor", value)
 
     # icon_color
     @property
@@ -237,7 +236,7 @@ class AlertDialog(AdaptiveControl):
     @icon_color.setter
     def icon_color(self, value: Optional[ColorValue]):
         self.__icon_color = value
-        self._set_enum_attr("iconColor", value, ColorEnums)
+        self._set_attr("iconColor", value)
 
     # elevation
     @property
@@ -431,7 +430,7 @@ class AlertDialog(AdaptiveControl):
     @clip_behavior.setter
     def clip_behavior(self, value: Optional[ClipBehavior]):
         self.__clip_behavior = value
-        self._set_enum_attr("clipBehavior", value, ClipBehavior)
+        self._set_attr("clipBehavior", value)
 
     # on_dismiss
     @property

--- a/sdk/python/packages/flet/src/flet/core/alignment.py
+++ b/sdk/python/packages/flet/src/flet/core/alignment.py
@@ -1,9 +1,10 @@
 import dataclasses
-from enum import Enum
 from typing import Union
 
+from flet.core.enumerations import ExtendedEnum
 
-class Axis(Enum):
+
+class Axis(ExtendedEnum):
     HORIZONTAL = "horizontal"
     VERTICAL = "vertical"
 

--- a/sdk/python/packages/flet/src/flet/core/animated_switcher.py
+++ b/sdk/python/packages/flet/src/flet/core/animated_switcher.py
@@ -1,10 +1,10 @@
-from enum import Enum
 from typing import Any, Optional, Union
 
 from flet.core.animation import AnimationCurve, AnimationValue
 from flet.core.badge import BadgeValue
 from flet.core.constrained_control import ConstrainedControl
 from flet.core.control import Control, OptionalNumber
+from flet.core.enumerations import ExtendedEnum
 from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
@@ -23,7 +23,7 @@ except ImportError:
 TransitionValueString = Literal["fade", "rotation", "scale"]
 
 
-class AnimatedSwitcherTransition(Enum):
+class AnimatedSwitcherTransition(ExtendedEnum):
     FADE = "fade"
     ROTATION = "rotation"
     SCALE = "scale"

--- a/sdk/python/packages/flet/src/flet/core/animated_switcher.py
+++ b/sdk/python/packages/flet/src/flet/core/animated_switcher.py
@@ -202,7 +202,7 @@ class AnimatedSwitcher(ConstrainedControl):
     @switch_in_curve.setter
     def switch_in_curve(self, value: Optional[AnimationCurve]):
         self.__switch_in_curve = value
-        self._set_enum_attr("switchInCurve", value, AnimationCurve)
+        self._set_attr("switchInCurve", value)
 
     # switch_out_curve
     @property
@@ -212,7 +212,7 @@ class AnimatedSwitcher(ConstrainedControl):
     @switch_out_curve.setter
     def switch_out_curve(self, value: Optional[AnimationCurve]):
         self.__switch_out_curve = value
-        self._set_enum_attr("switchOutCurve", value, AnimationCurve)
+        self._set_attr("switchOutCurve", value)
 
     # transition
     @property
@@ -222,4 +222,4 @@ class AnimatedSwitcher(ConstrainedControl):
     @transition.setter
     def transition(self, value: Optional[AnimatedSwitcherTransition]):
         self.__transition = value
-        self._set_enum_attr("transition", value, AnimatedSwitcherTransition)
+        self._set_attr("transition", value)

--- a/sdk/python/packages/flet/src/flet/core/animation.py
+++ b/sdk/python/packages/flet/src/flet/core/animation.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
-from enum import Enum
 from typing import Optional, Union
 
+from flet.core.enumerations import ExtendedEnum
 from flet.core.types import DurationValue
 
 try:
@@ -10,7 +10,7 @@ except ImportError:
     from typing_extensions import Literal
 
 
-class AnimationCurve(Enum):
+class AnimationCurve(ExtendedEnum):
     BOUNCE_IN = "bounceIn"
     BOUNCE_IN_OUT = "bounceInOut"
     BOUNCE_OUT = "bounceOut"

--- a/sdk/python/packages/flet/src/flet/core/app_bar.py
+++ b/sdk/python/packages/flet/src/flet/core/app_bar.py
@@ -5,7 +5,7 @@ from flet.core.buttons import OutlinedBorder
 from flet.core.control import Control
 from flet.core.ref import Ref
 from flet.core.text_style import TextStyle
-from flet.core.types import ClipBehavior, ColorEnums, ColorValue, OptionalNumber
+from flet.core.types import ClipBehavior, ColorValue, OptionalNumber
 
 
 class AppBar(AdaptiveControl):
@@ -258,7 +258,7 @@ class AppBar(AdaptiveControl):
     @color.setter
     def color(self, value: Optional[ColorValue]):
         self.__color = value
-        self._set_enum_attr("color", value, ColorEnums)
+        self._set_attr("color", value)
 
     # bgcolor
     @property
@@ -268,7 +268,7 @@ class AppBar(AdaptiveControl):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgcolor", value, ColorEnums)
+        self._set_attr("bgcolor", value)
 
     # shadow_color
     @property
@@ -278,7 +278,7 @@ class AppBar(AdaptiveControl):
     @shadow_color.setter
     def shadow_color(self, value: Optional[ColorValue]):
         self.__shadow_color = value
-        self._set_enum_attr("shadowColor", value, ColorEnums)
+        self._set_attr("shadowColor", value)
 
     # surface_tint_color
     @property
@@ -288,7 +288,7 @@ class AppBar(AdaptiveControl):
     @surface_tint_color.setter
     def surface_tint_color(self, value: Optional[ColorValue]):
         self.__surface_tint_color = value
-        self._set_enum_attr("surfaceTintColor", value, ColorEnums)
+        self._set_attr("surfaceTintColor", value)
 
     # is_secondary
     @property
@@ -348,7 +348,7 @@ class AppBar(AdaptiveControl):
 
     @clip_behavior.setter
     def clip_behavior(self, value: Optional[ClipBehavior]):
-        self._set_enum_attr("clipBehavior", value, ClipBehavior)
+        self._set_attr("clipBehavior", value)
 
     # actions
     @property

--- a/sdk/python/packages/flet/src/flet/core/audio.py
+++ b/sdk/python/packages/flet/src/flet/core/audio.py
@@ -1,21 +1,21 @@
-from enum import Enum
 from typing import Any, Optional
 
 from flet.core.control import Control, OptionalNumber
 from flet.core.control_event import ControlEvent
+from flet.core.enumerations import ExtendedEnum
 from flet.core.event_handler import EventHandler
 from flet.core.ref import Ref
 from flet.core.types import OptionalControlEventCallable, OptionalEventCallable
 from flet.utils import deprecated
 
 
-class ReleaseMode(Enum):
+class ReleaseMode(ExtendedEnum):
     RELEASE = "release"
     LOOP = "loop"
     STOP = "stop"
 
 
-class AudioState(Enum):
+class AudioState(ExtendedEnum):
     STOPPED = "stopped"
     PLAYING = "playing"
     PAUSED = "paused"

--- a/sdk/python/packages/flet/src/flet/core/audio.py
+++ b/sdk/python/packages/flet/src/flet/core/audio.py
@@ -279,7 +279,7 @@ class Audio(Control):
 
     @release_mode.setter
     def release_mode(self, value: Optional[ReleaseMode]):
-        self._set_enum_attr("releaseMode", value, ReleaseMode)
+        self._set_attr("releaseMode", value)
 
     # on_loaded
     @property

--- a/sdk/python/packages/flet/src/flet/core/audio_recorder.py
+++ b/sdk/python/packages/flet/src/flet/core/audio_recorder.py
@@ -249,7 +249,7 @@ class AudioRecorder(Control):
 
     @audio_encoder.setter
     def audio_encoder(self, value: Optional[AudioEncoder]):
-        self._set_enum_attr("audioEncoder", value, AudioEncoder)
+        self._set_attr("audioEncoder", value)
 
     # suppress_noise
     @property

--- a/sdk/python/packages/flet/src/flet/core/audio_recorder.py
+++ b/sdk/python/packages/flet/src/flet/core/audio_recorder.py
@@ -1,16 +1,16 @@
 import json
-from enum import Enum
 from typing import Any, Optional
 
 from flet.core.control import Control, OptionalNumber
 from flet.core.control_event import ControlEvent
+from flet.core.enumerations import ExtendedEnum
 from flet.core.event_handler import EventHandler
 from flet.core.ref import Ref
 from flet.core.types import OptionalEventCallable
 from flet.utils import deprecated
 
 
-class AudioRecorderState(Enum):
+class AudioRecorderState(ExtendedEnum):
     STOPPED = "stopped"
     RECORDING = "recording"
     PAUSED = "paused"
@@ -22,7 +22,7 @@ class AudioRecorderStateChangeEvent(ControlEvent):
         self.state: AudioRecorderState = AudioRecorderState(e.data)
 
 
-class AudioEncoder(Enum):
+class AudioEncoder(ExtendedEnum):
     AACLC = "aacLc"
     AACELD = "aacEld"
     AACHE = "aacHe"

--- a/sdk/python/packages/flet/src/flet/core/autofill_group.py
+++ b/sdk/python/packages/flet/src/flet/core/autofill_group.py
@@ -136,4 +136,4 @@ class AutofillGroup(Control):
     @dispose_action.setter
     def dispose_action(self, value: Optional[AutofillGroupDisposeAction]):
         self.__dispose_action = value
-        self._set_enum_attr("disposeAction", value, AutofillGroupDisposeAction)
+        self._set_attr("disposeAction", value)

--- a/sdk/python/packages/flet/src/flet/core/autofill_group.py
+++ b/sdk/python/packages/flet/src/flet/core/autofill_group.py
@@ -1,11 +1,11 @@
-from enum import Enum
 from typing import Any, Optional
 
 from flet.core.control import Control
+from flet.core.enumerations import ExtendedEnum
 from flet.core.ref import Ref
 
 
-class AutofillHint(Enum):
+class AutofillHint(ExtendedEnum):
     ADDRESS_CITY = "addressCity"
     ADDRESS_CITY_AND_STATE = "addressCityAndState"
     ADDRESS_STATE = "addressState"
@@ -74,7 +74,7 @@ class AutofillHint(Enum):
     USERNAME = "username"
 
 
-class AutofillGroupDisposeAction(Enum):
+class AutofillGroupDisposeAction(ExtendedEnum):
     COMMIT = "commit"
     CANCEL = "cancel"
 

--- a/sdk/python/packages/flet/src/flet/core/banner.py
+++ b/sdk/python/packages/flet/src/flet/core/banner.py
@@ -4,7 +4,6 @@ from flet.core.control import Control, OptionalNumber
 from flet.core.ref import Ref
 from flet.core.text_style import TextStyle
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
     MarginValue,
     OptionalControlEventCallable,
@@ -221,7 +220,7 @@ class Banner(Control):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgColor", value, ColorEnums)
+        self._set_attr("bgColor", value)
 
     # content_text_style
     @property
@@ -240,7 +239,7 @@ class Banner(Control):
     @shadow_color.setter
     def shadow_color(self, value: Optional[ColorValue]):
         self.__shadow_color = value
-        self._set_enum_attr("shadowColor", value, ColorEnums)
+        self._set_attr("shadowColor", value)
 
     # surface_tint_color
     @property
@@ -250,7 +249,7 @@ class Banner(Control):
     @surface_tint_color.setter
     def surface_tint_color(self, value: Optional[ColorValue]):
         self.__surface_tint_color = value
-        self._set_enum_attr("surfaceTintColor", value, ColorEnums)
+        self._set_attr("surfaceTintColor", value)
 
     # divider_color
     @property
@@ -260,7 +259,7 @@ class Banner(Control):
     @divider_color.setter
     def divider_color(self, value: Optional[ColorValue]):
         self.__divider_color = value
-        self._set_enum_attr("dividerColor", value, ColorEnums)
+        self._set_attr("dividerColor", value)
 
     # elevation
     @property

--- a/sdk/python/packages/flet/src/flet/core/blur.py
+++ b/sdk/python/packages/flet/src/flet/core/blur.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass, field
-from enum import Enum
+
+from flet.core.enumerations import ExtendedEnum
 
 
-class BlurTileMode(Enum):
+class BlurTileMode(ExtendedEnum):
     CLAMP = "clamp"
     DECAL = "decal"
     MIRROR = "mirror"

--- a/sdk/python/packages/flet/src/flet/core/bottom_app_bar.py
+++ b/sdk/python/packages/flet/src/flet/core/bottom_app_bar.py
@@ -6,7 +6,6 @@ from flet.core.control import Control, OptionalNumber
 from flet.core.ref import Ref
 from flet.core.types import (
     ClipBehavior,
-    ColorEnums,
     ColorValue,
     NotchShape,
     OffsetValue,
@@ -136,7 +135,7 @@ class BottomAppBar(ConstrainedControl):
     @surface_tint_color.setter
     def surface_tint_color(self, value: Optional[ColorValue]):
         self.__surface_tint_color = value
-        self._set_enum_attr("surfaceTintColor", value, ColorEnums)
+        self._set_attr("surfaceTintColor", value)
 
     # bgcolor
     @property
@@ -146,7 +145,7 @@ class BottomAppBar(ConstrainedControl):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgcolor", value, ColorEnums)
+        self._set_attr("bgcolor", value)
 
     # shadow_color
     @property
@@ -156,7 +155,7 @@ class BottomAppBar(ConstrainedControl):
     @shadow_color.setter
     def shadow_color(self, value: Optional[ColorValue]):
         self.__shadow_color = value
-        self._set_enum_attr("shadowColor", value, ColorEnums)
+        self._set_attr("shadowColor", value)
 
     # padding
     @property
@@ -175,7 +174,7 @@ class BottomAppBar(ConstrainedControl):
     @shape.setter
     def shape(self, value: Optional[NotchShape]):
         self.__shape = value
-        self._set_enum_attr("shape", value, NotchShape)
+        self._set_attr("shape", value)
 
     # clip_behavior
     @property
@@ -185,7 +184,7 @@ class BottomAppBar(ConstrainedControl):
     @clip_behavior.setter
     def clip_behavior(self, value: Optional[ClipBehavior]):
         self.__clip_behavior = value
-        self._set_enum_attr("clipBehavior", value, ClipBehavior)
+        self._set_attr("clipBehavior", value)
 
     # notch_margin
     @property

--- a/sdk/python/packages/flet/src/flet/core/bottom_sheet.py
+++ b/sdk/python/packages/flet/src/flet/core/bottom_sheet.py
@@ -2,7 +2,7 @@ from typing import Any, Optional
 
 from flet.core.control import Control, OptionalNumber
 from flet.core.ref import Ref
-from flet.core.types import ColorEnums, ColorValue, OptionalControlEventCallable
+from flet.core.types import ColorValue, OptionalControlEventCallable
 
 
 class BottomSheet(Control):
@@ -122,7 +122,7 @@ class BottomSheet(Control):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgColor", value, ColorEnums)
+        self._set_attr("bgColor", value)
 
     # dismissible
     @property

--- a/sdk/python/packages/flet/src/flet/core/box.py
+++ b/sdk/python/packages/flet/src/flet/core/box.py
@@ -1,9 +1,9 @@
 from dataclasses import dataclass, field
-from enum import Enum
 from typing import List, Optional, Union
 
 from flet.core.alignment import Alignment
 from flet.core.border import Border
+from flet.core.enumerations import ExtendedEnum
 from flet.core.gradients import Gradient
 from flet.core.types import (
     BlendMode,
@@ -23,14 +23,14 @@ class ColorFilter:
     blend_mode: Optional[BlendMode] = None
 
 
-class FilterQuality(Enum):
+class FilterQuality(ExtendedEnum):
     NONE = "none"
     LOW = "low"
     MEDIUM = "medium"
     HIGH = "high"
 
 
-class ShadowBlurStyle(Enum):
+class ShadowBlurStyle(ExtendedEnum):
     NORMAL = "normal"
     SOLID = "solid"
     OUTER = "outer"
@@ -46,7 +46,7 @@ class BoxShadow:
     blur_style: ShadowBlurStyle = field(default=ShadowBlurStyle.NORMAL)
 
 
-class BoxShape(Enum):
+class BoxShape(ExtendedEnum):
     RECTANGLE = "rectangle"
     CIRCLE = "circle"
 

--- a/sdk/python/packages/flet/src/flet/core/canvas/color.py
+++ b/sdk/python/packages/flet/src/flet/core/canvas/color.py
@@ -1,7 +1,7 @@
 from typing import Any, Optional
 
 from flet.core.canvas.shape import Shape
-from flet.core.types import BlendMode, ColorEnums, ColorValue
+from flet.core.types import BlendMode, ColorValue
 
 
 class Color(Shape):
@@ -36,7 +36,7 @@ class Color(Shape):
     @color.setter
     def color(self, value: Optional[ColorValue]):
         self.__color = value
-        self._set_enum_attr("color", value, ColorEnums)
+        self._set_attr("color", value)
 
     # blend_mode
     @property

--- a/sdk/python/packages/flet/src/flet/core/canvas/points.py
+++ b/sdk/python/packages/flet/src/flet/core/canvas/points.py
@@ -1,12 +1,12 @@
-from enum import Enum
 from typing import Any, List, Optional
 
 from flet.core.canvas.shape import Shape
+from flet.core.enumerations import ExtendedEnum
 from flet.core.painting import Paint
 from flet.core.types import OffsetValue
 
 
-class PointMode(Enum):
+class PointMode(ExtendedEnum):
     POINTS = "points"
     LINES = "lines"
     POLYGON = "polygon"

--- a/sdk/python/packages/flet/src/flet/core/canvas/shadow.py
+++ b/sdk/python/packages/flet/src/flet/core/canvas/shadow.py
@@ -3,7 +3,7 @@ from typing import Any, List, Optional
 from flet.core.canvas.path import Path
 from flet.core.canvas.shape import Shape
 from flet.core.control import OptionalNumber
-from flet.core.types import ColorEnums, ColorValue
+from flet.core.types import ColorValue
 
 
 class Shadow(Shape):
@@ -52,7 +52,7 @@ class Shadow(Shape):
     @color.setter
     def color(self, value: Optional[ColorValue]):
         self.__color = value
-        self._set_enum_attr("color", value, ColorEnums)
+        self._set_attr("color", value)
 
     # elevation
     @property

--- a/sdk/python/packages/flet/src/flet/core/card.py
+++ b/sdk/python/packages/flet/src/flet/core/card.py
@@ -11,7 +11,6 @@ from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
     ClipBehavior,
-    ColorEnums,
     ColorValue,
     MarginValue,
     OffsetValue,
@@ -204,7 +203,7 @@ class Card(ConstrainedControl, AdaptiveControl):
     @color.setter
     def color(self, value):
         self.__color = value
-        self._set_enum_attr("color", value, ColorEnums)
+        self._set_attr("color", value)
 
     # shadow_color
     @property
@@ -214,7 +213,7 @@ class Card(ConstrainedControl, AdaptiveControl):
     @shadow_color.setter
     def shadow_color(self, value):
         self.__shadow_color = value
-        self._set_enum_attr("shadowColor", value, ColorEnums)
+        self._set_attr("shadowColor", value)
 
     # surface_tint_color
     @property
@@ -224,7 +223,7 @@ class Card(ConstrainedControl, AdaptiveControl):
     @surface_tint_color.setter
     def surface_tint_color(self, value):
         self.__surface_tint_color = value
-        self._set_enum_attr("surfaceTintColor", value, ColorEnums)
+        self._set_attr("surfaceTintColor", value)
 
     # shape
     @property
@@ -252,7 +251,7 @@ class Card(ConstrainedControl, AdaptiveControl):
     @clip_behavior.setter
     def clip_behavior(self, value: Optional[ClipBehavior]):
         self.__clip_behavior = value
-        self._set_enum_attr("clipBehavior", value, ClipBehavior)
+        self._set_attr("clipBehavior", value)
 
     # is_semantic_container
     @property
@@ -282,4 +281,4 @@ class Card(ConstrainedControl, AdaptiveControl):
     @variant.setter
     def variant(self, value: Optional[CardVariant]):
         self.__variant = value
-        self._set_enum_attr("variant", value, CardVariant)
+        self._set_attr("variant", value)

--- a/sdk/python/packages/flet/src/flet/core/card.py
+++ b/sdk/python/packages/flet/src/flet/core/card.py
@@ -1,4 +1,3 @@
-from enum import Enum
 from typing import Any, Optional, Union
 
 from flet.core.adaptive_control import AdaptiveControl
@@ -7,6 +6,7 @@ from flet.core.badge import BadgeValue
 from flet.core.buttons import OutlinedBorder
 from flet.core.constrained_control import ConstrainedControl
 from flet.core.control import Control, OptionalNumber
+from flet.core.enumerations import ExtendedEnum
 from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
@@ -21,7 +21,7 @@ from flet.core.types import (
 )
 
 
-class CardVariant(Enum):
+class CardVariant(ExtendedEnum):
     ELEVATED = "elevated"
     FILLED = "filled"
     OUTLINED = "outlined"

--- a/sdk/python/packages/flet/src/flet/core/charts/bar_chart.py
+++ b/sdk/python/packages/flet/src/flet/core/charts/bar_chart.py
@@ -1,5 +1,4 @@
 import json
-from enum import Enum
 from typing import Any, List, Optional, Union
 
 from flet.core.animation import AnimationValue
@@ -11,6 +10,7 @@ from flet.core.charts.chart_grid_lines import ChartGridLines
 from flet.core.constrained_control import ConstrainedControl
 from flet.core.control import OptionalNumber
 from flet.core.control_event import ControlEvent
+from flet.core.enumerations import ExtendedEnum
 from flet.core.event_handler import EventHandler
 from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
@@ -26,7 +26,7 @@ from flet.core.types import (
 )
 
 
-class TooltipDirection(Enum):
+class TooltipDirection(ExtendedEnum):
     AUTO = "auto"
     TOP = "top"
     BOTTOM = "bottom"

--- a/sdk/python/packages/flet/src/flet/core/charts/bar_chart.py
+++ b/sdk/python/packages/flet/src/flet/core/charts/bar_chart.py
@@ -15,7 +15,6 @@ from flet.core.event_handler import EventHandler
 from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
     OffsetValue,
     OptionalControlEventCallable,
@@ -221,7 +220,7 @@ class BarChart(ConstrainedControl):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgcolor", value, ColorEnums)
+        self._set_attr("bgcolor", value)
 
     # interactive
     @property
@@ -240,7 +239,7 @@ class BarChart(ConstrainedControl):
     @tooltip_bgcolor.setter
     def tooltip_bgcolor(self, value: Optional[str]):
         self.__tooltip_bgcolor = value
-        self._set_enum_attr("tooltipBgcolor", value, ColorEnums)
+        self._set_attr("tooltipBgcolor", value)
 
     # border
     @property
@@ -412,7 +411,7 @@ class BarChart(ConstrainedControl):
     @tooltip_direction.setter
     def tooltip_direction(self, value: Optional[TooltipDirection]):
         self.__tooltip_direction = value
-        self._set_enum_attr("tooltipDirection", value, TooltipDirection)
+        self._set_attr("tooltipDirection", value)
 
     # on_chart_event
     @property

--- a/sdk/python/packages/flet/src/flet/core/charts/bar_chart_rod.py
+++ b/sdk/python/packages/flet/src/flet/core/charts/bar_chart_rod.py
@@ -7,7 +7,7 @@ from flet.core.control import Control, OptionalNumber
 from flet.core.gradients import Gradient
 from flet.core.ref import Ref
 from flet.core.text_style import TextStyle
-from flet.core.types import BorderRadiusValue, ColorEnums, ColorValue, TextAlign
+from flet.core.types import BorderRadiusValue, ColorValue, TextAlign
 
 
 class BarChartRod(Control):
@@ -124,7 +124,7 @@ class BarChartRod(Control):
     @color.setter
     def color(self, value: Optional[ColorValue]):
         self.__color = value
-        self._set_enum_attr("color", value, ColorEnums)
+        self._set_attr("color", value)
 
     # border_side
     @property
@@ -179,7 +179,7 @@ class BarChartRod(Control):
     @bg_color.setter
     def bg_color(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgColor", value, ColorEnums)
+        self._set_attr("bgColor", value)
 
     # bg_gradient
     @property

--- a/sdk/python/packages/flet/src/flet/core/charts/bar_chart_rod_stack_item.py
+++ b/sdk/python/packages/flet/src/flet/core/charts/bar_chart_rod_stack_item.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 from flet.core.border import BorderSide
 from flet.core.control import Control, OptionalNumber
 from flet.core.ref import Ref
-from flet.core.types import ColorEnums, ColorValue
+from flet.core.types import ColorValue
 
 
 class BarChartRodStackItem(Control):
@@ -68,7 +68,7 @@ class BarChartRodStackItem(Control):
     @color.setter
     def color(self, value: Optional[ColorValue]):
         self.__color = value
-        self._set_enum_attr("color", value, ColorEnums)
+        self._set_attr("color", value)
 
     # border_side
     @property

--- a/sdk/python/packages/flet/src/flet/core/charts/chart_point_shape.py
+++ b/sdk/python/packages/flet/src/flet/core/charts/chart_point_shape.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional
 
 from flet.core.types import ColorValue, OptionalNumber

--- a/sdk/python/packages/flet/src/flet/core/charts/line_chart.py
+++ b/sdk/python/packages/flet/src/flet/core/charts/line_chart.py
@@ -14,7 +14,6 @@ from flet.core.event_handler import EventHandler
 from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
     OffsetValue,
     OptionalControlEventCallable,
@@ -215,7 +214,7 @@ class LineChart(ConstrainedControl):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgcolor", value, ColorEnums)
+        self._set_attr("bgcolor", value)
 
     # interactive
     @property
@@ -252,7 +251,7 @@ class LineChart(ConstrainedControl):
     @tooltip_bgcolor.setter
     def tooltip_bgcolor(self, value: Optional[str]):
         self.__tooltip_bgcolor = value
-        self._set_enum_attr("tooltipBgcolor", value, ColorEnums)
+        self._set_attr("tooltipBgcolor", value)
 
     # border
     @property

--- a/sdk/python/packages/flet/src/flet/core/charts/line_chart_data.py
+++ b/sdk/python/packages/flet/src/flet/core/charts/line_chart_data.py
@@ -7,7 +7,7 @@ from flet.core.charts.line_chart_data_point import LineChartDataPoint
 from flet.core.control import Control, OptionalNumber
 from flet.core.gradients import Gradient
 from flet.core.ref import Ref
-from flet.core.types import ColorEnums, ColorValue
+from flet.core.types import ColorValue
 
 
 class LineChartData(Control):
@@ -129,7 +129,7 @@ class LineChartData(Control):
     @color.setter
     def color(self, value: Optional[ColorValue]):
         self.__color = value
-        self._set_enum_attr("color", value, ColorEnums)
+        self._set_attr("color", value)
 
     # gradient
     @property
@@ -213,7 +213,7 @@ class LineChartData(Control):
     @above_line_bgcolor.setter
     def above_line_bgcolor(self, value: Optional[str]):
         self.__above_line_bgcolor = value
-        self._set_enum_attr("aboveLineBgcolor", value, ColorEnums)
+        self._set_attr("aboveLineBgcolor", value)
 
     # above_line_gradient
     @property
@@ -250,7 +250,7 @@ class LineChartData(Control):
     @below_line_bgcolor.setter
     def below_line_bgcolor(self, value: Optional[str]):
         self.__below_line_bgcolor = value
-        self._set_enum_attr("belowLineBgcolor", value, ColorEnums)
+        self._set_attr("belowLineBgcolor", value)
 
     # below_line_gradient
     @property

--- a/sdk/python/packages/flet/src/flet/core/charts/pie_chart.py
+++ b/sdk/python/packages/flet/src/flet/core/charts/pie_chart.py
@@ -1,5 +1,4 @@
 import json
-from enum import Enum
 from typing import Any, List, Optional, Union
 
 from flet.core.animation import AnimationValue
@@ -8,6 +7,7 @@ from flet.core.charts.pie_chart_section import PieChartSection
 from flet.core.constrained_control import ConstrainedControl
 from flet.core.control import OptionalNumber
 from flet.core.control_event import ControlEvent
+from flet.core.enumerations import ExtendedEnum
 from flet.core.event_handler import EventHandler
 from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
@@ -184,7 +184,7 @@ class PieChart(ConstrainedControl):
         self._set_attr("onChartEvent", True if handler is not None else None)
 
 
-class PieChartEventType(Enum):
+class PieChartEventType(ExtendedEnum):
     POINTER_ENTER = "pointerEnter"
     POINTER_EXIT = "pointerExit"
     POINTER_HOVER = "pointerHover"

--- a/sdk/python/packages/flet/src/flet/core/charts/pie_chart.py
+++ b/sdk/python/packages/flet/src/flet/core/charts/pie_chart.py
@@ -12,7 +12,6 @@ from flet.core.event_handler import EventHandler
 from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
     OffsetValue,
     OptionalControlEventCallable,
@@ -136,7 +135,7 @@ class PieChart(ConstrainedControl):
     @center_space_color.setter
     def center_space_color(self, value: Optional[ColorValue]):
         self.__center_space_color = value
-        self._set_enum_attr("centerSpaceColor", value, ColorEnums)
+        self._set_attr("centerSpaceColor", value)
 
     # center_space_radius
     @property

--- a/sdk/python/packages/flet/src/flet/core/charts/pie_chart_section.py
+++ b/sdk/python/packages/flet/src/flet/core/charts/pie_chart_section.py
@@ -4,7 +4,7 @@ from flet.core.border import BorderSide
 from flet.core.control import Control, OptionalNumber
 from flet.core.ref import Ref
 from flet.core.text_style import TextStyle
-from flet.core.types import ColorEnums, ColorValue
+from flet.core.types import ColorValue
 
 
 class PieChartSection(Control):
@@ -96,7 +96,7 @@ class PieChartSection(Control):
     @color.setter
     def color(self, value: Optional[ColorValue]):
         self.__color = value
-        self._set_enum_attr("color", value, ColorEnums)
+        self._set_attr("color", value)
 
     # badge
     @property

--- a/sdk/python/packages/flet/src/flet/core/checkbox.py
+++ b/sdk/python/packages/flet/src/flet/core/checkbox.py
@@ -11,7 +11,6 @@ from flet.core.ref import Ref
 from flet.core.text_style import TextStyle
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
     ControlStateValue,
     LabelPosition,
@@ -222,7 +221,7 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
     @label_position.setter
     def label_position(self, value: Optional[LabelPosition]):
         self.__label_position = value
-        self._set_enum_attr("labelPosition", value, LabelPosition)
+        self._set_attr("labelPosition", value)
 
     # mouse_cursor
     @property
@@ -232,7 +231,7 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
     @mouse_cursor.setter
     def mouse_cursor(self, value: Optional[MouseCursor]):
         self.__mouse_cursor = value
-        self._set_enum_attr("mouseCursor", value, MouseCursor)
+        self._set_attr("mouseCursor", value)
 
     # visual_density
     @property
@@ -242,7 +241,7 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
     @visual_density.setter
     def visual_density(self, value: Union[None, ThemeVisualDensity, VisualDensity]):
         self.__visual_density = value
-        self._set_enum_attr("visualDensity", value, (ThemeVisualDensity, VisualDensity))
+        self._set_attr("visualDensity", value)
 
     # autofocus
     @property
@@ -261,7 +260,7 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
     @check_color.setter
     def check_color(self, value: Optional[ColorValue]):
         self.__check_color = value
-        self._set_enum_attr("checkColor", value, ColorEnums)
+        self._set_attr("checkColor", value)
 
     # active_color
     @property
@@ -271,7 +270,7 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
     @active_color.setter
     def active_color(self, value: Optional[ColorValue]):
         self.__active_color = value
-        self._set_enum_attr("activeColor", value, ColorEnums)
+        self._set_attr("activeColor", value)
 
     # focus_color
     @property
@@ -281,7 +280,7 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
     @focus_color.setter
     def focus_color(self, value: Optional[ColorValue]):
         self.__focus_color = value
-        self._set_enum_attr("focusColor", value, ColorEnums)
+        self._set_attr("focusColor", value)
 
     # hover_color
     @property
@@ -291,7 +290,7 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
     @hover_color.setter
     def hover_color(self, value: Optional[ColorValue]):
         self.__hover_color = value
-        self._set_enum_attr("hoverColor", value, ColorEnums)
+        self._set_attr("hoverColor", value)
 
     # fill_color
     @property

--- a/sdk/python/packages/flet/src/flet/core/chip.py
+++ b/sdk/python/packages/flet/src/flet/core/chip.py
@@ -11,7 +11,6 @@ from flet.core.text_style import TextStyle
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
     ClipBehavior,
-    ColorEnums,
     ColorValue,
     ControlStateValue,
     OffsetValue,
@@ -313,7 +312,7 @@ class Chip(ConstrainedControl):
     @delete_icon_color.setter
     def delete_icon_color(self, value: Optional[ColorValue]):
         self.__delete_icon_color = value
-        self._set_enum_attr("deleteIconColor", value, ColorEnums)
+        self._set_attr("deleteIconColor", value)
 
     # disabled_color
     @property
@@ -323,7 +322,7 @@ class Chip(ConstrainedControl):
     @disabled_color.setter
     def disabled_color(self, value: Optional[ColorValue]):
         self.__disabled_color = value
-        self._set_enum_attr("disabledColor", value, ColorEnums)
+        self._set_attr("disabledColor", value)
 
     # color
     @property
@@ -351,7 +350,7 @@ class Chip(ConstrainedControl):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgcolor", value, ColorEnums)
+        self._set_attr("bgcolor", value)
 
     # check_color
     @property
@@ -361,7 +360,7 @@ class Chip(ConstrainedControl):
     @check_color.setter
     def check_color(self, value: Optional[ColorValue]):
         self.__check_color = value
-        self._set_enum_attr("checkColor", value, ColorEnums)
+        self._set_attr("checkColor", value)
 
     # selected_color
     @property
@@ -371,7 +370,7 @@ class Chip(ConstrainedControl):
     @selected_color.setter
     def selected_color(self, value: Optional[ColorValue]):
         self.__selected_color = value
-        self._set_enum_attr("selectedColor", value, ColorEnums)
+        self._set_attr("selectedColor", value)
 
     # selected_shadow_color
     @property
@@ -381,7 +380,7 @@ class Chip(ConstrainedControl):
     @selected_shadow_color.setter
     def selected_shadow_color(self, value: Optional[ColorValue]):
         self.__selected_shadow_color = value
-        self._set_enum_attr("selectedShadowColor", value, ColorEnums)
+        self._set_attr("selectedShadowColor", value)
 
     # surface_tint_color
     @property
@@ -391,7 +390,7 @@ class Chip(ConstrainedControl):
     @surface_tint_color.setter
     def surface_tint_color(self, value: Optional[ColorValue]):
         self.__surface_tint_color = value
-        self._set_enum_attr("surfaceTintColor", value, ColorEnums)
+        self._set_attr("surfaceTintColor", value)
 
     # shadow_color
     @property
@@ -401,7 +400,7 @@ class Chip(ConstrainedControl):
     @shadow_color.setter
     def shadow_color(self, value: Optional[ColorValue]):
         self.__shadow_color = value
-        self._set_enum_attr("shadowColor", value, ColorEnums)
+        self._set_attr("shadowColor", value)
 
     # elevation
     @property
@@ -438,7 +437,7 @@ class Chip(ConstrainedControl):
     @visual_density.setter
     def visual_density(self, value: Union[None, ThemeVisualDensity, VisualDensity]):
         self.__visual_density = value
-        self._set_enum_attr("visualDensity", value, (ThemeVisualDensity, VisualDensity))
+        self._set_attr("visualDensity", value)
 
     # clip_behavior
     @property
@@ -448,7 +447,7 @@ class Chip(ConstrainedControl):
     @clip_behavior.setter
     def clip_behavior(self, value: Optional[ClipBehavior]):
         self.__clip_behavior = value
-        self._set_enum_attr("clipBehavior", value, ClipBehavior)
+        self._set_attr("clipBehavior", value)
 
     # border_side
     @property

--- a/sdk/python/packages/flet/src/flet/core/circle_avatar.py
+++ b/sdk/python/packages/flet/src/flet/core/circle_avatar.py
@@ -1,4 +1,3 @@
-import warnings
 from typing import Any, Optional, Union
 
 from flet.core.animation import AnimationValue
@@ -8,7 +7,6 @@ from flet.core.control import Control, OptionalNumber
 from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
     OffsetValue,
     OptionalControlEventCallable,
@@ -273,7 +271,7 @@ class CircleAvatar(ConstrainedControl):
     @color.setter
     def color(self, value: Optional[ColorValue]):
         self.__color = value
-        self._set_enum_attr("color", value, ColorEnums)
+        self._set_attr("color", value)
 
     # bgcolor
     @property
@@ -283,7 +281,7 @@ class CircleAvatar(ConstrainedControl):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgcolor", value, ColorEnums)
+        self._set_attr("bgcolor", value)
 
     # content
     @property

--- a/sdk/python/packages/flet/src/flet/core/circle_avatar.py
+++ b/sdk/python/packages/flet/src/flet/core/circle_avatar.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any, Optional, Union
 
 from flet.core.animation import AnimationValue

--- a/sdk/python/packages/flet/src/flet/core/colors.py
+++ b/sdk/python/packages/flet/src/flet/core/colors.py
@@ -40,6 +40,8 @@ from enum import Enum, EnumMeta
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
 from warnings import warn
 
+from flet.core.enumerations import ExtendedEnum
+
 if TYPE_CHECKING:
     from flet.core.types import ColorValue
 
@@ -58,7 +60,7 @@ class ColorsDeprecated(EnumMeta):
         return EnumMeta.__getattribute__(self, item)
 
 
-class colors(str, Enum, metaclass=ColorsDeprecated):
+class colors(ExtendedEnum, metaclass=ColorsDeprecated):
     @staticmethod
     @deprecated(
         reason="Use Colors.with_opacity() method instead.",
@@ -425,7 +427,7 @@ class colors(str, Enum, metaclass=ColorsDeprecated):
     GREY_900 = "grey900"
 
 
-class Colors(str, Enum):
+class Colors(ExtendedEnum):
     @staticmethod
     def with_opacity(opacity: Union[int, float], color: "ColorValue") -> str:
         assert 0 <= opacity <= 1, "opacity must be between 0 and 1"
@@ -792,3 +794,6 @@ class Colors(str, Enum):
     GREY_700 = "grey700"
     GREY_800 = "grey800"
     GREY_900 = "grey900"
+
+
+MaterialColorsEnums = Union[colors, Colors]

--- a/sdk/python/packages/flet/src/flet/core/column.py
+++ b/sdk/python/packages/flet/src/flet/core/column.py
@@ -204,7 +204,7 @@ class Column(ConstrainedControl, ScrollableControl, AdaptiveControl):
     @horizontal_alignment.setter
     def horizontal_alignment(self, value: CrossAxisAlignment):
         self.__horizontal_alignment = value
-        self._set_enum_attr("horizontalAlignment", value, CrossAxisAlignment)
+        self._set_attr("horizontalAlignment", value)
 
     # spacing
     @property

--- a/sdk/python/packages/flet/src/flet/core/container.py
+++ b/sdk/python/packages/flet/src/flet/core/container.py
@@ -27,7 +27,6 @@ from flet.core.types import (
     BlendMode,
     BorderRadiusValue,
     ClipBehavior,
-    ColorEnums,
     ColorValue,
     ImageFit,
     ImageRepeat,
@@ -300,13 +299,13 @@ class Container(ConstrainedControl, AdaptiveControl):
 
     # bgcolor
     @property
-    def bgcolor(self):
+    def bgcolor(self) -> Optional[ColorValue]:
         return self.__bgcolor
 
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgColor", value, ColorEnums)
+        self._set_attr("bgColor", value)
 
     # gradient
     @property
@@ -325,7 +324,7 @@ class Container(ConstrainedControl, AdaptiveControl):
     @blend_mode.setter
     def blend_mode(self, value: Optional[BlendMode]):
         self.__blend_mode = value
-        self._set_enum_attr("blendMode", value, BlendMode)
+        self._set_attr("blendMode", value)
 
     # blur
     @property
@@ -446,7 +445,7 @@ class Container(ConstrainedControl, AdaptiveControl):
     @image_fit.setter
     def image_fit(self, value: Optional[ImageFit]):
         self.__image_fit = value
-        self._set_enum_attr("imageFit", value, ImageFit)
+        self._set_attr("imageFit", value)
         if value is not None:
             warnings.warn(
                 f"image_fit is deprecated since version 0.24.0 "
@@ -469,7 +468,7 @@ class Container(ConstrainedControl, AdaptiveControl):
     @image_repeat.setter
     def image_repeat(self, value: Optional[ImageRepeat]):
         self.__image_repeat = value
-        self._set_enum_attr("imageRepeat", value, ImageRepeat)
+        self._set_attr("imageRepeat", value)
         if value is not None:
             warnings.warn(
                 f"image_repeat is deprecated since version 0.24.0 "
@@ -517,7 +516,7 @@ class Container(ConstrainedControl, AdaptiveControl):
     @shape.setter
     def shape(self, value: Optional[BoxShape]):
         self.__shape = value
-        self._set_enum_attr("shape", value, BoxShape)
+        self._set_attr("shape", value)
 
     # clip_behavior
     @property
@@ -527,7 +526,7 @@ class Container(ConstrainedControl, AdaptiveControl):
     @clip_behavior.setter
     def clip_behavior(self, value: Optional[ClipBehavior]):
         self.__clip_behavior = value
-        self._set_enum_attr("clipBehavior", value, ClipBehavior)
+        self._set_attr("clipBehavior", value)
 
     # ink
     @property
@@ -546,7 +545,7 @@ class Container(ConstrainedControl, AdaptiveControl):
     @ink_color.setter
     def ink_color(self, value: Optional[ColorValue]):
         self.__ink_color = value
-        self._set_enum_attr("inkColor", value, ColorEnums)
+        self._set_attr("inkColor", value)
 
     # animate
     @property
@@ -574,7 +573,7 @@ class Container(ConstrainedControl, AdaptiveControl):
     @url_target.setter
     def url_target(self, value: Optional[UrlTarget]):
         self.__url_target = value
-        self._set_enum_attr("urlTarget", value, UrlTarget)
+        self._set_attr("urlTarget", value)
 
     # theme
     @property
@@ -593,7 +592,7 @@ class Container(ConstrainedControl, AdaptiveControl):
     @theme_mode.setter
     def theme_mode(self, value: Optional[ThemeMode]):
         self.__theme_mode = value
-        self._set_enum_attr("themeMode", value, ThemeMode)
+        self._set_attr("themeMode", value)
 
     # on_click
     @property

--- a/sdk/python/packages/flet/src/flet/core/control.py
+++ b/sdk/python/packages/flet/src/flet/core/control.py
@@ -17,6 +17,8 @@ from flet.core.types import (
     SupportsStr,
 )
 
+from ..utils import deprecated
+
 if TYPE_CHECKING:
     from .page import Page
 

--- a/sdk/python/packages/flet/src/flet/core/control.py
+++ b/sdk/python/packages/flet/src/flet/core/control.py
@@ -2,18 +2,7 @@ import datetime as dt
 import json
 from difflib import SequenceMatcher
 from enum import Enum
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    AnyStr,
-    Dict,
-    List,
-    Optional,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, AnyStr, Dict, List, Optional, TypeVar, Union
 
 from flet.core.badge import Badge, BadgeValue
 from flet.core.embed_json_encoder import EmbedJsonEncoder
@@ -27,7 +16,6 @@ from flet.core.types import (
     ResponsiveNumber,
     SupportsStr,
 )
-from flet.utils import deprecated
 
 if TYPE_CHECKING:
     from .page import Page
@@ -149,18 +137,9 @@ class Control:
             return s_val
 
     def _set_attr(self, name: str, value: V, dirty: bool = True) -> None:
+        if isinstance(value, Enum):
+            value = value.value
         self._set_attr_internal(name, value, dirty)
-
-    def _set_enum_attr(
-        self,
-        name: str,
-        value: V,
-        enum_type: Union[Type[Enum], Tuple[Type[Enum], ...]],
-        dirty: bool = True,
-    ) -> None:
-        self._set_attr_internal(
-            name, value.value if isinstance(value, enum_type) else value, dirty
-        )
 
     def _get_value_or_list_attr(self, name: str, delimiter: str) -> Union[List[str], V]:
         v = self._get_attr(name)

--- a/sdk/python/packages/flet/src/flet/core/cupertino_activity_indicator.py
+++ b/sdk/python/packages/flet/src/flet/core/cupertino_activity_indicator.py
@@ -7,7 +7,6 @@ from flet.core.control import OptionalNumber
 from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
     OffsetValue,
     OptionalControlEventCallable,
@@ -98,7 +97,7 @@ class CupertinoActivityIndicator(ConstrainedControl):
     @color.setter
     def color(self, value: Optional[ColorValue]):
         self.__color = value
-        self._set_enum_attr("color", value, ColorEnums)
+        self._set_attr("color", value)
 
     # animating
     @property

--- a/sdk/python/packages/flet/src/flet/core/cupertino_app_bar.py
+++ b/sdk/python/packages/flet/src/flet/core/cupertino_app_bar.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 from flet.core.border import Border
 from flet.core.control import Control
 from flet.core.ref import Ref
-from flet.core.types import ColorEnums, ColorValue, PaddingValue
+from flet.core.types import ColorValue, PaddingValue
 
 
 class CupertinoAppBar(Control):
@@ -191,4 +191,4 @@ class CupertinoAppBar(Control):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgcolor", value, ColorEnums)
+        self._set_attr("bgcolor", value)

--- a/sdk/python/packages/flet/src/flet/core/cupertino_bottom_sheet.py
+++ b/sdk/python/packages/flet/src/flet/core/cupertino_bottom_sheet.py
@@ -2,12 +2,7 @@ from typing import Any, Optional
 
 from flet.core.control import Control, OptionalNumber
 from flet.core.ref import Ref
-from flet.core.types import (
-    ColorEnums,
-    ColorValue,
-    OptionalControlEventCallable,
-    PaddingValue,
-)
+from flet.core.types import ColorValue, OptionalControlEventCallable, PaddingValue
 
 
 class CupertinoBottomSheet(Control):
@@ -94,7 +89,7 @@ class CupertinoBottomSheet(Control):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgColor", value, ColorEnums)
+        self._set_attr("bgColor", value)
 
     # height
     @property

--- a/sdk/python/packages/flet/src/flet/core/cupertino_button.py
+++ b/sdk/python/packages/flet/src/flet/core/cupertino_button.py
@@ -10,9 +10,7 @@ from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
     BorderRadiusValue,
-    ColorEnums,
     ColorValue,
-    IconEnums,
     IconValue,
     OffsetValue,
     OptionalControlEventCallable,
@@ -167,7 +165,7 @@ class CupertinoButton(ConstrainedControl):
     @icon.setter
     def icon(self, value):
         self.__icon = value
-        self._set_enum_attr("icon", value, IconEnums)
+        self._set_attr("icon", value)
 
     # icon_color
     @property
@@ -177,7 +175,7 @@ class CupertinoButton(ConstrainedControl):
     @icon_color.setter
     def icon_color(self, value):
         self.__icon_color = value
-        self._set_enum_attr("iconColor", value, ColorEnums)
+        self._set_attr("iconColor", value)
 
     # alignment
     @property
@@ -202,7 +200,7 @@ class CupertinoButton(ConstrainedControl):
     @disabled_color.setter
     def disabled_color(self, value: Optional[ColorValue]):
         self.__disabled_color = value
-        self._set_enum_attr("disabledColor", value, ColorEnums)
+        self._set_attr("disabledColor", value)
         if value is not None:
             warnings.warn(
                 f"disabled_color is deprecated since version 0.24.0 "
@@ -219,7 +217,7 @@ class CupertinoButton(ConstrainedControl):
     @disabled_bgcolor.setter
     def disabled_bgcolor(self, value: Optional[str]):
         self.__disabled_bgcolor = value
-        self._set_enum_attr("disabledBgcolor", value, ColorEnums)
+        self._set_attr("disabledBgcolor", value)
 
     # opacity_on_click
     @property
@@ -267,7 +265,7 @@ class CupertinoButton(ConstrainedControl):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgColor", value, ColorEnums)
+        self._set_attr("bgColor", value)
 
     # color
     @property
@@ -277,7 +275,7 @@ class CupertinoButton(ConstrainedControl):
     @color.setter
     def color(self, value: Optional[ColorValue]):
         self.__color = value
-        self._set_enum_attr("color", value, ColorEnums)
+        self._set_attr("color", value)
 
     # url
     @property
@@ -296,7 +294,7 @@ class CupertinoButton(ConstrainedControl):
     @url_target.setter
     def url_target(self, value: Optional[UrlTarget]):
         self.__url_target = value
-        self._set_enum_attr("urlTarget", value, UrlTarget)
+        self._set_attr("urlTarget", value)
 
     # on_click
     @property

--- a/sdk/python/packages/flet/src/flet/core/cupertino_checkbox.py
+++ b/sdk/python/packages/flet/src/flet/core/cupertino_checkbox.py
@@ -7,7 +7,6 @@ from flet.core.control import OptionalNumber
 from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
     LabelPosition,
     OffsetValue,
@@ -172,7 +171,7 @@ class CupertinoCheckbox(ConstrainedControl):
     @label_position.setter
     def label_position(self, value: Optional[LabelPosition]):
         self.__label_position = value
-        self._set_enum_attr("labelPosition", value, LabelPosition)
+        self._set_attr("labelPosition", value)
 
     # autofocus
     @property
@@ -191,7 +190,7 @@ class CupertinoCheckbox(ConstrainedControl):
     @check_color.setter
     def check_color(self, value: Optional[ColorValue]):
         self.__check_color = value
-        self._set_enum_attr("checkColor", value, ColorEnums)
+        self._set_attr("checkColor", value)
 
     # active_color
     @property
@@ -201,7 +200,7 @@ class CupertinoCheckbox(ConstrainedControl):
     @active_color.setter
     def active_color(self, value: Optional[ColorValue]):
         self.__active_color = value
-        self._set_enum_attr("activeColor", value, ColorEnums)
+        self._set_attr("activeColor", value)
 
     # inactive_color
     @property
@@ -211,7 +210,7 @@ class CupertinoCheckbox(ConstrainedControl):
     @inactive_color.setter
     def inactive_color(self, value: Optional[ColorValue]):
         self.__inactive_color = value
-        self._set_enum_attr("inactiveColor", value, ColorEnums)
+        self._set_attr("inactiveColor", value)
 
     # focus_color
     @property
@@ -221,7 +220,7 @@ class CupertinoCheckbox(ConstrainedControl):
     @focus_color.setter
     def focus_color(self, value: Optional[ColorValue]):
         self.__focus_color = value
-        self._set_enum_attr("focusColor", value, ColorEnums)
+        self._set_attr("focusColor", value)
 
     # on_change
     @property

--- a/sdk/python/packages/flet/src/flet/core/cupertino_colors.py
+++ b/sdk/python/packages/flet/src/flet/core/cupertino_colors.py
@@ -16,7 +16,7 @@ for line in __import__("sys").stdin:
 
 import random
 from enum import Enum, EnumMeta
-from typing import Dict, List, Optional, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 from warnings import warn
 
 from flet.utils import deprecated
@@ -213,3 +213,6 @@ class CupertinoColors(str, Enum):
     SEPARATOR = "separator"
     OPAQUE_SEPARATOR = "opaqueSeparator"
     LINK = "link"
+
+
+CupertinoColorsEnums = Union[cupertino_colors, CupertinoColors]

--- a/sdk/python/packages/flet/src/flet/core/cupertino_context_menu_action.py
+++ b/sdk/python/packages/flet/src/flet/core/cupertino_context_menu_action.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 from flet.core.adaptive_control import AdaptiveControl
 from flet.core.control import Control
 from flet.core.ref import Ref
-from flet.core.types import IconEnums, IconValue, OptionalControlEventCallable
+from flet.core.types import IconValue, OptionalControlEventCallable
 
 
 class CupertinoContextMenuAction(AdaptiveControl):
@@ -81,7 +81,7 @@ class CupertinoContextMenuAction(AdaptiveControl):
     @trailing_icon.setter
     def trailing_icon(self, value: Optional[IconValue]):
         self.__trailing_icon = value
-        self._set_enum_attr("trailingIcon", value, IconEnums)
+        self._set_attr("trailingIcon", value)
 
     # text
     @property

--- a/sdk/python/packages/flet/src/flet/core/cupertino_date_picker.py
+++ b/sdk/python/packages/flet/src/flet/core/cupertino_date_picker.py
@@ -1,10 +1,10 @@
 from datetime import datetime
-from enum import Enum
 from typing import Any, Optional, Union
 
 from flet.core.animation import AnimationValue
 from flet.core.constrained_control import ConstrainedControl
 from flet.core.control import OptionalNumber
+from flet.core.enumerations import ExtendedEnum
 from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
@@ -18,14 +18,14 @@ from flet.core.types import (
 )
 
 
-class CupertinoDatePickerMode(Enum):
+class CupertinoDatePickerMode(ExtendedEnum):
     TIME = "time"
     DATE = "date"
     DATE_AND_TIME = "dateAndTime"
     MONTH_YEAR = "monthYear"
 
 
-class CupertinoDatePickerDateOrder(Enum):
+class CupertinoDatePickerDateOrder(ExtendedEnum):
     DAY_MONTH_YEAR = "dmy"
     MONTH_YEAR_DAY = "myd"
     YEAR_MONTH_DAY = "ymd"

--- a/sdk/python/packages/flet/src/flet/core/cupertino_date_picker.py
+++ b/sdk/python/packages/flet/src/flet/core/cupertino_date_picker.py
@@ -1,15 +1,13 @@
-from datetime import date, datetime
+from datetime import datetime
 from enum import Enum
 from typing import Any, Optional, Union
 
 from flet.core.animation import AnimationValue
-from flet.core.badge import BadgeValue
 from flet.core.constrained_control import ConstrainedControl
 from flet.core.control import OptionalNumber
 from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
     DateTimeValue,
     OffsetValue,
@@ -173,7 +171,7 @@ class CupertinoDatePicker(ConstrainedControl):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgcolor", value, ColorEnums)
+        self._set_attr("bgcolor", value)
 
     # item_extent
     @property
@@ -232,7 +230,7 @@ class CupertinoDatePicker(ConstrainedControl):
     @date_picker_mode.setter
     def date_picker_mode(self, value: Optional[CupertinoDatePickerMode]):
         self.__date_picker_mode = value
-        self._set_enum_attr("datePickerMode", value, CupertinoDatePickerMode)
+        self._set_attr("datePickerMode", value)
 
     # date_order
     @property
@@ -242,7 +240,7 @@ class CupertinoDatePicker(ConstrainedControl):
     @date_order.setter
     def date_order(self, value: Optional[CupertinoDatePickerDateOrder]):
         self.__date_order = value
-        self._set_enum_attr("dateOrder", value, CupertinoDatePickerDateOrder)
+        self._set_attr("dateOrder", value)
 
     # on_change
     @property

--- a/sdk/python/packages/flet/src/flet/core/cupertino_icons.py
+++ b/sdk/python/packages/flet/src/flet/core/cupertino_icons.py
@@ -8,7 +8,7 @@ sh ci/generate_cupertino_icons_python.sh
 
 import random
 from enum import Enum, EnumMeta
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 from warnings import warn
 
 from flet.utils import deprecated
@@ -2764,3 +2764,6 @@ class CupertinoIcons(str, Enum):
     ZOOM_IN = "cupertino_zoom_in"
     ZOOM_OUT = "cupertino_zoom_out"
     ZZZ = "cupertino_zzz"
+
+
+CupertinoIconEnums = Union[cupertino_icons, CupertinoIcons]

--- a/sdk/python/packages/flet/src/flet/core/cupertino_list_tile.py
+++ b/sdk/python/packages/flet/src/flet/core/cupertino_list_tile.py
@@ -7,7 +7,6 @@ from flet.core.control import Control, OptionalNumber
 from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
     OffsetValue,
     OptionalControlEventCallable,
@@ -267,7 +266,7 @@ class CupertinoListTile(ConstrainedControl):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgcolor", value, ColorEnums)
+        self._set_attr("bgcolor", value)
 
     # bgcolor_activated
     @property
@@ -295,7 +294,7 @@ class CupertinoListTile(ConstrainedControl):
     @url_target.setter
     def url_target(self, value: Optional[UrlTarget]):
         self.__url_target = value
-        self._set_enum_attr("urlTarget", value, UrlTarget)
+        self._set_attr("urlTarget", value)
 
     # toggle_inputs
     @property

--- a/sdk/python/packages/flet/src/flet/core/cupertino_navigation_bar.py
+++ b/sdk/python/packages/flet/src/flet/core/cupertino_navigation_bar.py
@@ -6,7 +6,6 @@ from flet.core.constrained_control import ConstrainedControl
 from flet.core.navigation_bar import NavigationBarDestination
 from flet.core.ref import Ref
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
     OffsetValue,
     OptionalControlEventCallable,
@@ -178,7 +177,7 @@ class CupertinoNavigationBar(ConstrainedControl):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgcolor", value, ColorEnums)
+        self._set_attr("bgcolor", value)
 
     # active_color
     @property
@@ -188,7 +187,7 @@ class CupertinoNavigationBar(ConstrainedControl):
     @active_color.setter
     def active_color(self, value: Optional[ColorValue]):
         self.__active_color = value
-        self._set_enum_attr("activeColor", value, ColorEnums)
+        self._set_attr("activeColor", value)
 
     # inactive_color
     @property
@@ -198,7 +197,7 @@ class CupertinoNavigationBar(ConstrainedControl):
     @inactive_color.setter
     def inactive_color(self, value: Optional[ColorValue]):
         self.__inactive_color = value
-        self._set_enum_attr("inactiveColor", value, ColorEnums)
+        self._set_attr("inactiveColor", value)
 
     # icon_size
     @property

--- a/sdk/python/packages/flet/src/flet/core/cupertino_picker.py
+++ b/sdk/python/packages/flet/src/flet/core/cupertino_picker.py
@@ -7,7 +7,6 @@ from flet.core.control import Control, OptionalNumber
 from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
     OffsetValue,
     OptionalControlEventCallable,
@@ -140,7 +139,7 @@ class CupertinoPicker(ConstrainedControl):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgcolor", value, ColorEnums)
+        self._set_attr("bgcolor", value)
 
     # use_magnifier
     @property

--- a/sdk/python/packages/flet/src/flet/core/cupertino_radio.py
+++ b/sdk/python/packages/flet/src/flet/core/cupertino_radio.py
@@ -7,7 +7,6 @@ from flet.core.control import OptionalNumber
 from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
     LabelPosition,
     OffsetValue,
@@ -151,7 +150,7 @@ class CupertinoRadio(ConstrainedControl):
     @label_position.setter
     def label_position(self, value: Optional[LabelPosition]):
         self.__label_position = value
-        self._set_enum_attr("labelPosition", value, LabelPosition)
+        self._set_attr("labelPosition", value)
 
     # fill_color
     @property
@@ -161,7 +160,7 @@ class CupertinoRadio(ConstrainedControl):
     @fill_color.setter
     def fill_color(self, value: Optional[ColorValue]):
         self.__fill_color = value
-        self._set_enum_attr("fillColor", value, ColorEnums)
+        self._set_attr("fillColor", value)
 
     # focus_color
     @property
@@ -171,7 +170,7 @@ class CupertinoRadio(ConstrainedControl):
     @focus_color.setter
     def focus_color(self, value: Optional[ColorValue]):
         self.__focus_color = value
-        self._set_enum_attr("focusColor", value, ColorEnums)
+        self._set_attr("focusColor", value)
 
     # toggleable
     @property
@@ -226,7 +225,7 @@ class CupertinoRadio(ConstrainedControl):
     @active_color.setter
     def active_color(self, value: Optional[ColorValue]):
         self.__active_color = value
-        self._set_enum_attr("activeColor", value, ColorEnums)
+        self._set_attr("activeColor", value)
 
     # inactive_color
     @property
@@ -236,4 +235,4 @@ class CupertinoRadio(ConstrainedControl):
     @inactive_color.setter
     def inactive_color(self, value: Optional[ColorValue]):
         self.__inactive_color = value
-        self._set_enum_attr("inactiveColor", value, ColorEnums)
+        self._set_attr("inactiveColor", value)

--- a/sdk/python/packages/flet/src/flet/core/cupertino_segmented_button.py
+++ b/sdk/python/packages/flet/src/flet/core/cupertino_segmented_button.py
@@ -7,7 +7,6 @@ from flet.core.control import Control, OptionalNumber
 from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
     OffsetValue,
     OptionalControlEventCallable,
@@ -142,7 +141,7 @@ class CupertinoSegmentedButton(ConstrainedControl):
     @border_color.setter
     def border_color(self, value: Optional[ColorValue]):
         self.__border_color = value
-        self._set_enum_attr("borderColor", value, ColorEnums)
+        self._set_attr("borderColor", value)
 
     # selected_index
     @property
@@ -163,7 +162,7 @@ class CupertinoSegmentedButton(ConstrainedControl):
     @selected_color.setter
     def selected_color(self, value: Optional[ColorValue]):
         self.__selected_color = value
-        self._set_enum_attr("selectedColor", value, ColorEnums)
+        self._set_attr("selectedColor", value)
 
     # unselected_color
     @property
@@ -173,7 +172,7 @@ class CupertinoSegmentedButton(ConstrainedControl):
     @unselected_color.setter
     def unselected_color(self, value: Optional[ColorValue]):
         self.__unselected_color = value
-        self._set_enum_attr("unselectedColor", value, ColorEnums)
+        self._set_attr("unselectedColor", value)
 
     # click_color
     @property
@@ -183,7 +182,7 @@ class CupertinoSegmentedButton(ConstrainedControl):
     @click_color.setter
     def click_color(self, value: Optional[ColorValue]):
         self.__click_color = value
-        self._set_enum_attr("clickColor", value, ColorEnums)
+        self._set_attr("clickColor", value)
 
     # padding
     @property

--- a/sdk/python/packages/flet/src/flet/core/cupertino_slider.py
+++ b/sdk/python/packages/flet/src/flet/core/cupertino_slider.py
@@ -7,7 +7,6 @@ from flet.core.control import OptionalNumber
 from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
     OffsetValue,
     OptionalControlEventCallable,
@@ -186,7 +185,7 @@ class CupertinoSlider(ConstrainedControl):
     @active_color.setter
     def active_color(self, value: Optional[ColorValue]):
         self.__active_color = value
-        self._set_enum_attr("activeColor", value, ColorEnums)
+        self._set_attr("activeColor", value)
 
     # thumb_color
     @property
@@ -196,7 +195,7 @@ class CupertinoSlider(ConstrainedControl):
     @thumb_color.setter
     def thumb_color(self, value: Optional[ColorValue]):
         self.__thumb_color = value
-        self._set_enum_attr("thumbColor", value, ColorEnums)
+        self._set_attr("thumbColor", value)
 
     # on_change
     @property

--- a/sdk/python/packages/flet/src/flet/core/cupertino_sliding_segmented_button.py
+++ b/sdk/python/packages/flet/src/flet/core/cupertino_sliding_segmented_button.py
@@ -7,7 +7,6 @@ from flet.core.control import Control, OptionalNumber
 from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
     OffsetValue,
     OptionalControlEventCallable,
@@ -146,7 +145,7 @@ class CupertinoSlidingSegmentedButton(ConstrainedControl):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgcolor", value, ColorEnums)
+        self._set_attr("bgcolor", value)
 
     # thumb_color
     @property
@@ -156,7 +155,7 @@ class CupertinoSlidingSegmentedButton(ConstrainedControl):
     @thumb_color.setter
     def thumb_color(self, value: Optional[ColorValue]):
         self.__thumb_color = value
-        self._set_enum_attr("thumbColor", value, ColorEnums)
+        self._set_attr("thumbColor", value)
 
     # padding
     @property

--- a/sdk/python/packages/flet/src/flet/core/cupertino_switch.py
+++ b/sdk/python/packages/flet/src/flet/core/cupertino_switch.py
@@ -7,7 +7,6 @@ from flet.core.control import OptionalNumber
 from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
     LabelPosition,
     OffsetValue,
@@ -170,7 +169,7 @@ class CupertinoSwitch(ConstrainedControl):
     @label_position.setter
     def label_position(self, value: Optional[LabelPosition]):
         self.__label_position = value
-        self._set_enum_attr("labelPosition", value, LabelPosition)
+        self._set_attr("labelPosition", value)
 
     # autofocus
     @property
@@ -189,7 +188,7 @@ class CupertinoSwitch(ConstrainedControl):
     @active_color.setter
     def active_color(self, value: Optional[ColorValue]):
         self.__active_color = value
-        self._set_enum_attr("activeColor", value, ColorEnums)
+        self._set_attr("activeColor", value)
 
     # focus_color
     @property
@@ -199,7 +198,7 @@ class CupertinoSwitch(ConstrainedControl):
     @focus_color.setter
     def focus_color(self, value: Optional[ColorValue]):
         self.__focus_color = value
-        self._set_enum_attr("focusColor", value, ColorEnums)
+        self._set_attr("focusColor", value)
 
     # thumb_color
     @property
@@ -227,7 +226,7 @@ class CupertinoSwitch(ConstrainedControl):
     @on_label_color.setter
     def on_label_color(self, value: Optional[ColorValue]):
         self.__on_label_color = value
-        self._set_enum_attr("onLabelColor", value, ColorEnums)
+        self._set_attr("onLabelColor", value)
 
     # off_label_color
     @property
@@ -237,7 +236,7 @@ class CupertinoSwitch(ConstrainedControl):
     @off_label_color.setter
     def off_label_color(self, value: Optional[ColorValue]):
         self.__off_label_color = value
-        self._set_enum_attr("offLabelColor", value, ColorEnums)
+        self._set_attr("offLabelColor", value)
 
     # on_change
     @property

--- a/sdk/python/packages/flet/src/flet/core/cupertino_textfield.py
+++ b/sdk/python/packages/flet/src/flet/core/cupertino_textfield.py
@@ -296,7 +296,7 @@ class CupertinoTextField(TextField):
     @blend_mode.setter
     def blend_mode(self, value: Optional[BlendMode]):
         self.__blend_mode = value
-        self._set_enum_attr("blendMode", value, BlendMode)
+        self._set_attr("blendMode", value)
 
     # shadow
     @property
@@ -324,7 +324,7 @@ class CupertinoTextField(TextField):
     @suffix_visibility_mode.setter
     def suffix_visibility_mode(self, value: Optional[VisibilityMode]):
         self.__suffix_visibility_mode = value
-        self._set_enum_attr("suffixVisibilityMode", value, VisibilityMode)
+        self._set_attr("suffixVisibilityMode", value)
 
     # clear_button_visibility_mode
     @property
@@ -334,7 +334,7 @@ class CupertinoTextField(TextField):
     @clear_button_visibility_mode.setter
     def clear_button_visibility_mode(self, value: Optional[VisibilityMode]):
         self.__clear_button_visibility_mode = value
-        self._set_enum_attr("clearButtonVisibilityMode", value, VisibilityMode)
+        self._set_attr("clearButtonVisibilityMode", value)
 
     # prefix_visibility_mode
     @property
@@ -344,7 +344,7 @@ class CupertinoTextField(TextField):
     @prefix_visibility_mode.setter
     def prefix_visibility_mode(self, value: Optional[VisibilityMode]):
         self.__prefix_visibility_mode = value
-        self._set_enum_attr("prefixVisibilityMode", value, VisibilityMode)
+        self._set_attr("prefixVisibilityMode", value)
 
     # clear_button_semantics_label
     @property

--- a/sdk/python/packages/flet/src/flet/core/cupertino_textfield.py
+++ b/sdk/python/packages/flet/src/flet/core/cupertino_textfield.py
@@ -1,4 +1,3 @@
-from enum import Enum
 from typing import Any, List, Optional, Union
 
 from flet.core.animation import AnimationValue
@@ -7,6 +6,7 @@ from flet.core.badge import BadgeValue
 from flet.core.border import Border
 from flet.core.box import BoxShadow, DecorationImage
 from flet.core.control import Control, OptionalNumber
+from flet.core.enumerations import ExtendedEnum
 from flet.core.gradients import Gradient
 from flet.core.ref import Ref
 from flet.core.text_style import StrutStyle, TextStyle
@@ -28,7 +28,7 @@ from flet.core.types import (
 )
 
 
-class VisibilityMode(Enum):
+class VisibilityMode(ExtendedEnum):
     NEVER = "never"
     EDITING = "editing"
     NOT_EDITING = "notEditing"

--- a/sdk/python/packages/flet/src/flet/core/cupertino_timer_picker.py
+++ b/sdk/python/packages/flet/src/flet/core/cupertino_timer_picker.py
@@ -1,4 +1,3 @@
-from enum import Enum
 from typing import Any, Optional, Union
 
 from flet.core.alignment import Alignment
@@ -6,6 +5,7 @@ from flet.core.animation import AnimationValue
 from flet.core.badge import BadgeValue
 from flet.core.constrained_control import ConstrainedControl
 from flet.core.control import OptionalNumber
+from flet.core.enumerations import ExtendedEnum
 from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
@@ -18,7 +18,7 @@ from flet.core.types import (
 )
 
 
-class CupertinoTimerPickerMode(Enum):
+class CupertinoTimerPickerMode(ExtendedEnum):
     HOUR_MINUTE = "hm"
     HOUR_MINUTE_SECONDS = "hms"
     MINUTE_SECONDS = "ms"

--- a/sdk/python/packages/flet/src/flet/core/cupertino_timer_picker.py
+++ b/sdk/python/packages/flet/src/flet/core/cupertino_timer_picker.py
@@ -9,7 +9,6 @@ from flet.core.control import OptionalNumber
 from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
     OffsetValue,
     OptionalControlEventCallable,
@@ -152,7 +151,7 @@ class CupertinoTimerPicker(ConstrainedControl):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgcolor", value, ColorEnums)
+        self._set_attr("bgcolor", value)
 
     # second_interval
     @property
@@ -189,7 +188,7 @@ class CupertinoTimerPicker(ConstrainedControl):
     @mode.setter
     def mode(self, value: Optional[CupertinoTimerPickerMode]):
         self.__mode = value
-        self._set_enum_attr("mode", value, CupertinoTimerPickerMode)
+        self._set_attr("mode", value)
 
     # on_change
     @property

--- a/sdk/python/packages/flet/src/flet/core/datatable.py
+++ b/sdk/python/packages/flet/src/flet/core/datatable.py
@@ -16,7 +16,6 @@ from flet.core.tooltip import TooltipValue
 from flet.core.types import (
     BorderRadiusValue,
     ClipBehavior,
-    ColorEnums,
     ColorValue,
     ControlStateValue,
     MainAxisAlignment,
@@ -110,7 +109,7 @@ class DataColumn(Control):
     @heading_row_alignment.setter
     def heading_row_alignment(self, value: Optional[MainAxisAlignment]):
         self.__heading_row_alignment = value
-        self._set_enum_attr("headingRowAlignment", value, MainAxisAlignment)
+        self._set_attr("headingRowAlignment", value)
 
     # on_sort
     @property
@@ -634,7 +633,7 @@ class DataTable(ConstrainedControl):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgColor", value, ColorEnums)
+        self._set_attr("bgColor", value)
 
     # gradient
     @property
@@ -716,7 +715,7 @@ class DataTable(ConstrainedControl):
     @clip_behavior.setter
     def clip_behavior(self, value: Optional[ClipBehavior]):
         self.__clip_behavior = value
-        self._set_enum_attr("clipBehavior", value, ClipBehavior)
+        self._set_attr("clipBehavior", value)
 
     # on_select_all
     @property

--- a/sdk/python/packages/flet/src/flet/core/date_picker.py
+++ b/sdk/python/packages/flet/src/flet/core/date_picker.py
@@ -1,8 +1,7 @@
-from datetime import date, datetime
+from datetime import datetime
 from enum import Enum
 from typing import Any, Optional, Union
 
-from flet.core.badge import BadgeValue
 from flet.core.control import Control, OptionalNumber
 from flet.core.control_event import ControlEvent
 from flet.core.event_handler import EventHandler
@@ -10,16 +9,13 @@ from flet.core.ref import Ref
 from flet.core.textfield import KeyboardType
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
     DateTimeValue,
-    IconEnums,
     IconValue,
     OptionalControlEventCallable,
     OptionalEventCallable,
     ResponsiveNumber,
 )
-from flet.utils import deprecated
 
 try:
     from typing import Literal
@@ -310,7 +306,7 @@ class DatePicker(Control):
     @keyboard_type.setter
     def keyboard_type(self, value: Optional[KeyboardType]):
         self.__keyboard_type = value
-        self._set_enum_attr("keyboardType", value, KeyboardType)
+        self._set_attr("keyboardType", value)
 
     # date_picker_mode
     @property
@@ -320,7 +316,7 @@ class DatePicker(Control):
     @date_picker_mode.setter
     def date_picker_mode(self, value: Optional[DatePickerMode]):
         self.__date_picker_mode = value
-        self._set_enum_attr("datePickerMode", value, DatePickerMode)
+        self._set_attr("datePickerMode", value)
 
     # date_picker_entry_mode
     @property
@@ -330,7 +326,7 @@ class DatePicker(Control):
     @date_picker_entry_mode.setter
     def date_picker_entry_mode(self, value: Optional[DatePickerEntryMode]):
         self.__date_picker_entry_mode = value
-        self._set_enum_attr("datePickerEntryMode", value, DatePickerEntryMode)
+        self._set_attr("datePickerEntryMode", value)
 
     # switch_to_calendar_icon
     @property
@@ -340,7 +336,7 @@ class DatePicker(Control):
     @switch_to_calendar_icon.setter
     def switch_to_calendar_icon(self, value: Optional[IconValue]):
         self.__switch_to_calendar_icon = value
-        self._set_enum_attr("switchToCalendarEntryModeIcon", value, IconEnums)
+        self._set_attr("switchToCalendarEntryModeIcon", value)
 
     # switch_to_input_icon
     @property
@@ -350,7 +346,7 @@ class DatePicker(Control):
     @switch_to_input_icon.setter
     def switch_to_input_icon(self, value: Optional[IconValue]):
         self.__switch_to_input_icon = value
-        self._set_enum_attr("switchToInputEntryModeIcon", value, IconEnums)
+        self._set_attr("switchToInputEntryModeIcon", value)
 
     # on_change
     @property
@@ -391,4 +387,4 @@ class DatePicker(Control):
     @barrier_color.setter
     def barrier_color(self, value: Optional[ColorValue]):
         self.__barrier_color = value
-        self._set_enum_attr("barrierColor", value, ColorEnums)
+        self._set_attr("barrierColor", value)

--- a/sdk/python/packages/flet/src/flet/core/date_picker.py
+++ b/sdk/python/packages/flet/src/flet/core/date_picker.py
@@ -1,9 +1,9 @@
 from datetime import datetime
-from enum import Enum
 from typing import Any, Optional, Union
 
 from flet.core.control import Control, OptionalNumber
 from flet.core.control_event import ControlEvent
+from flet.core.enumerations import ExtendedEnum
 from flet.core.event_handler import EventHandler
 from flet.core.ref import Ref
 from flet.core.textfield import KeyboardType
@@ -16,6 +16,7 @@ from flet.core.types import (
     OptionalEventCallable,
     ResponsiveNumber,
 )
+from flet.utils import deprecated
 
 try:
     from typing import Literal
@@ -23,12 +24,12 @@ except ImportError:
     from typing_extensions import Literal
 
 
-class DatePickerMode(Enum):
+class DatePickerMode(ExtendedEnum):
     DAY = "day"
     YEAR = "year"
 
 
-class DatePickerEntryMode(Enum):
+class DatePickerEntryMode(ExtendedEnum):
     CALENDAR = "calendar"
     INPUT = "input"
     CALENDAR_ONLY = "calendarOnly"

--- a/sdk/python/packages/flet/src/flet/core/dismissible.py
+++ b/sdk/python/packages/flet/src/flet/core/dismissible.py
@@ -234,7 +234,7 @@ class Dismissible(ConstrainedControl, AdaptiveControl):
     @dismiss_direction.setter
     def dismiss_direction(self, value: Optional[DismissDirection]):
         self.__dismiss_direction = value
-        self._set_enum_attr("dismissDirection", value, DismissDirection)
+        self._set_attr("dismissDirection", value)
 
     # dismissThresholds
     @property

--- a/sdk/python/packages/flet/src/flet/core/divider.py
+++ b/sdk/python/packages/flet/src/flet/core/divider.py
@@ -4,7 +4,7 @@ from flet.core.badge import BadgeValue
 from flet.core.control import Control, OptionalNumber
 from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
-from flet.core.types import ColorEnums, ColorValue
+from flet.core.types import ColorValue
 
 
 class Divider(Control):
@@ -113,7 +113,7 @@ class Divider(Control):
     @color.setter
     def color(self, value: Optional[ColorValue]):
         self.__color = value
-        self._set_enum_attr("color", value, ColorEnums)
+        self._set_attr("color", value)
 
     # leading_indent
     @property

--- a/sdk/python/packages/flet/src/flet/core/draggable.py
+++ b/sdk/python/packages/flet/src/flet/core/draggable.py
@@ -224,7 +224,7 @@ class Draggable(Control):
     @axis.setter
     def axis(self, value: Optional[Axis]):
         self.__axis = value
-        self._set_enum_attr("axis", value, Axis)
+        self._set_attr("axis", value)
 
     # affinity
     @property
@@ -234,7 +234,7 @@ class Draggable(Control):
     @affinity.setter
     def affinity(self, value: Optional[Axis]):
         self.__affinity = value
-        self._set_enum_attr("affinity", value, Axis)
+        self._set_attr("affinity", value)
 
     # on_drag_start
     @property

--- a/sdk/python/packages/flet/src/flet/core/dropdown.py
+++ b/sdk/python/packages/flet/src/flet/core/dropdown.py
@@ -23,6 +23,7 @@ from flet.core.types import (
     RotateValue,
     ScaleValue,
 )
+from flet.utils import deprecated
 
 
 class Option(Control):

--- a/sdk/python/packages/flet/src/flet/core/dropdown.py
+++ b/sdk/python/packages/flet/src/flet/core/dropdown.py
@@ -13,10 +13,8 @@ from flet.core.text_style import TextStyle
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
     BorderRadiusValue,
-    ColorEnums,
     ColorValue,
     DurationValue,
-    IconEnums,
     IconValueOrControl,
     OffsetValue,
     OptionalControlEventCallable,
@@ -25,7 +23,6 @@ from flet.core.types import (
     RotateValue,
     ScaleValue,
 )
-from flet.utils import deprecated
 
 
 class Option(Control):
@@ -433,7 +430,7 @@ class Dropdown(FormFieldControl):
     @select_icon.setter
     def select_icon(self, value: Optional[IconValueOrControl]):
         self.__select_icon = value
-        self._set_enum_attr("selectIcon", value, IconEnums)
+        self._set_attr("selectIcon", value)
 
     # icon_content
     @property
@@ -498,7 +495,7 @@ class Dropdown(FormFieldControl):
     @icon_enabled_color.setter
     def icon_enabled_color(self, value: Optional[ColorValue]):
         self.__icon_enabled_color = value
-        self._set_enum_attr("selectIconEnabledColor", value, ColorEnums)
+        self._set_attr("selectIconEnabledColor", value)
         if value is not None:
             warnings.warn(
                 f"icon_enabled_color is deprecated since version 0.25.0 "
@@ -515,7 +512,7 @@ class Dropdown(FormFieldControl):
     @select_icon_enabled_color.setter
     def select_icon_enabled_color(self, value: Optional[ColorValue]):
         self.__select_icon_enabled_color = value
-        self._set_enum_attr("selectIconEnabledColor", value, ColorEnums)
+        self._set_attr("selectIconEnabledColor", value)
 
     # icon_disabled_color
     @property
@@ -531,7 +528,7 @@ class Dropdown(FormFieldControl):
     @icon_disabled_color.setter
     def icon_disabled_color(self, value: Optional[ColorValue]):
         self.__icon_disabled_color = value
-        self._set_enum_attr("selectIconDisabledColor", value, ColorEnums)
+        self._set_attr("selectIconDisabledColor", value)
         if value is not None:
             warnings.warn(
                 f"icon_disabled_color is deprecated since version 0.25.0 "
@@ -548,7 +545,7 @@ class Dropdown(FormFieldControl):
     @select_icon_disabled_color.setter
     def select_icon_disabled_color(self, value: Optional[ColorValue]):
         self.__select_icon_disabled_color = value
-        self._set_enum_attr("selectIconDisabledColor", value, ColorEnums)
+        self._set_attr("selectIconDisabledColor", value)
 
     # item_height
     @property

--- a/sdk/python/packages/flet/src/flet/core/elevated_button.py
+++ b/sdk/python/packages/flet/src/flet/core/elevated_button.py
@@ -11,9 +11,7 @@ from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
     ClipBehavior,
-    ColorEnums,
     ColorValue,
-    IconEnums,
     IconValue,
     OffsetValue,
     OptionalControlEventCallable,
@@ -22,7 +20,6 @@ from flet.core.types import (
     ScaleValue,
     UrlTarget,
 )
-from flet.utils import deprecated
 
 
 class ElevatedButton(ConstrainedControl, AdaptiveControl):
@@ -218,7 +215,7 @@ class ElevatedButton(ConstrainedControl, AdaptiveControl):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgColor", value, ColorEnums)
+        self._set_attr("bgColor", value)
 
     # elevation
     @property
@@ -246,7 +243,7 @@ class ElevatedButton(ConstrainedControl, AdaptiveControl):
     @icon.setter
     def icon(self, value: Optional[IconValue]):
         self.__icon = value
-        self._set_enum_attr("icon", value, IconEnums)
+        self._set_attr("icon", value)
 
     # icon_color
     @property
@@ -256,7 +253,7 @@ class ElevatedButton(ConstrainedControl, AdaptiveControl):
     @icon_color.setter
     def icon_color(self, value: Optional[ColorValue]):
         self.__icon_color = value
-        self._set_enum_attr("iconColor", value, ColorEnums)
+        self._set_attr("iconColor", value)
 
     # url
     @property
@@ -275,7 +272,7 @@ class ElevatedButton(ConstrainedControl, AdaptiveControl):
     @url_target.setter
     def url_target(self, value: Optional[UrlTarget]):
         self.__url_target = value
-        self._set_enum_attr("urlTarget", value, UrlTarget)
+        self._set_attr("urlTarget", value)
 
     # on_click
     @property
@@ -322,7 +319,7 @@ class ElevatedButton(ConstrainedControl, AdaptiveControl):
     @clip_behavior.setter
     def clip_behavior(self, value: Optional[ClipBehavior]):
         self.__clip_behavior = value
-        self._set_enum_attr("clipBehavior", value, ClipBehavior)
+        self._set_attr("clipBehavior", value)
 
     # on_hover
     @property

--- a/sdk/python/packages/flet/src/flet/core/elevated_button.py
+++ b/sdk/python/packages/flet/src/flet/core/elevated_button.py
@@ -20,6 +20,7 @@ from flet.core.types import (
     ScaleValue,
     UrlTarget,
 )
+from flet.utils import deprecated
 
 
 class ElevatedButton(ConstrainedControl, AdaptiveControl):

--- a/sdk/python/packages/flet/src/flet/core/enumerations.py
+++ b/sdk/python/packages/flet/src/flet/core/enumerations.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+
+class ExtendedEnum(Enum):
+    def __eq__(self, other):
+        if isinstance(other, str):
+            return self.value.lower() == other.lower()
+        return self.value == other.value

--- a/sdk/python/packages/flet/src/flet/core/expansion_panel.py
+++ b/sdk/python/packages/flet/src/flet/core/expansion_panel.py
@@ -6,7 +6,6 @@ from flet.core.constrained_control import ConstrainedControl
 from flet.core.control import Control, OptionalNumber
 from flet.core.ref import Ref
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
     OffsetValue,
     OptionalControlEventCallable,
@@ -129,7 +128,7 @@ class ExpansionPanel(ConstrainedControl, AdaptiveControl):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgColor", value, ColorEnums)
+        self._set_attr("bgColor", value)
 
     # expanded
     @property
@@ -276,7 +275,7 @@ class ExpansionPanelList(ConstrainedControl):
     @divider_color.setter
     def divider_color(self, value: Optional[ColorValue]):
         self.__divider_color = value
-        self._set_enum_attr("dividerColor", value, ColorEnums)
+        self._set_attr("dividerColor", value)
 
     # expanded_icon_color
     @property
@@ -286,7 +285,7 @@ class ExpansionPanelList(ConstrainedControl):
     @expanded_icon_color.setter
     def expanded_icon_color(self, value: Optional[ColorValue]):
         self.__expanded_icon_color = value
-        self._set_enum_attr("expandedIconColor", value, ColorEnums)
+        self._set_attr("expandedIconColor", value)
 
     # expanded_header_padding
     @property

--- a/sdk/python/packages/flet/src/flet/core/expansion_tile.py
+++ b/sdk/python/packages/flet/src/flet/core/expansion_tile.py
@@ -12,7 +12,6 @@ from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
     ClipBehavior,
-    ColorEnums,
     ColorValue,
     CrossAxisAlignment,
     OffsetValue,
@@ -241,7 +240,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
     @expanded_cross_axis_alignment.setter
     def expanded_cross_axis_alignment(self, value: Optional[CrossAxisAlignment]):
         self.__expanded_cross_axis_alignment = value
-        self._set_enum_attr("crossAxisAlignment", value, CrossAxisAlignment)
+        self._set_attr("crossAxisAlignment", value)
 
     # affinity
     @property
@@ -251,7 +250,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
     @affinity.setter
     def affinity(self, value: Optional[TileAffinity]):
         self.__affinity = value
-        self._set_enum_attr("affinity", value, TileAffinity)
+        self._set_attr("affinity", value)
 
     # leading
     @property
@@ -315,7 +314,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
     @clip_behavior.setter
     def clip_behavior(self, value: Optional[ClipBehavior]):
         self.__clip_behavior = value
-        self._set_enum_attr("clipBehavior", value, ClipBehavior)
+        self._set_attr("clipBehavior", value)
 
     # visual_density
     @property
@@ -325,7 +324,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
     @visual_density.setter
     def visual_density(self, value: Union[None, ThemeVisualDensity, VisualDensity]):
         self.__visual_density = value
-        self._set_enum_attr("visualDensity", value, (ThemeVisualDensity, VisualDensity))
+        self._set_attr("visualDensity", value)
 
     # maintain_state
     @property
@@ -362,7 +361,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
     @text_color.setter
     def text_color(self, value: Optional[ColorValue]):
         self.__text_color = value
-        self._set_enum_attr("textColor", value, ColorEnums)
+        self._set_attr("textColor", value)
 
     # icon_color
     @property
@@ -372,7 +371,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
     @icon_color.setter
     def icon_color(self, value: Optional[ColorValue]):
         self.__icon_color = value
-        self._set_enum_attr("iconColor", value, ColorEnums)
+        self._set_attr("iconColor", value)
 
     # bgcolor
     @property
@@ -382,7 +381,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgColor", value, ColorEnums)
+        self._set_attr("bgColor", value)
 
     # collapsed_bgcolor
     @property
@@ -392,7 +391,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
     @collapsed_bgcolor.setter
     def collapsed_bgcolor(self, value: Optional[str]):
         self.__collapsed_bgcolor = value
-        self._set_enum_attr("collapsedBgColor", value, ColorEnums)
+        self._set_attr("collapsedBgColor", value)
 
     # collapsed_icon_color
     @property
@@ -402,7 +401,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
     @collapsed_icon_color.setter
     def collapsed_icon_color(self, value: Optional[ColorValue]):
         self.__collapsed_icon_color = value
-        self._set_enum_attr("collapsedIconColor", value, ColorEnums)
+        self._set_attr("collapsedIconColor", value)
 
     # collapsed_text_color
     @property
@@ -412,7 +411,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
     @collapsed_text_color.setter
     def collapsed_text_color(self, value: Optional[ColorValue]):
         self.__collapsed_text_color = value
-        self._set_enum_attr("collapsedTextColor", value, ColorEnums)
+        self._set_attr("collapsedTextColor", value)
 
     # collapsed_shape
     @property

--- a/sdk/python/packages/flet/src/flet/core/expansion_tile.py
+++ b/sdk/python/packages/flet/src/flet/core/expansion_tile.py
@@ -1,4 +1,3 @@
-from enum import Enum
 from typing import Any, Optional, Sequence, Union
 
 from flet.core.adaptive_control import AdaptiveControl
@@ -8,6 +7,7 @@ from flet.core.badge import BadgeValue
 from flet.core.buttons import OutlinedBorder
 from flet.core.constrained_control import ConstrainedControl
 from flet.core.control import Control, OptionalNumber
+from flet.core.enumerations import ExtendedEnum
 from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
@@ -25,7 +25,7 @@ from flet.core.types import (
 )
 
 
-class TileAffinity(Enum):
+class TileAffinity(ExtendedEnum):
     LEADING = "leading"
     TRAILING = "trailing"
     PLATFORM = "platform"

--- a/sdk/python/packages/flet/src/flet/core/file_picker.py
+++ b/sdk/python/packages/flet/src/flet/core/file_picker.py
@@ -266,7 +266,7 @@ class FilePicker(Control):
     @state.setter
     def state(self, value: Optional[FilePickerState]):
         self.__state = value
-        self._set_enum_attr("state", value, FilePickerState)
+        self._set_attr("state", value)
 
     # result
     @property
@@ -308,7 +308,7 @@ class FilePicker(Control):
     @file_type.setter
     def file_type(self, value: FilePickerFileType):
         self.__file_type = value
-        self._set_enum_attr("fileType", value, FilePickerFileType)
+        self._set_attr("fileType", value)
 
     # allowed_extensions
     @property

--- a/sdk/python/packages/flet/src/flet/core/file_picker.py
+++ b/sdk/python/packages/flet/src/flet/core/file_picker.py
@@ -1,10 +1,10 @@
 import json
 from dataclasses import dataclass, field
-from enum import Enum
 from typing import Any, Callable, List, Optional
 
 from flet.core.control import Control
 from flet.core.control_event import ControlEvent
+from flet.core.enumerations import ExtendedEnum
 from flet.core.event_handler import EventHandler
 from flet.core.ref import Ref
 from flet.core.types import OptionalEventCallable
@@ -16,13 +16,13 @@ except ImportError:
     from typing_extensions import Literal
 
 
-class FilePickerState(Enum):
+class FilePickerState(ExtendedEnum):
     PICK_FILES = "pickFiles"
     SAVE_FILE = "saveFile"
     GET_DIRECTORY_PATH = "getDirectoryPath"
 
 
-class FilePickerFileType(Enum):
+class FilePickerFileType(ExtendedEnum):
     ANY = "any"
     MEDIA = "media"
     IMAGE = "image"

--- a/sdk/python/packages/flet/src/flet/core/floating_action_button.py
+++ b/sdk/python/packages/flet/src/flet/core/floating_action_button.py
@@ -9,9 +9,7 @@ from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
     ClipBehavior,
-    ColorEnums,
     ColorValue,
-    IconEnums,
     IconValue,
     MouseCursor,
     OffsetValue,
@@ -212,7 +210,7 @@ class FloatingActionButton(ConstrainedControl):
     @icon.setter
     def icon(self, value: Optional[IconValue]):
         self.__icon = value
-        self._set_enum_attr("icon", value, IconEnums)
+        self._set_attr("icon", value)
 
     # bgcolor
     @property
@@ -222,7 +220,7 @@ class FloatingActionButton(ConstrainedControl):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgcolor", value, ColorEnums)
+        self._set_attr("bgcolor", value)
 
     # url
     @property
@@ -241,7 +239,7 @@ class FloatingActionButton(ConstrainedControl):
     @url_target.setter
     def url_target(self, value: Optional[UrlTarget]):
         self.__url_target = value
-        self._set_enum_attr("urlTarget", value, UrlTarget)
+        self._set_attr("urlTarget", value)
 
     # mouse_cursor
     @property
@@ -251,7 +249,7 @@ class FloatingActionButton(ConstrainedControl):
     @mouse_cursor.setter
     def mouse_cursor(self, value: Optional[MouseCursor]):
         self.__mouse_cursor = value
-        self._set_enum_attr("mouseCursor", value, MouseCursor)
+        self._set_attr("mouseCursor", value)
 
     # on_click
     @property
@@ -335,7 +333,7 @@ class FloatingActionButton(ConstrainedControl):
     @focus_color.setter
     def focus_color(self, value: Optional[ColorValue]):
         self.__focus_color = value
-        self._set_enum_attr("focusColor", value, ColorEnums)
+        self._set_attr("focusColor", value)
 
     # focus_elevation
     @property
@@ -355,7 +353,7 @@ class FloatingActionButton(ConstrainedControl):
     @foreground_color.setter
     def foreground_color(self, value: Optional[ColorValue]):
         self.__foreground_color = value
-        self._set_enum_attr("foregroundColor", value, ColorEnums)
+        self._set_attr("foregroundColor", value)
 
     # highlight_elevation
     @property
@@ -385,4 +383,4 @@ class FloatingActionButton(ConstrainedControl):
     @clip_behavior.setter
     def clip_behavior(self, value: Optional[ClipBehavior]):
         self.__clip_behavior = value
-        self._set_enum_attr("clipBehavior", value, ClipBehavior)
+        self._set_attr("clipBehavior", value)

--- a/sdk/python/packages/flet/src/flet/core/form_field_control.py
+++ b/sdk/python/packages/flet/src/flet/core/form_field_control.py
@@ -11,10 +11,8 @@ from flet.core.text_style import TextStyle
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
     BorderRadiusValue,
-    ColorEnums,
     ColorValue,
     DurationValue,
-    IconEnums,
     IconValueOrControl,
     OffsetValue,
     OptionalControlEventCallable,
@@ -300,7 +298,7 @@ class FormFieldControl(ConstrainedControl):
     @icon.setter
     def icon(self, value: Optional[IconValueOrControl]):
         self.__icon = value
-        self._set_enum_attr("icon", value, IconEnums)
+        self._set_attr("icon", value)
 
     # border
     @property
@@ -310,7 +308,7 @@ class FormFieldControl(ConstrainedControl):
     @border.setter
     def border(self, value: Optional[InputBorder]):
         self.__border = value
-        self._set_enum_attr("border", value, InputBorder)
+        self._set_attr("border", value)
 
     # color
     @property
@@ -320,7 +318,7 @@ class FormFieldControl(ConstrainedControl):
     @color.setter
     def color(self, value: Optional[ColorValue]):
         self.__color = value
-        self._set_enum_attr("color", value, ColorEnums)
+        self._set_attr("color", value)
 
     # focus_color
     @property
@@ -429,7 +427,7 @@ class FormFieldControl(ConstrainedControl):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgcolor", value, ColorEnums)
+        self._set_attr("bgcolor", value)
 
     # border_radius
     @property
@@ -457,7 +455,7 @@ class FormFieldControl(ConstrainedControl):
     @border_color.setter
     def border_color(self, value: Optional[ColorValue]):
         self.__border_color = value
-        self._set_enum_attr("borderColor", value, ColorEnums)
+        self._set_attr("borderColor", value)
 
     # text_vertical_align
     @property
@@ -479,7 +477,7 @@ class FormFieldControl(ConstrainedControl):
     @focused_color.setter
     def focused_color(self, value: Optional[ColorValue]):
         self.__focused_color = value
-        self._set_enum_attr("focusedColor", value, ColorEnums)
+        self._set_attr("focusedColor", value)
 
     # focused_bgcolor
     @property
@@ -489,7 +487,7 @@ class FormFieldControl(ConstrainedControl):
     @focused_bgcolor.setter
     def focused_bgcolor(self, value: Optional[str]):
         self.__focused_bgcolor = value
-        self._set_enum_attr("focusedBgcolor", value, ColorEnums)
+        self._set_attr("focusedBgcolor", value)
 
     # focused_border_width
     @property
@@ -508,7 +506,7 @@ class FormFieldControl(ConstrainedControl):
     @focused_border_color.setter
     def focused_border_color(self, value: Optional[ColorValue]):
         self.__focused_border_color = value
-        self._set_enum_attr("focusedBorderColor", value, ColorEnums)
+        self._set_attr("focusedBorderColor", value)
 
     # content_padding
     @property
@@ -653,7 +651,7 @@ class FormFieldControl(ConstrainedControl):
     @prefix_icon.setter
     def prefix_icon(self, value: Optional[IconValueOrControl]):
         self.__prefix_icon = value
-        self._set_enum_attr("prefixIcon", value, IconEnums)
+        self._set_attr("prefixIcon", value)
 
     # prefix_text
     @property
@@ -690,7 +688,7 @@ class FormFieldControl(ConstrainedControl):
     @suffix_icon.setter
     def suffix_icon(self, value: Optional[IconValueOrControl]):
         self.__suffix_icon = value
-        self._set_enum_attr("suffixIcon", value, IconEnums)
+        self._set_attr("suffixIcon", value)
 
     # suffix_text
     @property
@@ -718,7 +716,7 @@ class FormFieldControl(ConstrainedControl):
     @fill_color.setter
     def fill_color(self, value: Optional[ColorValue]):
         self.__fill_color = value
-        self._set_enum_attr("fillColor", value, ColorEnums)
+        self._set_attr("fillColor", value)
 
     # hover_color
     @property
@@ -728,4 +726,4 @@ class FormFieldControl(ConstrainedControl):
     @hover_color.setter
     def hover_color(self, value: Optional[ColorValue]):
         self.__hover_color = value
-        self._set_enum_attr("hoverColor", value, ColorEnums)
+        self._set_attr("hoverColor", value)

--- a/sdk/python/packages/flet/src/flet/core/form_field_control.py
+++ b/sdk/python/packages/flet/src/flet/core/form_field_control.py
@@ -1,4 +1,3 @@
-from enum import Enum
 from typing import Any, Optional, Union
 
 from flet.core.animation import AnimationValue
@@ -6,6 +5,7 @@ from flet.core.badge import BadgeValue
 from flet.core.box import BoxConstraints
 from flet.core.constrained_control import ConstrainedControl
 from flet.core.control import Control, OptionalNumber
+from flet.core.enumerations import ExtendedEnum
 from flet.core.ref import Ref
 from flet.core.text_style import TextStyle
 from flet.core.tooltip import TooltipValue
@@ -29,7 +29,7 @@ except ImportError:
     from typing_extensions import Literal
 
 
-class InputBorder(Enum):
+class InputBorder(ExtendedEnum):
     NONE = "none"
     OUTLINE = "outline"
     UNDERLINE = "underline"

--- a/sdk/python/packages/flet/src/flet/core/geolocator.py
+++ b/sdk/python/packages/flet/src/flet/core/geolocator.py
@@ -1,10 +1,10 @@
 import json
 from dataclasses import dataclass
-from enum import Enum
 from typing import Any, Optional
 
 from flet.core.control import Control
 from flet.core.control_event import ControlEvent
+from flet.core.enumerations import ExtendedEnum
 from flet.core.event_handler import EventHandler
 from flet.core.ref import Ref
 from flet.core.types import (
@@ -16,7 +16,7 @@ from flet.core.types import (
 )
 
 
-class GeolocatorPositionAccuracy(Enum):
+class GeolocatorPositionAccuracy(ExtendedEnum):
     LOWEST = "lowest"
     LOW = "low"
     MEDIUM = "medium"
@@ -26,7 +26,7 @@ class GeolocatorPositionAccuracy(Enum):
     REDUCED = "reduced"
 
 
-class GeolocatorPermissionStatus(Enum):
+class GeolocatorPermissionStatus(ExtendedEnum):
     DENIED = "denied"
     DENIED_FOREVER = "deniedForever"
     WHILE_IN_USE = "whileInUse"
@@ -34,7 +34,7 @@ class GeolocatorPermissionStatus(Enum):
     UNABLE_TO_DETERMINE = "unableToDetermine"
 
 
-class GeolocatorActivityType(Enum):
+class GeolocatorActivityType(ExtendedEnum):
     AUTOMOTIVE_NAVIGATION = "automotiveNavigation"
     FITNESS = "fitness"
     OTHER_NAVIGATION = "otherNavigation"

--- a/sdk/python/packages/flet/src/flet/core/gesture_detector.py
+++ b/sdk/python/packages/flet/src/flet/core/gesture_detector.py
@@ -355,7 +355,7 @@ class GestureDetector(ConstrainedControl, AdaptiveControl):
     @mouse_cursor.setter
     def mouse_cursor(self, value: Optional[MouseCursor]):
         self.__mouse_cursor = value
-        self._set_enum_attr("mouseCursor", value, MouseCursor)
+        self._set_attr("mouseCursor", value)
 
     # drag_interval
     @property

--- a/sdk/python/packages/flet/src/flet/core/gradients.py
+++ b/sdk/python/packages/flet/src/flet/core/gradients.py
@@ -1,14 +1,14 @@
 import dataclasses
 import math
 from dataclasses import field
-from enum import Enum
 from typing import List, Optional, Union
 
 from flet.core import alignment
 from flet.core.alignment import Alignment
+from flet.core.enumerations import ExtendedEnum
 
 
-class GradientTileMode(Enum):
+class GradientTileMode(ExtendedEnum):
     CLAMP = "clamp"
     DECAL = "decal"
     MIRROR = "mirror"

--- a/sdk/python/packages/flet/src/flet/core/grid_view.py
+++ b/sdk/python/packages/flet/src/flet/core/grid_view.py
@@ -286,7 +286,7 @@ class GridView(ConstrainedControl, ScrollableControl, AdaptiveControl):
     @clip_behavior.setter
     def clip_behavior(self, value: Optional[ClipBehavior]):
         self.__clip_behavior = value
-        self._set_enum_attr("clipBehavior", value, ClipBehavior)
+        self._set_attr("clipBehavior", value)
 
     # semantic_child_count
     @property

--- a/sdk/python/packages/flet/src/flet/core/icon.py
+++ b/sdk/python/packages/flet/src/flet/core/icon.py
@@ -8,9 +8,7 @@ from flet.core.control import OptionalNumber
 from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
-    IconEnums,
     IconValue,
     OffsetValue,
     OptionalControlEventCallable,
@@ -141,7 +139,7 @@ class Icon(ConstrainedControl):
     @name.setter
     def name(self, value: Optional[IconValue]):
         self.__name = value
-        self._set_enum_attr("name", value, IconEnums)
+        self._set_attr("name", value)
 
     # color
     @property
@@ -151,7 +149,7 @@ class Icon(ConstrainedControl):
     @color.setter
     def color(self, value: Optional[ColorValue]):
         self.__color = value
-        self._set_enum_attr("color", value, ColorEnums)
+        self._set_attr("color", value)
 
     # size
     @property

--- a/sdk/python/packages/flet/src/flet/core/icon_button.py
+++ b/sdk/python/packages/flet/src/flet/core/icon_button.py
@@ -25,6 +25,7 @@ from flet.core.types import (
     UrlTarget,
     VisualDensity,
 )
+from flet.utils import deprecated
 
 
 class IconButton(ConstrainedControl, AdaptiveControl):

--- a/sdk/python/packages/flet/src/flet/core/icon_button.py
+++ b/sdk/python/packages/flet/src/flet/core/icon_button.py
@@ -12,9 +12,7 @@ from flet.core.control import Control, OptionalNumber
 from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
-    IconEnums,
     IconValue,
     MouseCursor,
     OffsetValue,
@@ -27,7 +25,6 @@ from flet.core.types import (
     UrlTarget,
     VisualDensity,
 )
-from flet.utils import deprecated
 
 
 class IconButton(ConstrainedControl, AdaptiveControl):
@@ -232,7 +229,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
     @icon.setter
     def icon(self, value: Optional[IconValue]):
         self.__icon = value
-        self._set_enum_attr("icon", value, IconEnums)
+        self._set_attr("icon", value)
 
     # selected_icon
     @property
@@ -242,7 +239,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
     @selected_icon.setter
     def selected_icon(self, value: Optional[IconValue]):
         self.__selected_icon = value
-        self._set_enum_attr("selectedIcon", value, IconEnums)
+        self._set_attr("selectedIcon", value)
 
     # icon_size
     @property
@@ -270,7 +267,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
     @splash_color.setter
     def splash_color(self, value: Optional[ColorValue]):
         self.__splash_color = value
-        self._set_enum_attr("splashColor", value, ColorEnums)
+        self._set_attr("splashColor", value)
 
     # icon_color
     @property
@@ -280,7 +277,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
     @icon_color.setter
     def icon_color(self, value: Optional[ColorValue]):
         self.__icon_color = value
-        self._set_enum_attr("iconColor", value, ColorEnums)
+        self._set_attr("iconColor", value)
 
     # highlight_color
     @property
@@ -290,7 +287,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
     @highlight_color.setter
     def highlight_color(self, value: Optional[ColorValue]):
         self.__highlight_color = value
-        self._set_enum_attr("highlightColor", value, ColorEnums)
+        self._set_attr("highlightColor", value)
 
     # selected_icon_color
     @property
@@ -300,7 +297,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
     @selected_icon_color.setter
     def selected_icon_color(self, value: Optional[ColorValue]):
         self.__selected_icon_color = value
-        self._set_enum_attr("selectedIconColor", value, ColorEnums)
+        self._set_attr("selectedIconColor", value)
 
     # bgcolor
     @property
@@ -310,7 +307,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgcolor", value, ColorEnums)
+        self._set_attr("bgcolor", value)
 
     # hover_color
     @property
@@ -320,7 +317,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
     @hover_color.setter
     def hover_color(self, value: Optional[ColorValue]):
         self.__hover_color = value
-        self._set_enum_attr("hoverColor", value, ColorEnums)
+        self._set_attr("hoverColor", value)
 
     # focus_color
     @property
@@ -330,7 +327,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
     @focus_color.setter
     def focus_color(self, value: Optional[ColorValue]):
         self.__focus_color = value
-        self._set_enum_attr("focusColor", value, ColorEnums)
+        self._set_attr("focusColor", value)
 
     # disabled_color
     @property
@@ -340,7 +337,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
     @disabled_color.setter
     def disabled_color(self, value: Optional[ColorValue]):
         self.__disabled_color = value
-        self._set_enum_attr("disabledColor", value, ColorEnums)
+        self._set_attr("disabledColor", value)
 
     # padding
     @property
@@ -404,7 +401,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
     @url_target.setter
     def url_target(self, value: Optional[UrlTarget]):
         self.__url_target = value
-        self._set_enum_attr("urlTarget", value, UrlTarget)
+        self._set_attr("urlTarget", value)
 
     # mouse_cursor
     @property
@@ -414,7 +411,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
     @mouse_cursor.setter
     def mouse_cursor(self, value: Optional[MouseCursor]):
         self.__mouse_cursor = value
-        self._set_enum_attr("mouseCursor", value, MouseCursor)
+        self._set_attr("mouseCursor", value)
 
     # visual_density
     @property
@@ -424,7 +421,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
     @visual_density.setter
     def visual_density(self, value: Union[None, ThemeVisualDensity, VisualDensity]):
         self.__visual_density = value
-        self._set_enum_attr("visualDensity", value, (ThemeVisualDensity, VisualDensity))
+        self._set_attr("visualDensity", value)
 
     # on_click
     @property

--- a/sdk/python/packages/flet/src/flet/core/icons.py
+++ b/sdk/python/packages/flet/src/flet/core/icons.py
@@ -8,7 +8,7 @@ sh ci/generate_material_icons_python.sh
 
 import random
 from enum import Enum, EnumMeta
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 from warnings import warn
 
 from flet.utils import deprecated
@@ -17782,3 +17782,6 @@ class Icons(str, Enum):
     ZOOM_OUT_MAP_SHARP = "zoom_out_map_sharp"
     ZOOM_OUT_MAP_ROUNDED = "zoom_out_map_rounded"
     ZOOM_OUT_MAP_OUTLINED = "zoom_out_map_outlined"
+
+
+MaterialIconEnums = Union[icons, Icons]

--- a/sdk/python/packages/flet/src/flet/core/image.py
+++ b/sdk/python/packages/flet/src/flet/core/image.py
@@ -7,10 +7,18 @@ from flet.core.constrained_control import ConstrainedControl
 from flet.core.control import Control, OptionalNumber
 from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
-from flet.core.types import (BlendMode, BorderRadiusValue, ColorEnums,
-                             ColorValue, ImageFit, ImageRepeat, OffsetValue,
-                             OptionalControlEventCallable, ResponsiveNumber,
-                             RotateValue, ScaleValue)
+from flet.core.types import (
+    BlendMode,
+    BorderRadiusValue,
+    ColorValue,
+    ImageFit,
+    ImageRepeat,
+    OffsetValue,
+    OptionalControlEventCallable,
+    ResponsiveNumber,
+    RotateValue,
+    ScaleValue,
+)
 
 try:
     from typing import Literal
@@ -198,7 +206,7 @@ class Image(ConstrainedControl):
     @repeat.setter
     def repeat(self, value: Optional[ImageRepeat]):
         self.__repeat = value
-        self._set_enum_attr("repeat", value, ImageRepeat)
+        self._set_attr("repeat", value)
 
     # border_radius
     @property
@@ -217,7 +225,7 @@ class Image(ConstrainedControl):
     @color.setter
     def color(self, value: Optional[ColorValue]):
         self.__color = value
-        self._set_enum_attr("color", value, ColorEnums)
+        self._set_attr("color", value)
 
     # color_blend_mode
     @property
@@ -227,7 +235,7 @@ class Image(ConstrainedControl):
     @color_blend_mode.setter
     def color_blend_mode(self, value: Optional[BlendMode]):
         self.__blend_mode = value
-        self._set_enum_attr("colorBlendMode", value, BlendMode)
+        self._set_attr("colorBlendMode", value)
 
     # gapless_playback
     @property

--- a/sdk/python/packages/flet/src/flet/core/interactive_viewer.py
+++ b/sdk/python/packages/flet/src/flet/core/interactive_viewer.py
@@ -312,7 +312,7 @@ class InteractiveViewer(ConstrainedControl, AdaptiveControl):
     @clip_behavior.setter
     def clip_behavior(self, value: Optional[ClipBehavior]):
         self.__clip_behavior = value
-        self._set_enum_attr("clipBehavior", value, ClipBehavior)
+        self._set_attr("clipBehavior", value)
 
     # alignment
     @property

--- a/sdk/python/packages/flet/src/flet/core/list_tile.py
+++ b/sdk/python/packages/flet/src/flet/core/list_tile.py
@@ -1,4 +1,3 @@
-from enum import Enum
 from typing import Any, Optional, Union
 
 from flet.core.adaptive_control import AdaptiveControl
@@ -7,6 +6,7 @@ from flet.core.badge import BadgeValue
 from flet.core.buttons import OutlinedBorder
 from flet.core.constrained_control import ConstrainedControl
 from flet.core.control import Control, OptionalNumber
+from flet.core.enumerations import ExtendedEnum
 from flet.core.ref import Ref
 from flet.core.text_style import TextStyle
 from flet.core.tooltip import TooltipValue
@@ -25,7 +25,7 @@ from flet.core.types import (
 )
 
 
-class ListTileTitleAlignment(Enum):
+class ListTileTitleAlignment(ExtendedEnum):
     TOP = "top"
     CENTER = "center"
     BOTTOM = "bottom"
@@ -33,7 +33,7 @@ class ListTileTitleAlignment(Enum):
     TITLE_HEIGHT = "titleHeight"
 
 
-class ListTileStyle(Enum):
+class ListTileStyle(ExtendedEnum):
     LIST = "list"
     DRAWER = "drawer"
 

--- a/sdk/python/packages/flet/src/flet/core/list_tile.py
+++ b/sdk/python/packages/flet/src/flet/core/list_tile.py
@@ -10,10 +10,19 @@ from flet.core.control import Control, OptionalNumber
 from flet.core.ref import Ref
 from flet.core.text_style import TextStyle
 from flet.core.tooltip import TooltipValue
-from flet.core.types import (ColorEnums, ColorValue, MouseCursor, OffsetValue,
-                             OptionalControlEventCallable, PaddingValue,
-                             ResponsiveNumber, RotateValue, ScaleValue,
-                             ThemeVisualDensity, UrlTarget, VisualDensity)
+from flet.core.types import (
+    ColorValue,
+    MouseCursor,
+    OffsetValue,
+    OptionalControlEventCallable,
+    PaddingValue,
+    ResponsiveNumber,
+    RotateValue,
+    ScaleValue,
+    ThemeVisualDensity,
+    UrlTarget,
+    VisualDensity,
+)
 
 
 class ListTileTitleAlignment(Enum):
@@ -258,7 +267,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgcolor", value, ColorEnums)
+        self._set_attr("bgcolor", value)
 
     # selected_color
     @property
@@ -268,7 +277,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
     @selected_color.setter
     def selected_color(self, value: Optional[ColorValue]):
         self.__selected_color = value
-        self._set_enum_attr("selectedColor", value, ColorEnums)
+        self._set_attr("selectedColor", value)
 
     # selected_tile_color
     @property
@@ -278,7 +287,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
     @selected_tile_color.setter
     def selected_tile_color(self, value: Optional[ColorValue]):
         self.__selected_tile_color = value
-        self._set_enum_attr("selectedTileColor", value, ColorEnums)
+        self._set_attr("selectedTileColor", value)
 
     # bgcolor_activated
     @property
@@ -324,7 +333,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
     @hover_color.setter
     def hover_color(self, value: Optional[ColorValue]):
         self.__hover_color = value
-        self._set_enum_attr("hoverColor", value, ColorEnums)
+        self._set_attr("hoverColor", value)
 
     # leading
     @property
@@ -397,7 +406,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
     @style.setter
     def style(self, value: Optional[ListTileStyle]):
         self.__style = value
-        self._set_enum_attr("style", value, ListTileStyle)
+        self._set_attr("style", value)
 
     # title_alignment
     @property
@@ -407,7 +416,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
     @title_alignment.setter
     def title_alignment(self, value: Optional[ListTileTitleAlignment]):
         self.__title_alignment = value
-        self._set_enum_attr("titleAlignment", value, ListTileTitleAlignment)
+        self._set_attr("titleAlignment", value)
 
     # selected
     @property
@@ -462,7 +471,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
     @icon_color.setter
     def icon_color(self, value: Optional[ColorValue]):
         self.__icon_color = value
-        self._set_enum_attr("iconColor", value, ColorEnums)
+        self._set_attr("iconColor", value)
 
     # text_color
     @property
@@ -472,7 +481,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
     @text_color.setter
     def text_color(self, value: Optional[ColorValue]):
         self.__text_color = value
-        self._set_enum_attr("textColor", value, ColorEnums)
+        self._set_attr("textColor", value)
 
     # url_target
     @property
@@ -482,7 +491,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
     @url_target.setter
     def url_target(self, value: Optional[UrlTarget]):
         self.__url_target = value
-        self._set_enum_attr("urlTarget", value, UrlTarget)
+        self._set_attr("urlTarget", value)
 
     # mouse_cursor
     @property
@@ -492,7 +501,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
     @mouse_cursor.setter
     def mouse_cursor(self, value: Optional[MouseCursor]):
         self.__mouse_cursor = value
-        self._set_enum_attr("mouseCursor", value, MouseCursor)
+        self._set_attr("mouseCursor", value)
 
     # visual_density
     @property
@@ -502,7 +511,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
     @visual_density.setter
     def visual_density(self, value: Union[None, ThemeVisualDensity, VisualDensity]):
         self.__visual_density = value
-        self._set_enum_attr("visualDensity", value, (ThemeVisualDensity, VisualDensity))
+        self._set_attr("visualDensity", value)
 
     # shape
     @property

--- a/sdk/python/packages/flet/src/flet/core/list_view.py
+++ b/sdk/python/packages/flet/src/flet/core/list_view.py
@@ -264,7 +264,7 @@ class ListView(ConstrainedControl, ScrollableControl, AdaptiveControl):
     @clip_behavior.setter
     def clip_behavior(self, value: Optional[ClipBehavior]):
         self.__clip_behavior = value
-        self._set_enum_attr("clipBehavior", value, ClipBehavior)
+        self._set_attr("clipBehavior", value)
 
     # semantic_child_count
     @property

--- a/sdk/python/packages/flet/src/flet/core/lottie.py
+++ b/sdk/python/packages/flet/src/flet/core/lottie.py
@@ -169,7 +169,7 @@ class Lottie(ConstrainedControl):
     @filter_quality.setter
     def filter_quality(self, value: Optional[FilterQuality]):
         self.__filter_quality = value
-        self._set_enum_attr("filterQuality", value, FilterQuality)
+        self._set_attr("filterQuality", value)
 
     # fit
     @property
@@ -179,7 +179,7 @@ class Lottie(ConstrainedControl):
     @fit.setter
     def fit(self, value: Optional[ImageFit]):
         self.__fit = value
-        self._set_enum_attr("fit", value, ImageFit)
+        self._set_attr("fit", value)
 
     # background_loading
     @property

--- a/sdk/python/packages/flet/src/flet/core/map/circle_layer.py
+++ b/sdk/python/packages/flet/src/flet/core/map/circle_layer.py
@@ -4,7 +4,7 @@ from flet.core.control import Control, OptionalNumber
 from flet.core.map.map import MapLatitudeLongitude
 from flet.core.map.map_layer import MapLayer
 from flet.core.ref import Ref
-from flet.core.types import ColorEnums, ColorValue
+from flet.core.types import ColorValue
 
 
 class CircleMarker(Control):
@@ -70,7 +70,7 @@ class CircleMarker(Control):
     @color.setter
     def color(self, value: Optional[ColorValue]):
         self.__color = value
-        self._set_enum_attr("color", value, ColorEnums)
+        self._set_attr("color", value)
 
     # border_color
     @property
@@ -80,7 +80,7 @@ class CircleMarker(Control):
     @border_color.setter
     def border_color(self, value: Optional[ColorValue]):
         self.__border_color = value
-        self._set_enum_attr("borderColor", value, ColorEnums)
+        self._set_attr("borderColor", value)
 
     # radius
     @property

--- a/sdk/python/packages/flet/src/flet/core/map/map.py
+++ b/sdk/python/packages/flet/src/flet/core/map/map.py
@@ -1,6 +1,6 @@
 import json
 from dataclasses import dataclass
-from enum import Enum, EnumMeta, IntFlag
+from enum import EnumMeta, IntFlag
 from typing import Any, List, Optional, Tuple, Union
 from warnings import warn
 
@@ -8,6 +8,7 @@ from flet.core.animation import AnimationCurve, AnimationValue
 from flet.core.badge import BadgeValue
 from flet.core.constrained_control import ConstrainedControl
 from flet.core.control import OptionalNumber
+from flet.core.enumerations import ExtendedEnum
 from flet.core.event_handler import EventHandler
 from flet.core.map.map_layer import MapLayer
 from flet.core.ref import Ref
@@ -88,7 +89,7 @@ class MapPointerDeviceTypeDeprecated(EnumMeta):
         return EnumMeta.__getattribute__(self, item)
 
 
-class MapPointerDeviceType(Enum, metaclass=MapPointerDeviceTypeDeprecated):
+class MapPointerDeviceType(ExtendedEnum, metaclass=MapPointerDeviceTypeDeprecated):
     TOUCH = "touch"
     MOUSE = "mouse"
     STYLUS = "stylus"
@@ -585,7 +586,7 @@ class Map(ConstrainedControl):
         self._set_attr("onPointerUp", True if handler is not None else None)
 
 
-class MapEventSource(Enum):
+class MapEventSource(ExtendedEnum):
     MAP_CONTROLLER = "mapController"
     TAP = "tap"
     SECONDARY_TAP = "secondaryTap"

--- a/sdk/python/packages/flet/src/flet/core/map/map.py
+++ b/sdk/python/packages/flet/src/flet/core/map/map.py
@@ -14,7 +14,6 @@ from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.transform import Offset
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
     ControlEvent,
     DurationValue,
@@ -435,7 +434,7 @@ class Map(ConstrainedControl):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgcolor", value, ColorEnums)
+        self._set_attr("bgcolor", value)
 
     # keep_alive
     @property
@@ -472,7 +471,7 @@ class Map(ConstrainedControl):
     @animation_curve.setter
     def animation_curve(self, value: Optional[AnimationCurve]):
         self.__animation_curve = value
-        self._set_enum_attr("animationCurve", value, AnimationCurve)
+        self._set_attr("animationCurve", value)
 
     # animation_duration
     @property

--- a/sdk/python/packages/flet/src/flet/core/map/polygon_layer.py
+++ b/sdk/python/packages/flet/src/flet/core/map/polygon_layer.py
@@ -5,7 +5,7 @@ from flet.core.map.map import MapLatitudeLongitude
 from flet.core.map.map_layer import MapLayer
 from flet.core.ref import Ref
 from flet.core.text_style import TextStyle
-from flet.core.types import ColorEnums, ColorValue, StrokeCap, StrokeJoin
+from flet.core.types import ColorValue, StrokeCap, StrokeJoin
 
 
 class PolygonMarker(Control):
@@ -71,7 +71,7 @@ class PolygonMarker(Control):
     @stroke_cap.setter
     def stroke_cap(self, value: Optional[StrokeCap]):
         self.__stroke_cap = value
-        self._set_enum_attr("strokeCap", value, StrokeCap)
+        self._set_attr("strokeCap", value)
 
     # stroke_join
     @property
@@ -81,7 +81,7 @@ class PolygonMarker(Control):
     @stroke_join.setter
     def stroke_join(self, value: Optional[StrokeJoin]):
         self.__stroke_join = value
-        self._set_enum_attr("strokeJoin", value, StrokeJoin)
+        self._set_attr("strokeJoin", value)
 
     # label_text_style
     @property
@@ -127,7 +127,7 @@ class PolygonMarker(Control):
     @color.setter
     def color(self, value: Optional[ColorValue]):
         self.__color = value
-        self._set_enum_attr("color", value, ColorEnums)
+        self._set_attr("color", value)
 
     # border_color
     @property
@@ -137,7 +137,7 @@ class PolygonMarker(Control):
     @border_color.setter
     def border_color(self, value: Optional[ColorValue]):
         self.__border_color = value
-        self._set_enum_attr("borderColor", value, ColorEnums)
+        self._set_attr("borderColor", value)
 
     # border_stroke_width
     @property

--- a/sdk/python/packages/flet/src/flet/core/map/polyline_layer.py
+++ b/sdk/python/packages/flet/src/flet/core/map/polyline_layer.py
@@ -1,15 +1,15 @@
 from dataclasses import dataclass
-from enum import Enum
 from typing import Any, List, Optional, Union
 
 from flet.core.control import Control, OptionalNumber
+from flet.core.enumerations import ExtendedEnum
 from flet.core.map.map import MapLatitudeLongitude
 from flet.core.map.map_layer import MapLayer
 from flet.core.ref import Ref
 from flet.core.types import ColorValue, StrokeCap, StrokeJoin
 
 
-class PatternFit(Enum):
+class PatternFit(ExtendedEnum):
     SCALE_DOWN = "scaleDown"
     SCALE_UP = "scaleUp"
     APPEND_DOT = "appendDot"

--- a/sdk/python/packages/flet/src/flet/core/map/polyline_layer.py
+++ b/sdk/python/packages/flet/src/flet/core/map/polyline_layer.py
@@ -6,7 +6,7 @@ from flet.core.control import Control, OptionalNumber
 from flet.core.map.map import MapLatitudeLongitude
 from flet.core.map.map_layer import MapLayer
 from flet.core.ref import Ref
-from flet.core.types import ColorEnums, ColorValue, StrokeCap, StrokeJoin
+from flet.core.types import ColorValue, StrokeCap, StrokeJoin
 
 
 class PatternFit(Enum):
@@ -113,7 +113,7 @@ class PolylineMarker(Control):
     @stroke_cap.setter
     def stroke_cap(self, value: Optional[StrokeCap]):
         self.__stroke_cap = value
-        self._set_enum_attr("strokeCap", value, StrokeCap)
+        self._set_attr("strokeCap", value)
 
     # gradient_colors
     @property
@@ -150,7 +150,7 @@ class PolylineMarker(Control):
     @stroke_join.setter
     def stroke_join(self, value: Optional[StrokeJoin]):
         self.__stroke_join = value
-        self._set_enum_attr("strokeJoin", value, StrokeJoin)
+        self._set_attr("strokeJoin", value)
 
     # use_stroke_width_in_meter
     @property
@@ -171,7 +171,7 @@ class PolylineMarker(Control):
     @color.setter
     def color(self, value: Optional[ColorValue]):
         self.__color = value
-        self._set_enum_attr("color", value, ColorEnums)
+        self._set_attr("color", value)
 
     # border_color
     @property
@@ -181,7 +181,7 @@ class PolylineMarker(Control):
     @border_color.setter
     def border_color(self, value: Optional[ColorValue]):
         self.__border_color = value
-        self._set_enum_attr("borderColor", value, ColorEnums)
+        self._set_attr("borderColor", value)
 
     # border_stroke_width
     @property

--- a/sdk/python/packages/flet/src/flet/core/map/rich_attribution.py
+++ b/sdk/python/packages/flet/src/flet/core/map/rich_attribution.py
@@ -1,15 +1,15 @@
-from enum import Enum
 from typing import Any, List, Optional
 
 from flet.core.border_radius import BorderRadius
 from flet.core.control import OptionalNumber
+from flet.core.enumerations import ExtendedEnum
 from flet.core.map.map_layer import MapLayer
 from flet.core.map.text_source_attribution import TextSourceAttribution
 from flet.core.ref import Ref
 from flet.core.types import ColorValue
 
 
-class AttributionAlignment(Enum):
+class AttributionAlignment(ExtendedEnum):
     BOTTOM_LEFT = "bottomLeft"
     BOTTOM_RIGHT = "bottomRight"
 

--- a/sdk/python/packages/flet/src/flet/core/map/rich_attribution.py
+++ b/sdk/python/packages/flet/src/flet/core/map/rich_attribution.py
@@ -6,7 +6,7 @@ from flet.core.control import OptionalNumber
 from flet.core.map.map_layer import MapLayer
 from flet.core.map.text_source_attribution import TextSourceAttribution
 from flet.core.ref import Ref
-from flet.core.types import ColorEnums, ColorValue
+from flet.core.types import ColorValue
 
 
 class AttributionAlignment(Enum):
@@ -108,7 +108,7 @@ class RichAttribution(MapLayer):
     @alignment.setter
     def alignment(self, value: Optional[AttributionAlignment]):
         self.__alignment = value
-        self._set_enum_attr("alignment", value, AttributionAlignment)
+        self._set_attr("alignment", value)
 
     # show_flutter_map_attribution
     @property
@@ -129,7 +129,7 @@ class RichAttribution(MapLayer):
     @popup_bgcolor.setter
     def popup_bgcolor(self, value: Optional[str]):
         self.__popup_bgcolor = value
-        self._set_enum_attr("popupBgcolor", value, ColorEnums)
+        self._set_attr("popupBgcolor", value)
 
     # attributions
     @property

--- a/sdk/python/packages/flet/src/flet/core/map/simple_attribution.py
+++ b/sdk/python/packages/flet/src/flet/core/map/simple_attribution.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 from flet.core.alignment import Alignment
 from flet.core.map.map_layer import MapLayer
 from flet.core.ref import Ref
-from flet.core.types import ColorEnums, ColorValue, OptionalControlEventCallable
+from flet.core.types import ColorValue, OptionalControlEventCallable
 
 
 class SimpleAttribution(MapLayer):
@@ -65,7 +65,7 @@ class SimpleAttribution(MapLayer):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgcolor", value, ColorEnums)
+        self._set_attr("bgcolor", value)
 
     # text
     @property

--- a/sdk/python/packages/flet/src/flet/core/map/tile_layer.py
+++ b/sdk/python/packages/flet/src/flet/core/map/tile_layer.py
@@ -1,14 +1,14 @@
-from enum import Enum
 from typing import Any, Dict, List, Optional
 
 from flet.core.control import OptionalNumber
+from flet.core.enumerations import ExtendedEnum
 from flet.core.map.map import MapLatitudeLongitudeBounds
 from flet.core.map.map_layer import MapLayer
 from flet.core.ref import Ref
 from flet.core.types import OptionalControlEventCallable
 
 
-class MapTileLayerEvictErrorTileStrategy(Enum):
+class MapTileLayerEvictErrorTileStrategy(ExtendedEnum):
     DISPOSE = "dispose"
     NOT_VISIBLE = "notVisible"
     NOT_VISIBLE_RESPECT_MARGIN = "notVisibleRespectMargin"

--- a/sdk/python/packages/flet/src/flet/core/map/tile_layer.py
+++ b/sdk/python/packages/flet/src/flet/core/map/tile_layer.py
@@ -264,9 +264,7 @@ class TileLayer(MapLayer):
         self, value: Optional[MapTileLayerEvictErrorTileStrategy]
     ):
         self.__evict_error_tile_strategy = value
-        self._set_enum_attr(
-            "evictErrorTileStrategy", value, MapTileLayerEvictErrorTileStrategy
-        )
+        self._set_attr("evictErrorTileStrategy", value)
 
     # on_image_error
     @property

--- a/sdk/python/packages/flet/src/flet/core/markdown.py
+++ b/sdk/python/packages/flet/src/flet/core/markdown.py
@@ -9,6 +9,7 @@ from flet.core.badge import BadgeValue
 from flet.core.box import BoxDecoration
 from flet.core.constrained_control import ConstrainedControl
 from flet.core.control import Control, OptionalNumber
+from flet.core.enumerations import ExtendedEnum
 from flet.core.event_handler import EventHandler
 from flet.core.ref import Ref
 from flet.core.text import TextSelectionChangeEvent
@@ -32,7 +33,7 @@ except ImportError:
     from typing_extensions import Literal
 
 
-class MarkdownExtensionSet(Enum):
+class MarkdownExtensionSet(ExtendedEnum):
     NONE = "none"
     COMMON_MARK = "commonMark"
     GITHUB_WEB = "gitHubWeb"
@@ -132,7 +133,7 @@ class MarkdownStyleSheet:
     unordered_list_alignment: Optional[MainAxisAlignment] = None
 
 
-class MarkdownCodeTheme(Enum):
+class MarkdownCodeTheme(ExtendedEnum):
     A11Y_DARK = "a11y-dark"
     A11Y_LIGHT = "a11y-light"
     AGATE = "agate"

--- a/sdk/python/packages/flet/src/flet/core/markdown.py
+++ b/sdk/python/packages/flet/src/flet/core/markdown.py
@@ -466,7 +466,7 @@ class Markdown(ConstrainedControl):
     @extension_set.setter
     def extension_set(self, value: Optional[MarkdownExtensionSet]):
         self.__extension_set = value
-        self._set_enum_attr("extensionSet", value, MarkdownExtensionSet)
+        self._set_attr("extensionSet", value)
 
     # code_style_sheet
     @property

--- a/sdk/python/packages/flet/src/flet/core/menu_bar.py
+++ b/sdk/python/packages/flet/src/flet/core/menu_bar.py
@@ -128,7 +128,7 @@ class MenuBar(Control):
     @clip_behavior.setter
     def clip_behavior(self, value: Optional[ClipBehavior]):
         self.__clip_behavior = value
-        self._set_enum_attr("clipBehavior", value, ClipBehavior)
+        self._set_attr("clipBehavior", value)
 
     # style
     @property

--- a/sdk/python/packages/flet/src/flet/core/menu_item_button.py
+++ b/sdk/python/packages/flet/src/flet/core/menu_item_button.py
@@ -204,7 +204,7 @@ class MenuItemButton(ConstrainedControl):
     @overflow_axis.setter
     def overflow_axis(self, value: Optional[Axis]):
         self.__overflow_axis = value
-        self._set_enum_attr("overflowAxis", value, Axis)
+        self._set_attr("overflowAxis", value)
 
     # leading
     @property
@@ -250,7 +250,7 @@ class MenuItemButton(ConstrainedControl):
     @clip_behavior.setter
     def clip_behavior(self, value: Optional[ClipBehavior]):
         self.__clip_behavior = value
-        self._set_enum_attr("clipBehavior", value, ClipBehavior)
+        self._set_attr("clipBehavior", value)
 
     # on_click
     @property

--- a/sdk/python/packages/flet/src/flet/core/navigation_bar.py
+++ b/sdk/python/packages/flet/src/flet/core/navigation_bar.py
@@ -9,12 +9,9 @@ from flet.core.buttons import OutlinedBorder
 from flet.core.constrained_control import ConstrainedControl
 from flet.core.control import Control
 from flet.core.ref import Ref
-from flet.core.tooltip import TooltipValue
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
     ControlStateValue,
-    IconEnums,
     IconValueOrControl,
     OffsetValue,
     OptionalControlEventCallable,
@@ -23,7 +20,6 @@ from flet.core.types import (
     RotateValue,
     ScaleValue,
 )
-from flet.utils import deprecated
 
 
 class NavigationBarLabelBehavior(Enum):
@@ -106,7 +102,7 @@ class NavigationBarDestination(AdaptiveControl, Control):
     @icon.setter
     def icon(self, value: Optional[IconValueOrControl]):
         self.__icon = value
-        self._set_enum_attr("icon", value, IconEnums)
+        self._set_attr("icon", value)
 
     # icon_content
     @property
@@ -138,7 +134,7 @@ class NavigationBarDestination(AdaptiveControl, Control):
     @selected_icon.setter
     def selected_icon(self, value: Optional[IconValueOrControl]):
         self.__selected_icon = value
-        self._set_enum_attr("selectedIcon", value, IconEnums)
+        self._set_attr("selectedIcon", value)
 
     # selected_icon_content
     @property
@@ -179,7 +175,7 @@ class NavigationBarDestination(AdaptiveControl, Control):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgcolor", value, ColorEnums)
+        self._set_attr("bgcolor", value)
 
     # tooltip
     @property
@@ -390,7 +386,7 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
     @label_behavior.setter
     def label_behavior(self, value: Optional[NavigationBarLabelBehavior]):
         self.__label_behavior = value
-        self._set_enum_attr("labelBehavior", value, NavigationBarLabelBehavior)
+        self._set_attr("labelBehavior", value)
 
     # overlay_color
     @property
@@ -409,7 +405,7 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgcolor", value, ColorEnums)
+        self._set_attr("bgcolor", value)
 
     # elevation
     @property
@@ -428,7 +424,7 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
     @shadow_color.setter
     def shadow_color(self, value: Optional[ColorValue]):
         self.__shadow_color = value
-        self._set_enum_attr("shadowColor", value, ColorEnums)
+        self._set_attr("shadowColor", value)
 
     # indicator_color
     @property
@@ -438,7 +434,7 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
     @indicator_color.setter
     def indicator_color(self, value: Optional[ColorValue]):
         self.__indicator_color = value
-        self._set_enum_attr("indicatorColor", value, ColorEnums)
+        self._set_attr("indicatorColor", value)
 
     # indicator_shape
     @property
@@ -457,7 +453,7 @@ class NavigationBar(ConstrainedControl, AdaptiveControl):
     @surface_tint_color.setter
     def surface_tint_color(self, value: Optional[ColorValue]):
         self.__surface_tint_color = value
-        self._set_enum_attr("surfaceTintColor", value, ColorEnums)
+        self._set_attr("surfaceTintColor", value)
 
     # border
     @property

--- a/sdk/python/packages/flet/src/flet/core/navigation_bar.py
+++ b/sdk/python/packages/flet/src/flet/core/navigation_bar.py
@@ -1,5 +1,4 @@
 import warnings
-from enum import Enum
 from typing import Any, Callable, List, Optional, Union
 
 from flet.core.adaptive_control import AdaptiveControl
@@ -8,7 +7,9 @@ from flet.core.border import Border
 from flet.core.buttons import OutlinedBorder
 from flet.core.constrained_control import ConstrainedControl
 from flet.core.control import Control
+from flet.core.enumerations import ExtendedEnum
 from flet.core.ref import Ref
+from flet.core.tooltip import TooltipValue
 from flet.core.types import (
     ColorValue,
     ControlStateValue,
@@ -20,9 +21,10 @@ from flet.core.types import (
     RotateValue,
     ScaleValue,
 )
+from flet.utils import deprecated
 
 
-class NavigationBarLabelBehavior(Enum):
+class NavigationBarLabelBehavior(ExtendedEnum):
     """Defines how the destinations' labels will be laid out and when they'll be displayed."""
 
     ALWAYS_SHOW = "alwaysShow"

--- a/sdk/python/packages/flet/src/flet/core/navigation_drawer.py
+++ b/sdk/python/packages/flet/src/flet/core/navigation_drawer.py
@@ -6,9 +6,7 @@ from flet.core.buttons import OutlinedBorder
 from flet.core.control import Control
 from flet.core.ref import Ref
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
-    IconEnums,
     IconValueOrControl,
     OptionalControlEventCallable,
     OptionalNumber,
@@ -78,7 +76,7 @@ class NavigationDrawerDestination(Control):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgColor", value, ColorEnums)
+        self._set_attr("bgColor", value)
 
     # icon
     @property
@@ -88,7 +86,7 @@ class NavigationDrawerDestination(Control):
     @icon.setter
     def icon(self, value: Optional[IconValueOrControl]):
         self.__icon = value
-        self._set_enum_attr("icon", value, IconEnums)
+        self._set_attr("icon", value)
 
     # icon_content
     @property
@@ -120,7 +118,7 @@ class NavigationDrawerDestination(Control):
     @selected_icon.setter
     def selected_icon(self, value: Optional[IconValueOrControl]):
         self.__selected_icon = value
-        self._set_enum_attr("selectedIcon", value, IconEnums)
+        self._set_attr("selectedIcon", value)
 
     # selected_icon_content
     @property
@@ -309,7 +307,7 @@ class NavigationDrawer(Control):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgcolor", value, ColorEnums)
+        self._set_attr("bgcolor", value)
 
     # position
     @property
@@ -337,7 +335,7 @@ class NavigationDrawer(Control):
     @indicator_color.setter
     def indicator_color(self, value: Optional[ColorValue]):
         self.__indicator_color = value
-        self._set_enum_attr("indicatorColor", value, ColorEnums)
+        self._set_attr("indicatorColor", value)
 
     # indicator_shape
     @property
@@ -356,7 +354,7 @@ class NavigationDrawer(Control):
     @shadow_color.setter
     def shadow_color(self, value: Optional[ColorValue]):
         self.__shadow_color = value
-        self._set_enum_attr("shadowColor", value, ColorEnums)
+        self._set_attr("shadowColor", value)
 
     # surface_tint_color
     @property
@@ -366,7 +364,7 @@ class NavigationDrawer(Control):
     @surface_tint_color.setter
     def surface_tint_color(self, value: Optional[ColorValue]):
         self.__surface_tint_color = value
-        self._set_enum_attr("surfaceTintColor", value, ColorEnums)
+        self._set_attr("surfaceTintColor", value)
 
     # tile_padding
     @property

--- a/sdk/python/packages/flet/src/flet/core/navigation_drawer.py
+++ b/sdk/python/packages/flet/src/flet/core/navigation_drawer.py
@@ -1,9 +1,9 @@
 import warnings
-from enum import Enum
 from typing import Any, List, Optional, Sequence
 
 from flet.core.buttons import OutlinedBorder
 from flet.core.control import Control
+from flet.core.enumerations import ExtendedEnum
 from flet.core.ref import Ref
 from flet.core.types import (
     ColorValue,
@@ -152,7 +152,7 @@ class NavigationDrawerDestination(Control):
         self._set_attr("label", value)
 
 
-class NavigationDrawerPosition(Enum):
+class NavigationDrawerPosition(ExtendedEnum):
     START = "start"
     END = "end"
 

--- a/sdk/python/packages/flet/src/flet/core/navigation_rail.py
+++ b/sdk/python/packages/flet/src/flet/core/navigation_rail.py
@@ -9,9 +9,7 @@ from flet.core.control import Control
 from flet.core.ref import Ref
 from flet.core.text_style import TextStyle
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
-    IconEnums,
     IconValueOrControl,
     OffsetValue,
     OptionalControlEventCallable,
@@ -98,7 +96,7 @@ class NavigationRailDestination(Control):
     @icon.setter
     def icon(self, value: Optional[IconValueOrControl]):
         self.__icon = value
-        self._set_enum_attr("icon", value, IconEnums)
+        self._set_attr("icon", value)
 
     # icon_content
     @property
@@ -130,7 +128,7 @@ class NavigationRailDestination(Control):
     @selected_icon.setter
     def selected_icon(self, value: Optional[IconValueOrControl]):
         self.__selected_icon = value
-        self._set_enum_attr("selectedIcon", value, IconEnums)
+        self._set_attr("selectedIcon", value)
 
     # selected_icon_content
     @property
@@ -180,7 +178,7 @@ class NavigationRailDestination(Control):
     @indicator_color.setter
     def indicator_color(self, value: Optional[ColorValue]):
         self.__indicator_color = value
-        self._set_enum_attr("indicatorColor", value, ColorEnums)
+        self._set_attr("indicatorColor", value)
 
     # indicator_shape
     @property
@@ -413,7 +411,7 @@ class NavigationRail(ConstrainedControl):
     @label_type.setter
     def label_type(self, value: Optional[NavigationRailLabelType]):
         self.__label_type = value
-        self._set_enum_attr("labelType", value, NavigationRailLabelType)
+        self._set_attr("labelType", value)
 
     # indicator_shape
     @property
@@ -432,7 +430,7 @@ class NavigationRail(ConstrainedControl):
     @indicator_color.setter
     def indicator_color(self, value: Optional[ColorValue]):
         self.__indicator_color = value
-        self._set_enum_attr("indicatorColor", value, ColorEnums)
+        self._set_attr("indicatorColor", value)
 
     # bgcolor
     @property
@@ -442,7 +440,7 @@ class NavigationRail(ConstrainedControl):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgcolor", value, ColorEnums)
+        self._set_attr("bgcolor", value)
 
     # elevation
     @property

--- a/sdk/python/packages/flet/src/flet/core/navigation_rail.py
+++ b/sdk/python/packages/flet/src/flet/core/navigation_rail.py
@@ -1,11 +1,11 @@
 import warnings
-from enum import Enum
 from typing import Any, Callable, List, Optional, Union
 
 from flet.core.animation import AnimationValue
 from flet.core.buttons import OutlinedBorder
 from flet.core.constrained_control import ConstrainedControl
 from flet.core.control import Control
+from flet.core.enumerations import ExtendedEnum
 from flet.core.ref import Ref
 from flet.core.text_style import TextStyle
 from flet.core.types import (
@@ -21,7 +21,7 @@ from flet.core.types import (
 )
 
 
-class NavigationRailLabelType(Enum):
+class NavigationRailLabelType(ExtendedEnum):
     NONE = "none"
     ALL = "all"
     SELECTED = "selected"

--- a/sdk/python/packages/flet/src/flet/core/outlined_button.py
+++ b/sdk/python/packages/flet/src/flet/core/outlined_button.py
@@ -20,6 +20,7 @@ from flet.core.types import (
     ScaleValue,
     UrlTarget,
 )
+from flet.utils import deprecated
 
 
 class OutlinedButton(ConstrainedControl, AdaptiveControl):

--- a/sdk/python/packages/flet/src/flet/core/outlined_button.py
+++ b/sdk/python/packages/flet/src/flet/core/outlined_button.py
@@ -11,9 +11,7 @@ from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
     ClipBehavior,
-    ColorEnums,
     ColorValue,
-    IconEnums,
     IconValue,
     OffsetValue,
     OptionalControlEventCallable,
@@ -22,7 +20,6 @@ from flet.core.types import (
     ScaleValue,
     UrlTarget,
 )
-from flet.utils import deprecated
 
 
 class OutlinedButton(ConstrainedControl, AdaptiveControl):
@@ -194,7 +191,7 @@ class OutlinedButton(ConstrainedControl, AdaptiveControl):
     @icon.setter
     def icon(self, value: Optional[IconValue]):
         self.__icon = value
-        self._set_enum_attr("icon", value, IconEnums)
+        self._set_attr("icon", value)
 
     # icon_color
     @property
@@ -204,7 +201,7 @@ class OutlinedButton(ConstrainedControl, AdaptiveControl):
     @icon_color.setter
     def icon_color(self, value: Optional[ColorValue]):
         self.__icon_color = value
-        self._set_enum_attr("iconColor", value, ColorEnums)
+        self._set_attr("iconColor", value)
 
     # style
     @property
@@ -232,7 +229,7 @@ class OutlinedButton(ConstrainedControl, AdaptiveControl):
     @url_target.setter
     def url_target(self, value: Optional[UrlTarget]):
         self.__url_target = value
-        self._set_enum_attr("urlTarget", value, UrlTarget)
+        self._set_attr("urlTarget", value)
 
     # on_click
     @property
@@ -279,7 +276,7 @@ class OutlinedButton(ConstrainedControl, AdaptiveControl):
     @clip_behavior.setter
     def clip_behavior(self, value: Optional[ClipBehavior]):
         self.__clip_behavior = value
-        self._set_enum_attr("clipBehavior", value, ClipBehavior)
+        self._set_attr("clipBehavior", value)
 
     # on_hover
     @property

--- a/sdk/python/packages/flet/src/flet/core/page.py
+++ b/sdk/python/packages/flet/src/flet/core/page.py
@@ -80,7 +80,7 @@ from flet.core.types import (
     Wrapper,
 )
 from flet.core.view import View
-from flet.utils import classproperty, is_pyodide
+from flet.utils import classproperty, deprecated, is_pyodide
 
 try:
     from typing import ParamSpec

--- a/sdk/python/packages/flet/src/flet/core/page.py
+++ b/sdk/python/packages/flet/src/flet/core/page.py
@@ -63,7 +63,6 @@ from flet.core.theme import Theme
 from flet.core.types import (
     AppLifecycleState,
     Brightness,
-    ColorEnums,
     ColorValue,
     CrossAxisAlignment,
     FloatingActionButtonLocation,
@@ -81,7 +80,7 @@ from flet.core.types import (
     Wrapper,
 )
 from flet.core.view import View
-from flet.utils import classproperty, deprecated, is_pyodide
+from flet.utils import classproperty, is_pyodide
 
 try:
     from typing import ParamSpec
@@ -171,7 +170,7 @@ class Window:
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self.page._set_enum_attr("windowBgcolor", value, ColorEnums)
+        self.page._set_attr("windowBgcolor", value)
 
     # width
     @property

--- a/sdk/python/packages/flet/src/flet/core/pagelet.py
+++ b/sdk/python/packages/flet/src/flet/core/pagelet.py
@@ -23,6 +23,7 @@ from flet.core.types import (
     RotateValue,
     ScaleValue,
 )
+from flet.utils import deprecated
 
 
 class Pagelet(ConstrainedControl, AdaptiveControl):

--- a/sdk/python/packages/flet/src/flet/core/pagelet.py
+++ b/sdk/python/packages/flet/src/flet/core/pagelet.py
@@ -15,7 +15,6 @@ from flet.core.navigation_drawer import NavigationDrawer
 from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
     FloatingActionButtonLocation,
     OffsetValue,
@@ -24,7 +23,6 @@ from flet.core.types import (
     RotateValue,
     ScaleValue,
 )
-from flet.utils import deprecated
 
 
 class Pagelet(ConstrainedControl, AdaptiveControl):
@@ -267,7 +265,7 @@ class Pagelet(ConstrainedControl, AdaptiveControl):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgcolor", value, ColorEnums)
+        self._set_attr("bgcolor", value)
 
     # bottom_appbar
     @property

--- a/sdk/python/packages/flet/src/flet/core/painting.py
+++ b/sdk/python/packages/flet/src/flet/core/painting.py
@@ -1,20 +1,20 @@
 import math
 from dataclasses import dataclass, field
-from enum import Enum
 from typing import List, Optional, Tuple, Union
 
 from flet.core.blur import Blur
+from flet.core.enumerations import ExtendedEnum
 from flet.core.gradients import GradientTileMode
 from flet.core.types import BlendMode, ColorValue, OffsetValue, StrokeCap
 
 
-class StrokeJoin(Enum):
+class StrokeJoin(ExtendedEnum):
     MITER = "miter"
     ROUND = "round"
     BEVEL = "bevel"
 
 
-class PaintingStyle(Enum):
+class PaintingStyle(ExtendedEnum):
     FILL = "fill"
     STROKE = "stroke"
 

--- a/sdk/python/packages/flet/src/flet/core/permission_handler.py
+++ b/sdk/python/packages/flet/src/flet/core/permission_handler.py
@@ -1,11 +1,11 @@
-from enum import Enum
 from typing import Any, Optional
 
 from flet.core.control import Control
+from flet.core.enumerations import ExtendedEnum
 from flet.core.ref import Ref
 
 
-class PermissionStatus(Enum):
+class PermissionStatus(ExtendedEnum):
     GRANTED = "granted"
     DENIED = "denied"
     PERMANENTLY_DENIED = "permanentlyDenied"
@@ -14,7 +14,7 @@ class PermissionStatus(Enum):
     RESTRICTED = "restricted"
 
 
-class PermissionType(Enum):
+class PermissionType(ExtendedEnum):
     ACCESS_MEDIA_LOCATION = "accessMediaLocation"
     ACCESS_NOTIFICATION_POLICY = "accessNotificationPolicy"
     ACTIVITY_RECOGNITION = "activityRecognition"

--- a/sdk/python/packages/flet/src/flet/core/placeholder.py
+++ b/sdk/python/packages/flet/src/flet/core/placeholder.py
@@ -7,7 +7,6 @@ from flet.core.control import Control, OptionalNumber
 from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
     OffsetValue,
     OptionalControlEventCallable,
@@ -148,7 +147,7 @@ class Placeholder(ConstrainedControl):
     @color.setter
     def color(self, value: Optional[ColorValue]):
         self.__color = value
-        self._set_enum_attr("color", value, ColorEnums)
+        self._set_attr("color", value)
 
     # content
     @property

--- a/sdk/python/packages/flet/src/flet/core/popup_menu_button.py
+++ b/sdk/python/packages/flet/src/flet/core/popup_menu_button.py
@@ -1,4 +1,4 @@
-from enum import Enum
+import warnings
 from typing import Any, List, Optional, Union
 
 from flet.core.animation import AnimationStyle, AnimationValue
@@ -7,6 +7,7 @@ from flet.core.box import BoxConstraints
 from flet.core.buttons import ButtonStyle, OutlinedBorder
 from flet.core.constrained_control import ConstrainedControl
 from flet.core.control import Control, OptionalNumber
+from flet.core.enumerations import ExtendedEnum
 from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
@@ -23,7 +24,7 @@ from flet.core.types import (
 )
 
 
-class PopupMenuPosition(Enum):
+class PopupMenuPosition(ExtendedEnum):
     OVER = "over"
     UNDER = "under"
 

--- a/sdk/python/packages/flet/src/flet/core/popup_menu_button.py
+++ b/sdk/python/packages/flet/src/flet/core/popup_menu_button.py
@@ -1,4 +1,3 @@
-import warnings
 from enum import Enum
 from typing import Any, List, Optional, Union
 
@@ -12,9 +11,7 @@ from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
     ClipBehavior,
-    ColorEnums,
     ColorValue,
-    IconEnums,
     IconValue,
     MouseCursor,
     OffsetValue,
@@ -96,7 +93,7 @@ class PopupMenuItem(Control):
 
     @mouse_cursor.setter
     def mouse_cursor(self, value: Optional[MouseCursor]):
-        self._set_enum_attr("mouseCursor", value, MouseCursor)
+        self._set_attr("mouseCursor", value)
 
     # icon
     @property
@@ -106,7 +103,7 @@ class PopupMenuItem(Control):
     @icon.setter
     def icon(self, value: Optional[IconValue]):
         self.__icon = value
-        self._set_enum_attr("icon", value, IconEnums)
+        self._set_attr("icon", value)
 
     # text
     @property
@@ -381,7 +378,7 @@ class PopupMenuButton(ConstrainedControl):
     @icon.setter
     def icon(self, value: Optional[IconValue]):
         self.__icon = value
-        self._set_enum_attr("icon", value, IconEnums)
+        self._set_attr("icon", value)
 
     # icon_color
     @property
@@ -391,7 +388,7 @@ class PopupMenuButton(ConstrainedControl):
     @icon_color.setter
     def icon_color(self, value: Optional[ColorValue]):
         self.__icon_color = value
-        self._set_enum_attr("iconColor", value, ColorEnums)
+        self._set_attr("iconColor", value)
 
     # bgcolor
     @property
@@ -401,7 +398,7 @@ class PopupMenuButton(ConstrainedControl):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgcolor", value, ColorEnums)
+        self._set_attr("bgcolor", value)
 
     # shadow_color
     @property
@@ -411,7 +408,7 @@ class PopupMenuButton(ConstrainedControl):
     @shadow_color.setter
     def shadow_color(self, value: Optional[ColorValue]):
         self.__shadow_color = value
-        self._set_enum_attr("shadowColor", value, ColorEnums)
+        self._set_attr("shadowColor", value)
 
     # surface_tint_color
     @property
@@ -421,7 +418,7 @@ class PopupMenuButton(ConstrainedControl):
     @surface_tint_color.setter
     def surface_tint_color(self, value: Optional[ColorValue]):
         self.__surface_tint_color = value
-        self._set_enum_attr("surfaceTintColor", value, ColorEnums)
+        self._set_attr("surfaceTintColor", value)
 
     # icon_size
     @property
@@ -494,7 +491,7 @@ class PopupMenuButton(ConstrainedControl):
     @menu_position.setter
     def menu_position(self, value: Optional[PopupMenuPosition]):
         self.__menu_position = value
-        self._set_enum_attr("menuPosition", value, PopupMenuPosition)
+        self._set_attr("menuPosition", value)
 
     # clip_behavior
     @property
@@ -504,7 +501,7 @@ class PopupMenuButton(ConstrainedControl):
     @clip_behavior.setter
     def clip_behavior(self, value: ClipBehavior):
         self.__clip_behavior = value
-        self._set_enum_attr("clipBehavior", value, ClipBehavior)
+        self._set_attr("clipBehavior", value)
 
     # on_cancel
     @property

--- a/sdk/python/packages/flet/src/flet/core/progress_bar.py
+++ b/sdk/python/packages/flet/src/flet/core/progress_bar.py
@@ -8,7 +8,6 @@ from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
     BorderRadiusValue,
-    ColorEnums,
     ColorValue,
     OffsetValue,
     OptionalControlEventCallable,
@@ -179,7 +178,7 @@ class ProgressBar(ConstrainedControl):
     @color.setter
     def color(self, value: Optional[ColorValue]):
         self.__color = value
-        self._set_enum_attr("color", value, ColorEnums)
+        self._set_attr("color", value)
 
     # semantics_label
     @property
@@ -198,7 +197,7 @@ class ProgressBar(ConstrainedControl):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgcolor", value, ColorEnums)
+        self._set_attr("bgcolor", value)
 
     # border_radius
     @property

--- a/sdk/python/packages/flet/src/flet/core/progress_ring.py
+++ b/sdk/python/packages/flet/src/flet/core/progress_ring.py
@@ -7,7 +7,6 @@ from flet.core.control import OptionalNumber
 from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
     OffsetValue,
     OptionalControlEventCallable,
@@ -177,7 +176,7 @@ class ProgressRing(ConstrainedControl):
     @stroke_cap.setter
     def stroke_cap(self, value: Optional[StrokeCap]):
         self.__stroke_cap = value
-        self._set_enum_attr("strokeCap", value, StrokeCap)
+        self._set_attr("strokeCap", value)
 
     # color
     @property
@@ -187,7 +186,7 @@ class ProgressRing(ConstrainedControl):
     @color.setter
     def color(self, value: Optional[ColorValue]):
         self.__color = value
-        self._set_enum_attr("color", value, ColorEnums)
+        self._set_attr("color", value)
 
     # bgcolor
     @property
@@ -197,4 +196,4 @@ class ProgressRing(ConstrainedControl):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgcolor", value, ColorEnums)
+        self._set_attr("bgcolor", value)

--- a/sdk/python/packages/flet/src/flet/core/radio.py
+++ b/sdk/python/packages/flet/src/flet/core/radio.py
@@ -9,7 +9,6 @@ from flet.core.ref import Ref
 from flet.core.text_style import TextStyle
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
     ControlStateValue,
     LabelPosition,
@@ -187,7 +186,7 @@ class Radio(ConstrainedControl, AdaptiveControl):
     @active_color.setter
     def active_color(self, value: Optional[ColorValue]):
         self.__active_color = value
-        self._set_enum_attr("activeColor", value, ColorEnums)
+        self._set_attr("activeColor", value)
 
     # focus_color
     @property
@@ -197,7 +196,7 @@ class Radio(ConstrainedControl, AdaptiveControl):
     @focus_color.setter
     def focus_color(self, value: Optional[ColorValue]):
         self.__focus_color = value
-        self._set_enum_attr("focusColor", value, ColorEnums)
+        self._set_attr("focusColor", value)
 
     # splash_radius
     @property
@@ -225,7 +224,7 @@ class Radio(ConstrainedControl, AdaptiveControl):
     @visual_density.setter
     def visual_density(self, value: Union[None, ThemeVisualDensity, VisualDensity]):
         self.__visual_density = value
-        self._set_enum_attr("visualDensity", value, (ThemeVisualDensity, VisualDensity))
+        self._set_attr("visualDensity", value)
 
     # label
     @property
@@ -244,7 +243,7 @@ class Radio(ConstrainedControl, AdaptiveControl):
     @label_position.setter
     def label_position(self, value: Optional[LabelPosition]):
         self.__label_position = value
-        self._set_enum_attr("labelPosition", value, LabelPosition)
+        self._set_attr("labelPosition", value)
 
     # mouse_cursor
     @property
@@ -254,7 +253,7 @@ class Radio(ConstrainedControl, AdaptiveControl):
     @mouse_cursor.setter
     def mouse_cursor(self, value: Optional[MouseCursor]):
         self.__mouse_cursor = value
-        self._set_enum_attr("mouseCursor", value, MouseCursor)
+        self._set_attr("mouseCursor", value)
 
     # label_style
     @property

--- a/sdk/python/packages/flet/src/flet/core/range_slider.py
+++ b/sdk/python/packages/flet/src/flet/core/range_slider.py
@@ -7,7 +7,6 @@ from flet.core.control import OptionalNumber
 from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
     ControlStateValue,
     OffsetValue,
@@ -255,7 +254,7 @@ class RangeSlider(ConstrainedControl):
     @active_color.setter
     def active_color(self, value: Optional[ColorValue]):
         self.__active_color = value
-        self._set_enum_attr("activeColor", value, ColorEnums)
+        self._set_attr("activeColor", value)
 
     # inactive_color
     @property
@@ -265,7 +264,7 @@ class RangeSlider(ConstrainedControl):
     @inactive_color.setter
     def inactive_color(self, value: Optional[ColorValue]):
         self.__inactive_color = value
-        self._set_enum_attr("inactiveColor", value, ColorEnums)
+        self._set_attr("inactiveColor", value)
 
     # overlay_color
     @property

--- a/sdk/python/packages/flet/src/flet/core/responsive_row.py
+++ b/sdk/python/packages/flet/src/flet/core/responsive_row.py
@@ -164,7 +164,7 @@ class ResponsiveRow(ConstrainedControl, AdaptiveControl):
     @alignment.setter
     def alignment(self, value: Optional[MainAxisAlignment]):
         self.__alignment = value
-        self._set_enum_attr("alignment", value, MainAxisAlignment)
+        self._set_attr("alignment", value)
 
     # vertical_alignment
     @property
@@ -174,7 +174,7 @@ class ResponsiveRow(ConstrainedControl, AdaptiveControl):
     @vertical_alignment.setter
     def vertical_alignment(self, value: Optional[CrossAxisAlignment]):
         self.__vertical_alignment = value
-        self._set_enum_attr("verticalAlignment", value, CrossAxisAlignment)
+        self._set_attr("verticalAlignment", value)
 
     # columns
     @property

--- a/sdk/python/packages/flet/src/flet/core/rive.py
+++ b/sdk/python/packages/flet/src/flet/core/rive.py
@@ -184,4 +184,4 @@ class Rive(ConstrainedControl):
     @fit.setter
     def fit(self, value: Optional[ImageFit]):
         self.__fit = value
-        self._set_enum_attr("fit", value, ImageFit)
+        self._set_attr("fit", value)

--- a/sdk/python/packages/flet/src/flet/core/row.py
+++ b/sdk/python/packages/flet/src/flet/core/row.py
@@ -199,7 +199,7 @@ class Row(ConstrainedControl, ScrollableControl, AdaptiveControl):
     @alignment.setter
     def alignment(self, value: Optional[MainAxisAlignment]):
         self.__alignment = value
-        self._set_enum_attr("alignment", value, MainAxisAlignment)
+        self._set_attr("alignment", value)
 
     # vertical_alignment
     @property
@@ -209,7 +209,7 @@ class Row(ConstrainedControl, ScrollableControl, AdaptiveControl):
     @vertical_alignment.setter
     def vertical_alignment(self, value: Optional[CrossAxisAlignment]):
         self.__vertical_alignment = value
-        self._set_enum_attr("verticalAlignment", value, CrossAxisAlignment)
+        self._set_attr("verticalAlignment", value)
 
     # spacing
     @property

--- a/sdk/python/packages/flet/src/flet/core/search_bar.py
+++ b/sdk/python/packages/flet/src/flet/core/search_bar.py
@@ -13,7 +13,6 @@ from flet.core.text_style import TextStyle
 from flet.core.textfield import KeyboardType, TextCapitalization
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
     ControlState,
     ControlStateValue,
@@ -26,7 +25,6 @@ from flet.core.types import (
     RotateValue,
     ScaleValue,
 )
-from flet.utils import deprecated
 
 
 class SearchBar(ConstrainedControl):
@@ -405,7 +403,7 @@ class SearchBar(ConstrainedControl):
     @view_surface_tint_color.setter
     def view_surface_tint_color(self, value: Optional[ColorValue]):
         self.__view_surface_tint_color = value
-        self._set_enum_attr("viewSurfaceTintColor", value, ColorEnums)
+        self._set_attr("viewSurfaceTintColor", value)
 
     # autofocus
     @property
@@ -451,7 +449,7 @@ class SearchBar(ConstrainedControl):
     @view_bgcolor.setter
     def view_bgcolor(self, value: Optional[str]):
         self.__view_bgcolor = value
-        self._set_enum_attr("viewBgcolor", value, ColorEnums)
+        self._set_attr("viewBgcolor", value)
 
     # divider_color
     @property
@@ -461,7 +459,7 @@ class SearchBar(ConstrainedControl):
     @divider_color.setter
     def divider_color(self, value: Optional[ColorValue]):
         self.__divider_color = value
-        self._set_enum_attr("dividerColor", value, ColorEnums)
+        self._set_attr("dividerColor", value)
 
     # bar_hint_text
     @property
@@ -525,7 +523,7 @@ class SearchBar(ConstrainedControl):
     @capitalization.setter
     def capitalization(self, value: TextCapitalization):
         self.__capitalization = value
-        self._set_enum_attr("capitalization", value, TextCapitalization)
+        self._set_attr("capitalization", value)
 
     # keyboard_type
     @property
@@ -535,7 +533,7 @@ class SearchBar(ConstrainedControl):
     @keyboard_type.setter
     def keyboard_type(self, value: KeyboardType):
         self.__keyboard_type = value
-        self._set_enum_attr("keyboardType", value, KeyboardType)
+        self._set_attr("keyboardType", value)
 
     # view_header_text_style
     @property

--- a/sdk/python/packages/flet/src/flet/core/search_bar.py
+++ b/sdk/python/packages/flet/src/flet/core/search_bar.py
@@ -25,6 +25,7 @@ from flet.core.types import (
     RotateValue,
     ScaleValue,
 )
+from flet.utils import deprecated
 
 
 class SearchBar(ConstrainedControl):

--- a/sdk/python/packages/flet/src/flet/core/semantics_service.py
+++ b/sdk/python/packages/flet/src/flet/core/semantics_service.py
@@ -1,11 +1,11 @@
-from enum import Enum
 from typing import Any, Optional
 
 from flet.core.control import Control
+from flet.core.enumerations import ExtendedEnum
 from flet.core.ref import Ref
 
 
-class Assertiveness(Enum):
+class Assertiveness(ExtendedEnum):
     POLITE = "polite"
     ASSERTIVE = "assertive"
 

--- a/sdk/python/packages/flet/src/flet/core/shader_mask.py
+++ b/sdk/python/packages/flet/src/flet/core/shader_mask.py
@@ -159,7 +159,7 @@ class ShaderMask(ConstrainedControl):
     @blend_mode.setter
     def blend_mode(self, value: Optional[BlendMode]):
         self.__blend_mode = value
-        self._set_enum_attr("blendMode", value, BlendMode)
+        self._set_attr("blendMode", value)
 
     # shader
     @property

--- a/sdk/python/packages/flet/src/flet/core/slider.py
+++ b/sdk/python/packages/flet/src/flet/core/slider.py
@@ -1,4 +1,3 @@
-from enum import Enum
 from typing import Any, Optional, Union
 
 from flet.core.adaptive_control import AdaptiveControl
@@ -6,6 +5,7 @@ from flet.core.animation import AnimationValue
 from flet.core.badge import BadgeValue
 from flet.core.constrained_control import ConstrainedControl
 from flet.core.control import OptionalNumber
+from flet.core.enumerations import ExtendedEnum
 from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
@@ -20,7 +20,7 @@ from flet.core.types import (
 )
 
 
-class SliderInteraction(Enum):
+class SliderInteraction(ExtendedEnum):
     TAP_AND_SLIDE = "tapAndSlide"
     TAP_ONLY = "tapOnly"
     SLIDE_ONLY = "slideOnly"

--- a/sdk/python/packages/flet/src/flet/core/slider.py
+++ b/sdk/python/packages/flet/src/flet/core/slider.py
@@ -9,7 +9,6 @@ from flet.core.control import OptionalNumber
 from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
     ControlStateValue,
     MouseCursor,
@@ -205,7 +204,7 @@ class Slider(ConstrainedControl, AdaptiveControl):
     @interaction.setter
     def interaction(self, value: Optional[SliderInteraction]):
         self.__interaction = value
-        self._set_enum_attr("interaction", value, SliderInteraction)
+        self._set_attr("interaction", value)
 
     # min
     @property
@@ -233,7 +232,7 @@ class Slider(ConstrainedControl, AdaptiveControl):
     @secondary_active_color.setter
     def secondary_active_color(self, value: Optional[ColorValue]):
         self.__secondary_active_color = value
-        self._set_enum_attr("secondaryActiveColor", value, ColorEnums)
+        self._set_attr("secondaryActiveColor", value)
 
     # mouse_cursor
     @property
@@ -242,7 +241,7 @@ class Slider(ConstrainedControl, AdaptiveControl):
 
     @mouse_cursor.setter
     def mouse_cursor(self, value: Optional[MouseCursor]):
-        self._set_enum_attr("mouseCursor", value, MouseCursor)
+        self._set_attr("mouseCursor", value)
 
     # max
     @property
@@ -297,7 +296,7 @@ class Slider(ConstrainedControl, AdaptiveControl):
     @active_color.setter
     def active_color(self, value: Optional[ColorValue]):
         self.__active_color = value
-        self._set_enum_attr("activeColor", value, ColorEnums)
+        self._set_attr("activeColor", value)
 
     # inactive_color
     @property
@@ -307,7 +306,7 @@ class Slider(ConstrainedControl, AdaptiveControl):
     @inactive_color.setter
     def inactive_color(self, value: Optional[ColorValue]):
         self.__inactive_color = value
-        self._set_enum_attr("inactiveColor", value, ColorEnums)
+        self._set_attr("inactiveColor", value)
 
     # thumb_color
     @property
@@ -317,7 +316,7 @@ class Slider(ConstrainedControl, AdaptiveControl):
     @thumb_color.setter
     def thumb_color(self, value: Optional[ColorValue]):
         self.__thumb_color = value
-        self._set_enum_attr("thumbColor", value, ColorEnums)
+        self._set_attr("thumbColor", value)
 
     # on_change
     @property

--- a/sdk/python/packages/flet/src/flet/core/snack_bar.py
+++ b/sdk/python/packages/flet/src/flet/core/snack_bar.py
@@ -6,7 +6,6 @@ from flet.core.control import Control, OptionalNumber
 from flet.core.ref import Ref
 from flet.core.types import (
     ClipBehavior,
-    ColorEnums,
     ColorValue,
     MarginValue,
     OptionalControlEventCallable,
@@ -181,7 +180,7 @@ class SnackBar(Control):
     @action_color.setter
     def action_color(self, value: Optional[ColorValue]):
         self.__action_color = value
-        self._set_enum_attr("actionColor", value, ColorEnums)
+        self._set_attr("actionColor", value)
 
     # bgcolor
     @property
@@ -191,7 +190,7 @@ class SnackBar(Control):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgColor", value, ColorEnums)
+        self._set_attr("bgColor", value)
 
     # close_icon_color
     @property
@@ -201,7 +200,7 @@ class SnackBar(Control):
     @close_icon_color.setter
     def close_icon_color(self, value: Optional[ColorValue]):
         self.__close_icon_color = value
-        self._set_enum_attr("closeIconColor", value, ColorEnums)
+        self._set_attr("closeIconColor", value)
 
     # duration
     @property
@@ -234,7 +233,7 @@ class SnackBar(Control):
     @behavior.setter
     def behavior(self, value: Optional[SnackBarBehavior]):
         self.__behavior = value
-        self._set_enum_attr("behavior", value, SnackBarBehavior)
+        self._set_attr("behavior", value)
 
     # dismissDirection
     @property
@@ -244,7 +243,7 @@ class SnackBar(Control):
     @dismiss_direction.setter
     def dismiss_direction(self, value: Optional[DismissDirection]):
         self.__dismiss_direction = value
-        self._set_enum_attr("dismissDirection", value, DismissDirection)
+        self._set_attr("dismissDirection", value)
 
     # padding
     @property
@@ -291,7 +290,7 @@ class SnackBar(Control):
     @clip_behavior.setter
     def clip_behavior(self, value: Optional[ClipBehavior]):
         self.__clip_behavior = value
-        self._set_enum_attr("clipBehavior", value, ClipBehavior)
+        self._set_attr("clipBehavior", value)
 
     # shape
     @property

--- a/sdk/python/packages/flet/src/flet/core/snack_bar.py
+++ b/sdk/python/packages/flet/src/flet/core/snack_bar.py
@@ -1,8 +1,8 @@
-from enum import Enum
 from typing import Any, Optional
 
 from flet.core.buttons import OutlinedBorder
 from flet.core.control import Control, OptionalNumber
+from flet.core.enumerations import ExtendedEnum
 from flet.core.ref import Ref
 from flet.core.types import (
     ClipBehavior,
@@ -13,12 +13,12 @@ from flet.core.types import (
 )
 
 
-class SnackBarBehavior(Enum):
+class SnackBarBehavior(ExtendedEnum):
     FIXED = "fixed"
     FLOATING = "floating"
 
 
-class DismissDirection(Enum):
+class DismissDirection(ExtendedEnum):
     NONE = "none"
     VERTICAL = "vertical"
     HORIZONTAL = "horizontal"

--- a/sdk/python/packages/flet/src/flet/core/stack.py
+++ b/sdk/python/packages/flet/src/flet/core/stack.py
@@ -177,7 +177,7 @@ class Stack(ConstrainedControl, AdaptiveControl):
     @clip_behavior.setter
     def clip_behavior(self, value: Optional[ClipBehavior]):
         self.__clip_behavior = value
-        self._set_enum_attr("clipBehavior", value, ClipBehavior)
+        self._set_attr("clipBehavior", value)
 
     # alignment
     @property
@@ -196,4 +196,4 @@ class Stack(ConstrainedControl, AdaptiveControl):
     @fit.setter
     def fit(self, value: Optional[StackFit]):
         self.__fit = value
-        self._set_enum_attr("fit", value, StackFit)
+        self._set_attr("fit", value)

--- a/sdk/python/packages/flet/src/flet/core/stack.py
+++ b/sdk/python/packages/flet/src/flet/core/stack.py
@@ -1,4 +1,3 @@
-from enum import Enum
 from typing import Any, List, Optional, Sequence, Union
 
 from flet.core.adaptive_control import AdaptiveControl
@@ -6,6 +5,7 @@ from flet.core.alignment import Alignment
 from flet.core.animation import AnimationValue
 from flet.core.constrained_control import ConstrainedControl
 from flet.core.control import Control, OptionalNumber
+from flet.core.enumerations import ExtendedEnum
 from flet.core.ref import Ref
 from flet.core.types import (
     ClipBehavior,
@@ -17,7 +17,7 @@ from flet.core.types import (
 )
 
 
-class StackFit(Enum):
+class StackFit(ExtendedEnum):
     LOOSE = "loose"
     EXPAND = "expand"
     PASS_THROUGH = "passThrough"

--- a/sdk/python/packages/flet/src/flet/core/submenu_button.py
+++ b/sdk/python/packages/flet/src/flet/core/submenu_button.py
@@ -230,7 +230,7 @@ class SubmenuButton(ConstrainedControl):
     @clip_behavior.setter
     def clip_behavior(self, value: Optional[ClipBehavior]):
         self.__clip_behavior = value
-        self._set_enum_attr("clipBehavior", value, ClipBehavior)
+        self._set_attr("clipBehavior", value)
 
     # alignment_offset
     @property

--- a/sdk/python/packages/flet/src/flet/core/switch.py
+++ b/sdk/python/packages/flet/src/flet/core/switch.py
@@ -9,7 +9,6 @@ from flet.core.ref import Ref
 from flet.core.text_style import TextStyle
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
     ControlStateValue,
     LabelPosition,
@@ -208,7 +207,7 @@ class Switch(ConstrainedControl, AdaptiveControl):
     @hover_color.setter
     def hover_color(self, value: Optional[ColorValue]):
         self.__hover_color = value
-        self._set_enum_attr("hoverColor", value, ColorEnums)
+        self._set_attr("hoverColor", value)
 
     # track_outline_color
     @property
@@ -255,7 +254,7 @@ class Switch(ConstrainedControl, AdaptiveControl):
     @label_position.setter
     def label_position(self, value: Optional[LabelPosition]):
         self.__label_position = value
-        self._set_enum_attr("labelPosition", value, LabelPosition)
+        self._set_attr("labelPosition", value)
 
     # mouse_cursor
     @property
@@ -265,7 +264,7 @@ class Switch(ConstrainedControl, AdaptiveControl):
     @mouse_cursor.setter
     def mouse_cursor(self, value: Optional[MouseCursor]):
         self.__mouse_cursor = value
-        self._set_enum_attr("mouseCursor", value, MouseCursor)
+        self._set_attr("mouseCursor", value)
 
     # autofocus
     @property
@@ -284,7 +283,7 @@ class Switch(ConstrainedControl, AdaptiveControl):
     @active_color.setter
     def active_color(self, value: Optional[ColorValue]):
         self.__active_color = value
-        self._set_enum_attr("activeColor", value, ColorEnums)
+        self._set_attr("activeColor", value)
 
     # active_track_color
     @property
@@ -294,7 +293,7 @@ class Switch(ConstrainedControl, AdaptiveControl):
     @active_track_color.setter
     def active_track_color(self, value: Optional[ColorValue]):
         self.__active_track_color = value
-        self._set_enum_attr("activeTrackColor", value, ColorEnums)
+        self._set_attr("activeTrackColor", value)
 
     # focus_color
     @property
@@ -304,7 +303,7 @@ class Switch(ConstrainedControl, AdaptiveControl):
     @focus_color.setter
     def focus_color(self, value: Optional[ColorValue]):
         self.__focus_color = value
-        self._set_enum_attr("focusColor", value, ColorEnums)
+        self._set_attr("focusColor", value)
 
     # inactive_thumb_color
     @property
@@ -314,7 +313,7 @@ class Switch(ConstrainedControl, AdaptiveControl):
     @inactive_thumb_color.setter
     def inactive_thumb_color(self, value: Optional[ColorValue]):
         self.__inactive_thumb_color = value
-        self._set_enum_attr("inactiveThumbColor", value, ColorEnums)
+        self._set_attr("inactiveThumbColor", value)
 
     # inactive_track_color
     @property
@@ -324,7 +323,7 @@ class Switch(ConstrainedControl, AdaptiveControl):
     @inactive_track_color.setter
     def inactive_track_color(self, value: Optional[ColorValue]):
         self.__inactive_track_color = value
-        self._set_enum_attr("inactiveTrackColor", value, ColorEnums)
+        self._set_attr("inactiveTrackColor", value)
 
     # thumb_color
     @property

--- a/sdk/python/packages/flet/src/flet/core/tabs.py
+++ b/sdk/python/packages/flet/src/flet/core/tabs.py
@@ -11,10 +11,8 @@ from flet.core.text_style import TextStyle
 from flet.core.types import (
     BorderRadiusValue,
     ClipBehavior,
-    ColorEnums,
     ColorValue,
     ControlStateValue,
-    IconEnums,
     IconValue,
     MarginValue,
     MouseCursor,
@@ -74,7 +72,7 @@ class Tab(AdaptiveControl):
         super().before_update()
         self._set_attr_json("iconMargin", self.__icon_margin)
         if isinstance(self.__icon, IconValue):
-            self._set_enum_attr("icon", self.__icon, IconEnums)
+            self._set_attr("icon", self.__icon)
 
     # text
     @property
@@ -362,7 +360,7 @@ class Tabs(ConstrainedControl, AdaptiveControl):
     @mouse_cursor.setter
     def mouse_cursor(self, value: Optional[MouseCursor]):
         self.__mouse_cursor = value
-        self._set_enum_attr("mouseCursor", value, MouseCursor)
+        self._set_attr("mouseCursor", value)
 
     # clip_behavior
     @property
@@ -372,7 +370,7 @@ class Tabs(ConstrainedControl, AdaptiveControl):
     @clip_behavior.setter
     def clip_behavior(self, value: Optional[ClipBehavior]):
         self.__clip_behavior = value
-        self._set_enum_attr("clipBehavior", value, ClipBehavior)
+        self._set_attr("clipBehavior", value)
 
     # is_secondary
     @property
@@ -391,7 +389,7 @@ class Tabs(ConstrainedControl, AdaptiveControl):
     @tab_alignment.setter
     def tab_alignment(self, value: Optional[TabAlignment]):
         self.__tab_alignment = value
-        self._set_enum_attr("tabAlignment", value, TabAlignment)
+        self._set_attr("tabAlignment", value)
 
     # animation_duration
     @property
@@ -438,7 +436,7 @@ class Tabs(ConstrainedControl, AdaptiveControl):
     @divider_color.setter
     def divider_color(self, value: Optional[ColorValue]):
         self.__divider_color = value
-        self._set_enum_attr("dividerColor", value, ColorEnums)
+        self._set_attr("dividerColor", value)
 
     # indicator_color
     @property
@@ -448,7 +446,7 @@ class Tabs(ConstrainedControl, AdaptiveControl):
     @indicator_color.setter
     def indicator_color(self, value: Optional[ColorValue]):
         self.__indicator_color = value
-        self._set_enum_attr("indicatorColor", value, ColorEnums)
+        self._set_attr("indicatorColor", value)
 
     # indicator_border_radius
     @property
@@ -494,7 +492,7 @@ class Tabs(ConstrainedControl, AdaptiveControl):
     @label_color.setter
     def label_color(self, value: Optional[ColorValue]):
         self.__label_color = value
-        self._set_enum_attr("labelColor", value, ColorEnums)
+        self._set_attr("labelColor", value)
 
     # unselected_label_color
     @property
@@ -504,7 +502,7 @@ class Tabs(ConstrainedControl, AdaptiveControl):
     @unselected_label_color.setter
     def unselected_label_color(self, value: Optional[ColorValue]):
         self.__unselected_label_color = value
-        self._set_enum_attr("unselectedLabelColor", value, ColorEnums)
+        self._set_attr("unselectedLabelColor", value)
 
     # overlay_color
     @property

--- a/sdk/python/packages/flet/src/flet/core/text.py
+++ b/sdk/python/packages/flet/src/flet/core/text.py
@@ -15,7 +15,6 @@ from flet.core.text_span import TextSpan
 from flet.core.text_style import TextOverflow, TextStyle, TextThemeStyle
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
     FontWeight,
     OffsetValue,
@@ -272,7 +271,7 @@ class Text(ConstrainedControl):
     @text_align.setter
     def text_align(self, value: Optional[TextAlign]):
         self.__text_align = value
-        self._set_enum_attr("textAlign", value, TextAlign)
+        self._set_attr("textAlign", value)
 
     # font_family
     @property
@@ -300,7 +299,7 @@ class Text(ConstrainedControl):
     @weight.setter
     def weight(self, value: Optional[FontWeight]):
         self.__weight = value
-        self._set_enum_attr("weight", value, FontWeight)
+        self._set_attr("weight", value)
 
     # style
     @property
@@ -330,7 +329,7 @@ class Text(ConstrainedControl):
     @theme_style.setter
     def theme_style(self, value: Optional[TextThemeStyle]):
         self.__theme_style = value
-        self._set_enum_attr("theme_style", value, TextThemeStyle)
+        self._set_attr("theme_style", value)
 
     # italic
     @property
@@ -376,7 +375,7 @@ class Text(ConstrainedControl):
     @overflow.setter
     def overflow(self, value: Optional[TextOverflow]):
         self.__overflow = value
-        self._set_enum_attr("overflow", value, TextOverflow)
+        self._set_attr("overflow", value)
 
     # color
     @property
@@ -386,7 +385,7 @@ class Text(ConstrainedControl):
     @color.setter
     def color(self, value: Optional[ColorValue]):
         self.__color = value
-        self._set_enum_attr("color", value, ColorEnums)
+        self._set_attr("color", value)
 
     # bgcolor
     @property
@@ -396,7 +395,7 @@ class Text(ConstrainedControl):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgcolor", value, ColorEnums)
+        self._set_attr("bgcolor", value)
 
     # semantics_label
     @property

--- a/sdk/python/packages/flet/src/flet/core/text.py
+++ b/sdk/python/packages/flet/src/flet/core/text.py
@@ -1,6 +1,5 @@
 import json
 from dataclasses import dataclass
-from enum import Enum
 from typing import Any, List, Optional, Union
 from warnings import warn
 
@@ -9,6 +8,7 @@ from flet.core.badge import BadgeValue
 from flet.core.constrained_control import ConstrainedControl
 from flet.core.control import OptionalNumber
 from flet.core.control_event import ControlEvent
+from flet.core.enumerations import ExtendedEnum
 from flet.core.event_handler import EventHandler
 from flet.core.ref import Ref
 from flet.core.text_span import TextSpan
@@ -32,7 +32,7 @@ except ImportError:
     from typing_extensions import Literal
 
 
-class TextAffinity(Enum):
+class TextAffinity(ExtendedEnum):
     UPSTREAM = "upstream"
     DOWNSTREAM = "downstream"
 
@@ -51,7 +51,7 @@ class TextSelection:
     normalized: Optional[bool] = None
 
 
-class TextSelectionChangeCause(Enum):
+class TextSelectionChangeCause(ExtendedEnum):
     UNKNOWN = "unknown"
     TAP = "tap"
     DOUBLE_TAP = "doubleTap"

--- a/sdk/python/packages/flet/src/flet/core/text_button.py
+++ b/sdk/python/packages/flet/src/flet/core/text_button.py
@@ -10,9 +10,7 @@ from flet.core.control import Control, OptionalNumber
 from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
-    IconEnums,
     IconValue,
     OffsetValue,
     OptionalControlEventCallable,
@@ -21,7 +19,6 @@ from flet.core.types import (
     ScaleValue,
     UrlTarget,
 )
-from flet.utils import deprecated
 
 
 class TextButton(ConstrainedControl, AdaptiveControl):
@@ -188,7 +185,7 @@ class TextButton(ConstrainedControl, AdaptiveControl):
     @icon.setter
     def icon(self, value: Optional[IconValue]):
         self.__icon = value
-        self._set_enum_attr("icon", value, IconEnums)
+        self._set_attr("icon", value)
 
     # icon_color
     @property
@@ -198,7 +195,7 @@ class TextButton(ConstrainedControl, AdaptiveControl):
     @icon_color.setter
     def icon_color(self, value: Optional[ColorValue]):
         self.__icon_color = value
-        self._set_enum_attr("iconColor", value, ColorEnums)
+        self._set_attr("iconColor", value)
 
     # style
     @property
@@ -226,7 +223,7 @@ class TextButton(ConstrainedControl, AdaptiveControl):
     @url_target.setter
     def url_target(self, value: Optional[UrlTarget]):
         self.__url_target = value
-        self._set_enum_attr("urlTarget", value, UrlTarget)
+        self._set_attr("urlTarget", value)
 
     # on_click
     @property

--- a/sdk/python/packages/flet/src/flet/core/text_button.py
+++ b/sdk/python/packages/flet/src/flet/core/text_button.py
@@ -19,6 +19,7 @@ from flet.core.types import (
     ScaleValue,
     UrlTarget,
 )
+from flet.utils import deprecated
 
 
 class TextButton(ConstrainedControl, AdaptiveControl):

--- a/sdk/python/packages/flet/src/flet/core/text_span.py
+++ b/sdk/python/packages/flet/src/flet/core/text_span.py
@@ -113,7 +113,7 @@ class TextSpan(InlineSpan):
     @url_target.setter
     def url_target(self, value: Optional[UrlTarget]):
         self.__url_target = value
-        self._set_enum_attr("urlTarget", value, UrlTarget)
+        self._set_attr("urlTarget", value)
 
     # on_click
     @property

--- a/sdk/python/packages/flet/src/flet/core/text_style.py
+++ b/sdk/python/packages/flet/src/flet/core/text_style.py
@@ -1,25 +1,26 @@
 from dataclasses import dataclass
-from enum import Enum, IntFlag
+from enum import IntFlag
 from typing import List, Optional, Union
 
 from flet.core.box import BoxShadow
+from flet.core.enumerations import ExtendedEnum
 from flet.core.painting import Paint
 from flet.core.types import ColorValue, FontWeight, OptionalNumber
 
 
-class TextOverflow(Enum):
+class TextOverflow(ExtendedEnum):
     CLIP = "clip"
     ELLIPSIS = "ellipsis"
     FADE = "fade"
     VISIBLE = "visible"
 
 
-class TextBaseline(Enum):
+class TextBaseline(ExtendedEnum):
     ALPHABETIC = "alphabetic"
     IDEOGRAPHIC = "ideographic"
 
 
-class TextThemeStyle(Enum):
+class TextThemeStyle(ExtendedEnum):
     DISPLAY_LARGE = "displayLarge"
     DISPLAY_MEDIUM = "displayMedium"
     DISPLAY_SMALL = "displaySmall"
@@ -44,7 +45,7 @@ class TextDecoration(IntFlag):
     LINE_THROUGH = 4
 
 
-class TextDecorationStyle(Enum):
+class TextDecorationStyle(ExtendedEnum):
     SOLID = "solid"
     DOUBLE = "double"
     DOTTED = "dotted"

--- a/sdk/python/packages/flet/src/flet/core/textfield.py
+++ b/sdk/python/packages/flet/src/flet/core/textfield.py
@@ -1,6 +1,5 @@
 import dataclasses
 import time
-from enum import Enum
 from typing import Any, List, Optional, Union
 
 from flet.core.adaptive_control import AdaptiveControl
@@ -9,6 +8,7 @@ from flet.core.autofill_group import AutofillHint
 from flet.core.badge import BadgeValue
 from flet.core.box import BoxConstraints
 from flet.core.control import Control, OptionalNumber
+from flet.core.enumerations import ExtendedEnum
 from flet.core.form_field_control import FormFieldControl, InputBorder
 from flet.core.ref import Ref
 from flet.core.text_style import StrutStyle, TextStyle
@@ -30,6 +30,7 @@ from flet.core.types import (
     TextAlign,
     VerticalAlignment,
 )
+from flet.utils import deprecated
 
 try:
     from typing import Literal
@@ -37,7 +38,7 @@ except ImportError:
     from typing_extensions import Literal
 
 
-class KeyboardType(Enum):
+class KeyboardType(ExtendedEnum):
     NONE = "none"
     TEXT = "text"
     MULTILINE = "multiline"
@@ -51,7 +52,7 @@ class KeyboardType(Enum):
     STREET_ADDRESS = "streetAddress"
 
 
-class TextCapitalization(Enum):
+class TextCapitalization(ExtendedEnum):
     CHARACTERS = "characters"
     WORDS = "words"
     SENTENCES = "sentences"

--- a/sdk/python/packages/flet/src/flet/core/textfield.py
+++ b/sdk/python/packages/flet/src/flet/core/textfield.py
@@ -17,7 +17,6 @@ from flet.core.types import (
     BorderRadiusValue,
     Brightness,
     ClipBehavior,
-    ColorEnums,
     ColorValue,
     DurationValue,
     IconValueOrControl,
@@ -31,7 +30,6 @@ from flet.core.types import (
     TextAlign,
     VerticalAlignment,
 )
-from flet.utils import deprecated
 
 try:
     from typing import Literal
@@ -473,7 +471,7 @@ class TextField(FormFieldControl, AdaptiveControl):
     @keyboard_type.setter
     def keyboard_type(self, value: Optional[KeyboardType]):
         self.__keyboard_type = value
-        self._set_enum_attr("keyboardType", value, KeyboardType)
+        self._set_attr("keyboardType", value)
 
     # text_align
     @property
@@ -483,7 +481,7 @@ class TextField(FormFieldControl, AdaptiveControl):
     @text_align.setter
     def text_align(self, value: Optional[TextAlign]):
         self.__text_align = value
-        self._set_enum_attr("textAlign", value, TextAlign)
+        self._set_attr("textAlign", value)
 
     # multiline
     @property
@@ -561,7 +559,7 @@ class TextField(FormFieldControl, AdaptiveControl):
     @keyboard_brightness.setter
     def keyboard_brightness(self, value: Optional[Brightness]):
         self.__keyboard_brightness = value
-        self._set_enum_attr("keyboardBrightness", value, Brightness)
+        self._set_attr("keyboardBrightness", value)
 
     # mouse_cursor
     @property
@@ -571,7 +569,7 @@ class TextField(FormFieldControl, AdaptiveControl):
     @mouse_cursor.setter
     def mouse_cursor(self, value: Optional[MouseCursor]):
         self.__mouse_cursor = value
-        self._set_enum_attr("mouseCursor", value, MouseCursor)
+        self._set_attr("mouseCursor", value)
 
     # ignore_pointers
     @property
@@ -590,7 +588,7 @@ class TextField(FormFieldControl, AdaptiveControl):
     @clip_behavior.setter
     def clip_behavior(self, value: Optional[ClipBehavior]):
         self.__clip_behavior = value
-        self._set_enum_attr("clipBehavior", value, ClipBehavior)
+        self._set_attr("clipBehavior", value)
 
     # can_request_focus
     @property
@@ -663,7 +661,7 @@ class TextField(FormFieldControl, AdaptiveControl):
     @capitalization.setter
     def capitalization(self, value: Optional[TextCapitalization]):
         self.__capitalization = value
-        self._set_enum_attr("capitalization", value, TextCapitalization)
+        self._set_attr("capitalization", value)
 
     # autocorrect
     @property
@@ -718,7 +716,7 @@ class TextField(FormFieldControl, AdaptiveControl):
     @cursor_color.setter
     def cursor_color(self, value):
         self.__cursor_color = value
-        self._set_enum_attr("cursorColor", value, ColorEnums)
+        self._set_attr("cursorColor", value)
 
     # cursor_height
     @property
@@ -755,7 +753,7 @@ class TextField(FormFieldControl, AdaptiveControl):
     @selection_color.setter
     def selection_color(self, value: Optional[ColorValue]):
         self.__selection_color = value
-        self._set_enum_attr("selectionColor", value, ColorEnums)
+        self._set_attr("selectionColor", value)
 
     # input_filter
     @property

--- a/sdk/python/packages/flet/src/flet/core/theme.py
+++ b/sdk/python/packages/flet/src/flet/core/theme.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass, field
-from enum import Enum
 from typing import List, Optional, Union
 
 from flet.core.alignment import Alignment
@@ -8,6 +7,7 @@ from flet.core.border_radius import BorderRadius
 from flet.core.box import BoxConstraints, BoxDecoration, BoxShadow
 from flet.core.buttons import ButtonStyle, OutlinedBorder
 from flet.core.control import OptionalNumber
+from flet.core.enumerations import ExtendedEnum
 from flet.core.menu_bar import MenuStyle
 from flet.core.navigation_bar import NavigationBarLabelBehavior
 from flet.core.navigation_rail import NavigationRailLabelType
@@ -42,7 +42,7 @@ except ImportError:
     from typing_extensions import Literal
 
 
-class PageTransitionTheme(Enum):
+class PageTransitionTheme(ExtendedEnum):
     NONE = "none"
     FADE_UPWARDS = "fadeUpwards"
     OPEN_UPWARDS = "openUpwards"

--- a/sdk/python/packages/flet/src/flet/core/time_picker.py
+++ b/sdk/python/packages/flet/src/flet/core/time_picker.py
@@ -1,9 +1,9 @@
 from datetime import datetime, time
-from enum import Enum
 from typing import Any, Optional, Union
 
 from flet.core.control import Control, OptionalNumber
 from flet.core.control_event import ControlEvent
+from flet.core.enumerations import ExtendedEnum
 from flet.core.event_handler import EventHandler
 from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
@@ -14,9 +14,10 @@ from flet.core.types import (
     Orientation,
     ResponsiveNumber,
 )
+from flet.utils import deprecated
 
 
-class TimePickerEntryMode(Enum):
+class TimePickerEntryMode(ExtendedEnum):
     DIAL = "dial"
     INPUT = "input"
     DIAL_ONLY = "dialOnly"

--- a/sdk/python/packages/flet/src/flet/core/time_picker.py
+++ b/sdk/python/packages/flet/src/flet/core/time_picker.py
@@ -2,21 +2,18 @@ from datetime import datetime, time
 from enum import Enum
 from typing import Any, Optional, Union
 
-from flet.core.badge import BadgeValue
 from flet.core.control import Control, OptionalNumber
 from flet.core.control_event import ControlEvent
 from flet.core.event_handler import EventHandler
 from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
     OptionalControlEventCallable,
     OptionalEventCallable,
     Orientation,
     ResponsiveNumber,
 )
-from flet.utils import deprecated
 
 
 class TimePickerEntryMode(Enum):
@@ -250,7 +247,7 @@ class TimePicker(Control):
     @time_picker_entry_mode.setter
     def time_picker_entry_mode(self, value: Optional[TimePickerEntryMode]):
         self.__time_picker_entry_mode = value
-        self._set_enum_attr("timePickerEntryMode", value, TimePickerEntryMode)
+        self._set_attr("timePickerEntryMode", value)
 
     # orientation
     @property
@@ -260,7 +257,7 @@ class TimePicker(Control):
     @orientation.setter
     def orientation(self, value: Optional[Orientation]):
         self.__orientation = value
-        self._set_enum_attr("orientation", value, Orientation)
+        self._set_attr("orientation", value)
 
     # on_change
     @property
@@ -301,4 +298,4 @@ class TimePicker(Control):
     @barrier_color.setter
     def barrier_color(self, value: Optional[ColorValue]):
         self.__barrier_color = value
-        self._set_enum_attr("barrierColor", value, ColorEnums)
+        self._set_attr("barrierColor", value)

--- a/sdk/python/packages/flet/src/flet/core/types.py
+++ b/sdk/python/packages/flet/src/flet/core/types.py
@@ -16,16 +16,17 @@ from typing import (
 from warnings import warn
 
 from flet.core.border_radius import BorderRadius
-from flet.core.colors import Colors, colors
+from flet.core.colors import MaterialColorsEnums
+from flet.core.enumerations import ExtendedEnum
 
 if TYPE_CHECKING:
-    from flet.core.control import Control
+    pass
 
 from flet.core.control_event import ControlEvent
-from flet.core.cupertino_colors import CupertinoColors, cupertino_colors
-from flet.core.cupertino_icons import CupertinoIcons, cupertino_icons
+from flet.core.cupertino_colors import CupertinoColorsEnums
+from flet.core.cupertino_icons import CupertinoIconEnums
 from flet.core.event import Event
-from flet.core.icons import Icons, icons
+from flet.core.icons import MaterialIconEnums
 from flet.core.margin import Margin
 from flet.core.padding import Padding
 from flet.core.transform import Offset, Rotate, Scale
@@ -36,14 +37,14 @@ FLET_APP_WEB = "flet_app_web"
 FLET_APP_HIDDEN = "flet_app_hidden"
 
 
-class AppView(Enum):
+class AppView(ExtendedEnum):
     WEB_BROWSER = "web_browser"
     FLET_APP = "flet_app"
     FLET_APP_WEB = "flet_app_web"
     FLET_APP_HIDDEN = "flet_app_hidden"
 
 
-class WindowEventType(Enum):
+class WindowEventType(ExtendedEnum):
     CLOSE = "close"
     FOCUS = "focus"
     BLUR = "blur"
@@ -61,13 +62,13 @@ class WindowEventType(Enum):
     ENTER_FULL_SCREEN = "enter-full-screen"
 
 
-class WebRenderer(Enum):
+class WebRenderer(ExtendedEnum):
     AUTO = "auto"
     HTML = "html"
     CANVAS_KIT = "canvaskit"
 
 
-class UrlTarget(Enum):
+class UrlTarget(ExtendedEnum):
     BLANK = "blank"
     SELF = "_self"
     PARENT = "_parent"
@@ -100,7 +101,7 @@ class Duration:
 DurationValue = Union[int, Duration, None]
 
 
-class FontWeight(Enum):
+class FontWeight(ExtendedEnum):
     NORMAL = "normal"
     BOLD = "bold"
     W_100 = "w100"
@@ -114,7 +115,7 @@ class FontWeight(Enum):
     W_900 = "w900"
 
 
-class NotchShape(Enum):
+class NotchShape(ExtendedEnum):
     AUTO = "auto"
     CIRCULAR = "circular"
 
@@ -161,7 +162,7 @@ class MaterialState(Enum, metaclass=MaterialStateDeprecated):
     DEFAULT = ""
 
 
-class ControlState(Enum):
+class ControlState(ExtendedEnum):
     HOVERED = "hovered"
     FOCUSED = "focused"
     PRESSED = "pressed"
@@ -173,7 +174,7 @@ class ControlState(Enum):
     DEFAULT = "default"
 
 
-class MainAxisAlignment(Enum):
+class MainAxisAlignment(ExtendedEnum):
     START = "start"
     END = "end"
     CENTER = "center"
@@ -182,7 +183,7 @@ class MainAxisAlignment(Enum):
     SPACE_EVENLY = "spaceEvenly"
 
 
-class CrossAxisAlignment(Enum):
+class CrossAxisAlignment(ExtendedEnum):
     START = "start"
     END = "end"
     CENTER = "center"
@@ -190,26 +191,26 @@ class CrossAxisAlignment(Enum):
     BASELINE = "baseline"
 
 
-class VerticalAlignment(Enum):
+class VerticalAlignment(ExtendedEnum):
     NONE = None
     START = -1.0
     END = 1.0
     CENTER = 0.0
 
 
-class TabAlignment(Enum):
+class TabAlignment(ExtendedEnum):
     START = "start"
     START_OFFSET = "startOffset"
     FILL = "fill"
     CENTER = "center"
 
 
-class LabelPosition(Enum):
+class LabelPosition(ExtendedEnum):
     RIGHT = "right"
     LEFT = "left"
 
 
-class BlendMode(Enum):
+class BlendMode(ExtendedEnum):
     CLEAR = "clear"
     COLOR = "color"
     COLOR_BURN = "colorBurn"
@@ -242,7 +243,7 @@ class BlendMode(Enum):
     XOR = "xor"
 
 
-class TextAlign(Enum):
+class TextAlign(ExtendedEnum):
     LEFT = "left"
     RIGHT = "right"
     CENTER = "center"
@@ -251,21 +252,21 @@ class TextAlign(Enum):
     END = "end"
 
 
-class ScrollMode(Enum):
+class ScrollMode(ExtendedEnum):
     AUTO = "auto"
     ADAPTIVE = "adaptive"
     ALWAYS = "always"
     HIDDEN = "hidden"
 
 
-class ClipBehavior(Enum):
+class ClipBehavior(ExtendedEnum):
     NONE = "none"
     ANTI_ALIAS = "antiAlias"
     ANTI_ALIAS_WITH_SAVE_LAYER = "antiAliasWithSaveLayer"
     HARD_EDGE = "hardEdge"
 
 
-class ImageFit(Enum):
+class ImageFit(ExtendedEnum):
     NONE = "none"
     CONTAIN = "contain"
     COVER = "cover"
@@ -275,14 +276,14 @@ class ImageFit(Enum):
     SCALE_DOWN = "scaleDown"
 
 
-class ImageRepeat(Enum):
+class ImageRepeat(ExtendedEnum):
     NO_REPEAT = "noRepeat"
     REPEAT = "repeat"
     REPEAT_X = "repeatX"
     REPEAT_Y = "repeatY"
 
 
-class PagePlatform(Enum):
+class PagePlatform(ExtendedEnum):
     IOS = "ios"
     ANDROID = "android"
     MACOS = "macos"
@@ -290,23 +291,23 @@ class PagePlatform(Enum):
     LINUX = "linux"
 
 
-class ThemeMode(Enum):
+class ThemeMode(ExtendedEnum):
     SYSTEM = "system"
     LIGHT = "light"
     DARK = "dark"
 
 
-class Brightness(Enum):
+class Brightness(ExtendedEnum):
     LIGHT = "light"
     DARK = "dark"
 
 
-class Orientation(Enum):
+class Orientation(ExtendedEnum):
     PORTRAIT = "portrait"
     LANDSCAPE = "landscape"
 
 
-class FloatingActionButtonLocation(Enum):
+class FloatingActionButtonLocation(ExtendedEnum):
     CENTER_DOCKED = "centerDocked"
     CENTER_FLOAT = "centerFloat"
     CENTER_TOP = "centerTop"
@@ -328,7 +329,7 @@ class FloatingActionButtonLocation(Enum):
     START_TOP = "startTop"
 
 
-class AppLifecycleState(Enum):
+class AppLifecycleState(ExtendedEnum):
     SHOW = "show"
     RESUME = "resume"
     HIDE = "hide"
@@ -338,7 +339,7 @@ class AppLifecycleState(Enum):
     RESTART = "restart"
 
 
-class MouseCursor(Enum):
+class MouseCursor(ExtendedEnum):
     ALIAS = "alias"
     ALL_SCROLL = "allScroll"
     BASIC = "basic"
@@ -377,7 +378,7 @@ class MouseCursor(Enum):
     ZOOM_OUT = "zoomOut"
 
 
-class PointerDeviceType(Enum):
+class PointerDeviceType(ExtendedEnum):
     TOUCH = "touch"
     MOUSE = "mouse"
     STYLUS = "stylus"
@@ -386,13 +387,13 @@ class PointerDeviceType(Enum):
     UNKNOWN = "unknown"
 
 
-class StrokeCap(Enum):
+class StrokeCap(ExtendedEnum):
     ROUND = "round"
     SQUARE = "square"
     BUTT = "butt"
 
 
-class StrokeJoin(Enum):
+class StrokeJoin(ExtendedEnum):
     MITER = "miter"
     ROUND = "round"
     BEVEL = "bevel"
@@ -423,7 +424,7 @@ class ThemeVisualDensity(Enum, metaclass=ThemeVisualDensityDeprecated):
     ADAPTIVE_PLATFORM_DENSITY = "adaptivePlatformDensity"
 
 
-class VisualDensity(Enum):
+class VisualDensity(ExtendedEnum):
     STANDARD = "standard"
     COMPACT = "compact"
     COMFORTABLE = "comfortable"
@@ -450,12 +451,10 @@ OptionalEventCallable = Optional[Callable[[EventType], Any]]
 OptionalControlEventCallable = Optional[Callable[[ControlEvent], Any]]
 
 # Colors
-ColorEnums = (colors, Colors, cupertino_colors, CupertinoColors)
-ColorValue = Union[str, colors, Colors, cupertino_colors, CupertinoColors]
+ColorValue = Union[str, MaterialColorsEnums, CupertinoColorsEnums]
 
 # Icons
-IconEnums = (icons, Icons, cupertino_icons, CupertinoIcons)
-IconValue = Union[str, icons, Icons, cupertino_icons, CupertinoIcons]
+IconValue = Union[str, MaterialIconEnums, CupertinoIconEnums]
 IconValueOrControl = Union[IconValue, "Control"]
 
 # ControlState

--- a/sdk/python/packages/flet/src/flet/core/types.py
+++ b/sdk/python/packages/flet/src/flet/core/types.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from datetime import date, datetime
-from enum import Enum, EnumMeta
+from enum import EnumMeta
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -150,7 +150,7 @@ class MaterialStateDeprecated(EnumMeta):
         return EnumMeta.__getattribute__(self, item)
 
 
-class MaterialState(Enum, metaclass=MaterialStateDeprecated):
+class MaterialState(ExtendedEnum, metaclass=MaterialStateDeprecated):
     HOVERED = "hovered"
     FOCUSED = "focused"
     PRESSED = "pressed"
@@ -416,7 +416,7 @@ class ThemeVisualDensityDeprecated(EnumMeta):
         return EnumMeta.__getattribute__(self, item)
 
 
-class ThemeVisualDensity(Enum, metaclass=ThemeVisualDensityDeprecated):
+class ThemeVisualDensity(ExtendedEnum, metaclass=ThemeVisualDensityDeprecated):
     STANDARD = "standard"
     COMPACT = "compact"
     COMFORTABLE = "comfortable"

--- a/sdk/python/packages/flet/src/flet/core/vertical_divider.py
+++ b/sdk/python/packages/flet/src/flet/core/vertical_divider.py
@@ -2,7 +2,7 @@ from typing import Any, Optional
 
 from flet.core.control import Control, OptionalNumber
 from flet.core.ref import Ref
-from flet.core.types import ColorEnums, ColorValue
+from flet.core.types import ColorValue
 
 
 class VerticalDivider(Control):
@@ -107,7 +107,7 @@ class VerticalDivider(Control):
     @color.setter
     def color(self, value: Optional[ColorValue]):
         self.__color = value
-        self._set_enum_attr("color", value, ColorEnums)
+        self._set_attr("color", value)
 
     # leading_indent
     @property

--- a/sdk/python/packages/flet/src/flet/core/video.py
+++ b/sdk/python/packages/flet/src/flet/core/video.py
@@ -1,5 +1,4 @@
 import dataclasses
-from enum import Enum
 from typing import Any, Dict, List, Optional, Union, cast
 
 from flet.core.alignment import Alignment
@@ -8,6 +7,7 @@ from flet.core.badge import BadgeValue
 from flet.core.box import FilterQuality
 from flet.core.constrained_control import ConstrainedControl
 from flet.core.control import OptionalNumber
+from flet.core.enumerations import ExtendedEnum
 from flet.core.ref import Ref
 from flet.core.text_style import TextStyle
 from flet.core.tooltip import TooltipValue
@@ -23,9 +23,10 @@ from flet.core.types import (
     ScaleValue,
     TextAlign,
 )
+from flet.utils import deprecated
 
 
-class PlaylistMode(Enum):
+class PlaylistMode(ExtendedEnum):
     NONE = "none"
     SINGLE = "single"
     LOOP = "loop"

--- a/sdk/python/packages/flet/src/flet/core/video.py
+++ b/sdk/python/packages/flet/src/flet/core/video.py
@@ -12,7 +12,6 @@ from flet.core.ref import Ref
 from flet.core.text_style import TextStyle
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
     ImageFit,
     OffsetValue,
@@ -24,7 +23,6 @@ from flet.core.types import (
     ScaleValue,
     TextAlign,
 )
-from flet.utils import deprecated
 
 
 class PlaylistMode(Enum):
@@ -434,7 +432,7 @@ class Video(ConstrainedControl):
     @fill_color.setter
     def fill_color(self, value: Optional[ColorValue]):
         self.__fill_color = value
-        self._set_enum_attr("fillColor", value, ColorEnums)
+        self._set_attr("fillColor", value)
 
     # wakelock
     @property
@@ -563,7 +561,7 @@ class Video(ConstrainedControl):
     @filter_quality.setter
     def filter_quality(self, value: Optional[FilterQuality]):
         self.__filter_quality = value
-        self._set_enum_attr("filterQuality", value, FilterQuality)
+        self._set_attr("filterQuality", value)
 
     # playlist_mode
     @property
@@ -573,7 +571,7 @@ class Video(ConstrainedControl):
     @playlist_mode.setter
     def playlist_mode(self, value: Optional[PlaylistMode]):
         self.__playlist_mode = value
-        self._set_enum_attr("playlistMode", value, PlaylistMode)
+        self._set_attr("playlistMode", value)
 
     # on_enter_fullscreen
     @property

--- a/sdk/python/packages/flet/src/flet/core/view.py
+++ b/sdk/python/packages/flet/src/flet/core/view.py
@@ -12,7 +12,6 @@ from flet.core.navigation_bar import NavigationBar
 from flet.core.navigation_drawer import NavigationDrawer
 from flet.core.scrollable_control import OnScrollEvent, ScrollableControl
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
     CrossAxisAlignment,
     FloatingActionButtonLocation,
@@ -235,7 +234,7 @@ class View(ScrollableControl, AdaptiveControl):
     @horizontal_alignment.setter
     def horizontal_alignment(self, value: CrossAxisAlignment):
         self.__horizontal_alignment = value
-        self._set_enum_attr("horizontalAlignment", value, CrossAxisAlignment)
+        self._set_attr("horizontalAlignment", value)
 
     # vertical_alignment
     @property
@@ -245,7 +244,7 @@ class View(ScrollableControl, AdaptiveControl):
     @vertical_alignment.setter
     def vertical_alignment(self, value: MainAxisAlignment):
         self.__vertical_alignment = value
-        self._set_enum_attr("verticalAlignment", value, MainAxisAlignment)
+        self._set_attr("verticalAlignment", value)
 
     # spacing
     @property
@@ -273,7 +272,7 @@ class View(ScrollableControl, AdaptiveControl):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgcolor", value, ColorEnums)
+        self._set_attr("bgcolor", value)
 
     # fullscreen_dialog
     @property

--- a/sdk/python/packages/flet/src/flet/core/webview.py
+++ b/sdk/python/packages/flet/src/flet/core/webview.py
@@ -13,7 +13,6 @@ from flet.core.exceptions import FletUnsupportedPlatformException
 from flet.core.ref import Ref
 from flet.core.tooltip import TooltipValue
 from flet.core.types import (
-    ColorEnums,
     ColorValue,
     OffsetValue,
     OptionalControlEventCallable,
@@ -354,7 +353,7 @@ class WebView(ConstrainedControl):
     @bgcolor.setter
     def bgcolor(self, value: Optional[ColorValue]):
         self.__bgcolor = value
-        self._set_enum_attr("bgcolor", value, ColorEnums)
+        self._set_attr("bgcolor", value)
 
     # url
     @property

--- a/sdk/python/packages/flet/src/flet/core/webview.py
+++ b/sdk/python/packages/flet/src/flet/core/webview.py
@@ -1,6 +1,5 @@
 import json
 import warnings
-from enum import Enum
 from typing import Any, Optional, Union
 
 from flet.core.animation import AnimationValue
@@ -8,6 +7,7 @@ from flet.core.badge import BadgeValue
 from flet.core.constrained_control import ConstrainedControl
 from flet.core.control import OptionalNumber
 from flet.core.control_event import ControlEvent
+from flet.core.enumerations import ExtendedEnum
 from flet.core.event_handler import EventHandler
 from flet.core.exceptions import FletUnsupportedPlatformException
 from flet.core.ref import Ref
@@ -24,12 +24,12 @@ from flet.core.types import (
 )
 
 
-class WebviewRequestMethod(Enum):
+class WebviewRequestMethod(ExtendedEnum):
     GET = "get"
     POST = "post"
 
 
-class WebviewLogLevelSeverity(Enum):
+class WebviewLogLevelSeverity(ExtendedEnum):
     ERROR = "error"
     WARNING = "warning"
     DEBUG = "debug"


### PR DESCRIPTION
This PR mainly attempts to fix https://github.com/flet-dev/flet/issues/3736#issuecomment-2577371194. The heavy enums (colors and icons) were imported in `types.py`, which might have been the cause. 

Also, Enum vs String comparisons are now possible, ex: `ft.Colors.AMBER == "amber"`

## Summary by Sourcery

Refactor enum handling to allow string comparison.

New Features:
- Introduce ExtendedEnum for enhanced enum functionality.

Enhancements:
- Change Enums to inherit from ExtendedEnum.
- Remove unnecessary `_set_enum_attr` method in favor of `_set_attr`.
- Update color and icon type definitions.