### PR TITLE
fix: make `Tooltip.message` a required parameter

### DIFF
--- a/sdk/python/packages/flet/src/flet/core/tooltip.py
+++ b/sdk/python/packages/flet/src/flet/core/tooltip.py
@@ -27,7 +27,7 @@ class TooltipTriggerMode:
 class Tooltip:
     """Tooltips provide text labels which help explain the function of a button or other user interface action."""
 
-    message: Optional[str] = None
+    message: str
     enable_feedback: Optional[bool] = None
     height: OptionalNumber = None
     vertical_offset: OptionalNumber = None


### PR DESCRIPTION
Resolves #4725

## Summary by Sourcery

Make the `Tooltip.message` parameter required.

Bug Fixes:
- Fix missing tooltip message.

Enhancements:
- Improve the clarity of the `Tooltip` API.