### PR TITLE
fix: disable markup for flet-cli stdout logs

### DIFF
--- a/sdk/python/packages/flet-cli/src/flet_cli/commands/build.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/commands/build.py
@@ -22,6 +22,15 @@ from rich.style import Style
 from rich.table import Column, Table
 from rich.theme import Theme
 
+import flet_cli.utils.processes as processes
+from flet_cli.commands.base import BaseCommand
+from flet_cli.utils.merge import merge_dict
+from flet_cli.utils.project_dependencies import (
+    get_poetry_dependencies,
+    get_project_dependencies,
+)
+from flet_cli.utils.pyproject_toml import load_pyproject_toml
+
 PYODIDE_ROOT_URL = "https://cdn.jsdelivr.net/pyodide/v0.25.0/full"
 DEFAULT_TEMPLATE_URL = "gh:flet-dev/flet-build-template"
 

--- a/sdk/python/packages/flet-cli/src/flet_cli/commands/build.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/commands/build.py
@@ -9,18 +9,10 @@ from pathlib import Path
 from typing import Optional, Union, cast
 
 import flet.version
-import flet_cli.utils.processes as processes
 import yaml
 from flet.utils import cleanup_path, copy_tree, is_windows, slugify
 from flet.utils.platform_utils import get_bool_env_var
 from flet.version import update_version
-from flet_cli.commands.base import BaseCommand
-from flet_cli.utils.merge import merge_dict
-from flet_cli.utils.project_dependencies import (
-    get_poetry_dependencies,
-    get_project_dependencies,
-)
-from flet_cli.utils.pyproject_toml import load_pyproject_toml
 from packaging import version
 from rich.console import Console, Group
 from rich.live import Live
@@ -1815,4 +1807,5 @@ class Command(BaseCommand):
                 message,
                 end="",
                 style=verbose2_style,
+                markup=False,
             )


### PR DESCRIPTION
## Description
Issue from discord: https://discord.com/channels/981374556059086931/1333791799180922930
![image](https://github.com/user-attachments/assets/3ce59950-472a-4d00-b600-ca8478425a7a)

## Summary by Sourcery

Bug Fixes:
- Fixed an issue where markup was incorrectly applied to flet-cli stdout logs.