### PR TITLE
fix: setting `ButtonTheme` displays a grey screen

### DIFF
--- a/packages/flet/lib/src/utils/borders.dart
+++ b/packages/flet/lib/src/utils/borders.dart
@@ -102,7 +102,11 @@ BorderSide? borderSideFromJSON(ThemeData? theme, dynamic json,
       : null;
 }
 
-OutlinedBorder? outlinedBorderFromJSON(Map<String, dynamic> json) {
+OutlinedBorder? outlinedBorderFromJSON(Map<String, dynamic>? json) {
+  if (json == null) {
+    return null;
+  }
+
   String type = json["type"];
   if (type == "roundedRectangle") {
     return RoundedRectangleBorder(


### PR DESCRIPTION
Fixes #4723

## Summary by Sourcery

Bug Fixes:
- Fix grey screen issue when setting `ButtonTheme`.