### PR TITLE
feat: add `ListView.build_controls_on_demand` property for optional on-demand building of controls

### DIFF
--- a/sdk/python/packages/flet/src/flet/core/list_tile.py
+++ b/sdk/python/packages/flet/src/flet/core/list_tile.py
@@ -82,15 +82,15 @@ class ListTile(ConstrainedControl, AdaptiveControl):
 
     def __init__(
         self,
-        content_padding: Optional[PaddingValue] = None,
+        title: Optional[Control] = None,
+        subtitle: Optional[Control] = None,
+        is_three_line: Optional[bool] = None,
+        leading: Optional[Control] = None,
+        trailing: Optional[Control] = None,
+        content_padding: PaddingValue = None,
         bgcolor: Optional[ColorValue] = None,
         bgcolor_activated: Optional[str] = None,
         hover_color: Optional[ColorValue] = None,
-        leading: Optional[Control] = None,
-        title: Optional[Control] = None,
-        subtitle: Optional[Control] = None,
-        trailing: Optional[Control] = None,
-        is_three_line: Optional[bool] = None,
         selected: Optional[bool] = None,
         dense: Optional[bool] = None,
         autofocus: Optional[bool] = None,
@@ -114,8 +114,8 @@ class ListTile(ConstrainedControl, AdaptiveControl):
         subtitle_text_style: Optional[TextStyle] = None,
         leading_and_trailing_text_style: Optional[TextStyle] = None,
         min_height: OptionalNumber = None,
-        on_click=None,
-        on_long_press=None,
+        on_click: OptionalControlEventCallable = None,
+        on_long_press: OptionalControlEventCallable = None,
         #
         # ConstrainedControl and AdaptiveControl
         #

--- a/sdk/python/packages/flet/src/flet/core/list_view.py
+++ b/sdk/python/packages/flet/src/flet/core/list_view.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, List, Optional, Sequence, Union
+from typing import Any, List, Optional, Sequence, Union
 
 from flet.core.adaptive_control import AdaptiveControl
 from flet.core.animation import AnimationValue
@@ -10,6 +10,7 @@ from flet.core.types import (
     ClipBehavior,
     OffsetValue,
     OptionalControlEventCallable,
+    OptionalEventCallable,
     PaddingValue,
     ResponsiveNumber,
     RotateValue,
@@ -68,13 +69,14 @@ class ListView(ConstrainedControl, ScrollableControl, AdaptiveControl):
         clip_behavior: Optional[ClipBehavior] = None,
         semantic_child_count: Optional[int] = None,
         cache_extent: OptionalNumber = None,
+        build_controls_on_demand: Optional[bool] = None,
         #
         # ScrollableControl specific
         #
         auto_scroll: Optional[bool] = None,
         reverse: Optional[bool] = None,
         on_scroll_interval: OptionalNumber = None,
-        on_scroll: Optional[Callable[[OnScrollEvent], None]] = None,
+        on_scroll: OptionalEventCallable[OnScrollEvent] = None,
         #
         # ConstrainedControl
         #
@@ -160,6 +162,7 @@ class ListView(ConstrainedControl, ScrollableControl, AdaptiveControl):
         self.clip_behavior = clip_behavior
         self.semantic_child_count = semantic_child_count
         self.cache_extent = cache_extent
+        self.build_controls_on_demand = build_controls_on_demand
 
     def _get_control_name(self):
         return "listview"
@@ -265,3 +268,12 @@ class ListView(ConstrainedControl, ScrollableControl, AdaptiveControl):
     @semantic_child_count.setter
     def semantic_child_count(self, value: Optional[int]):
         self._set_attr("semanticChildCount", value)
+
+    # build_controls_on_demand
+    @property
+    def build_controls_on_demand(self) -> Optional[bool]:
+        return self._get_attr("buildControlsOnDemand", data_type="bool", def_value=True)
+
+    @build_controls_on_demand.setter
+    def build_controls_on_demand(self, value: Optional[bool]):
+        self._set_attr("buildControlsOnDemand", value)


### PR DESCRIPTION
Resolves #3931 

## Code Example
```python
import flet as ft

def main(page: ft.Page):

    page.add(
        ft.ListView(
            build_controls_on_demand=False,
            controls=[ft.ListTile(ft.Text(f"Item {i}")) for i in range(200)],
        )
    )

ft.app(target=main)
``` 