### PR TITLE
Flutter 3.27.3, JDK 17

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,7 @@ skip_commits:
 
 environment:
   python_stack: python 3.12
-  FLUTTER_VERSION: 3.27.2
+  FLUTTER_VERSION: 3.27.3
   GITHUB_TOKEN:
     secure: 9SKIwc3VSfYJ5IChvNR74hQprJ0DRmcV9pPX+8KyE6IXIdfMsX6ikeUmMhJGRu3ztkZaF45jmU7Xn/6tauXQXhDBxK1N8kFHFSAnq6LjUXyhS0TZKX/H+jDozBeVbCXp
   TWINE_USERNAME: __token__

--- a/sdk/python/packages/flet-cli/src/flet_cli/commands/build.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/commands/build.py
@@ -33,7 +33,7 @@ from rich.theme import Theme
 PYODIDE_ROOT_URL = "https://cdn.jsdelivr.net/pyodide/v0.25.0/full"
 DEFAULT_TEMPLATE_URL = "gh:flet-dev/flet-build-template"
 
-MINIMAL_FLUTTER_VERSION = version.Version("3.27.2")
+MINIMAL_FLUTTER_VERSION = version.Version("3.27.3")
 
 error_style = Style(color="red", bold=True)
 console = Console(log_path=False, theme=Theme({"log.message": "green bold"}))

--- a/sdk/python/packages/flet-cli/src/flet_cli/utils/jdk.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/utils/jdk.py
@@ -33,7 +33,7 @@ def check_jdk_version(jdk_path):
             1
         ]  # Extract version from output
         major_version = int(version_line.split(".")[0])
-        return major_version >= JDK_MAJOR_VER
+        return major_version == JDK_MAJOR_VER
     except (IndexError, ValueError, FileNotFoundError) as e:
         return False
 


### PR DESCRIPTION
## Summary by Sourcery

Upgrade Flutter to version 3.27.3 and enforce JDK 17.

Build:
- Upgrade Flutter to 3.27.3.
- Enforce JDK 17.