### PR TITLE
Make `ControlEvent.data` of type `Optional[str]` with `None` as default

### DIFF
--- a/packages/flet/lib/src/controls/checkbox.dart
+++ b/packages/flet/lib/src/controls/checkbox.dart
@@ -46,7 +46,7 @@ class _CheckboxControlState extends State<CheckboxControl> with FletStoreMixin {
 
   void _onFocusChange() {
     widget.backend.triggerControlEvent(
-        widget.control.id, _focusNode.hasFocus ? "focus" : "blur", "");
+        widget.control.id, _focusNode.hasFocus ? "focus" : "blur");
   }
 
   @override

--- a/packages/flet/lib/src/controls/cupertino_sliding_segmented_button.dart
+++ b/packages/flet/lib/src/controls/cupertino_sliding_segmented_button.dart
@@ -57,8 +57,8 @@ class _CupertinoSlidingSegmentedButtonControlState
         if (!disabled) {
           widget.backend.updateControlState(widget.control.id,
               {"selectedIndex": index != null ? index.toString() : ""});
-          widget.backend.triggerControlEvent(widget.control.id, "change",
-              index != null ? index.toString() : "");
+          widget.backend.triggerControlEvent(
+              widget.control.id, "change", index?.toString());
         }
       },
       thumbColor: widget.control.attrColor(

--- a/packages/flet/lib/src/controls/cupertino_textfield.dart
+++ b/packages/flet/lib/src/controls/cupertino_textfield.dart
@@ -87,8 +87,7 @@ class _CupertinoTextFieldControlState extends State<CupertinoTextFieldControl>
     setState(() {
       _focused = _shiftEnterfocusNode.hasFocus;
     });
-    widget.backend.triggerControlEvent(widget.control.id,
-        _shiftEnterfocusNode.hasFocus ? "focus" : "blur", "");
+    widget.backend.triggerControlEvent(widget.control.id, _shiftEnterfocusNode.hasFocus ? "focus" : "blur");
   }
 
   void _onFocusChange() {
@@ -96,7 +95,7 @@ class _CupertinoTextFieldControlState extends State<CupertinoTextFieldControl>
       _focused = _focusNode.hasFocus;
     });
     widget.backend.triggerControlEvent(
-        widget.control.id, _focusNode.hasFocus ? "focus" : "blur", "");
+        widget.control.id, _focusNode.hasFocus ? "focus" : "blur");
   }
 
   @override

--- a/packages/flet/lib/src/controls/datatable.dart
+++ b/packages/flet/lib/src/controls/datatable.dart
@@ -103,11 +103,9 @@ class _DataTableControlState extends State<DataTableControl>
           sortAscending: widget.control.attrBool("sortAscending", false)!,
           sortColumnIndex: widget.control.attrInt("sortColumnIndex"),
           onSelectAll: widget.control.attrBool("onSelectAll", false)!
-              ? (selected) {
+              ? (bool? selected) {
                   widget.backend.triggerControlEvent(
-                      widget.control.id,
-                      "select_all",
-                      selected != null ? selected.toString() : "");
+                      widget.control.id, "select_all", selected?.toString());
                 }
               : null,
           columns: viewModel.controlViews
@@ -143,10 +141,8 @@ class _DataTableControlState extends State<DataTableControl>
                     Theme.of(context), row.control, "color"),
                 onSelectChanged: row.control.attrBool("onSelectChanged", false)!
                     ? (selected) {
-                        widget.backend.triggerControlEvent(
-                            row.control.id,
-                            "select_changed",
-                            selected != null ? selected.toString() : "");
+                        widget.backend.triggerControlEvent(row.control.id,
+                            "select_changed", selected?.toString());
                       }
                     : null,
                 onLongPress: row.control.attrBool("onLongPress", false)!

--- a/packages/flet/lib/src/controls/markdown.dart
+++ b/packages/flet/lib/src/controls/markdown.dart
@@ -133,7 +133,7 @@ class MarkdownControl extends StatelessWidget with FletStoreMixin {
               openWebBrowser(href, webWindowName: autoFollowLinksTarget);
             }
             backend.triggerControlEvent(
-                control.id, "tap_link", href?.toString() ?? "");
+                control.id, "tap_link", href?.toString());
           });
 
       return constrainedControl(context, markdown, parent, control);

--- a/packages/flet/lib/src/controls/selection_area.dart
+++ b/packages/flet/lib/src/controls/selection_area.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 
 import '../flet_control_backend.dart';
 import '../models/control.dart';
@@ -36,9 +37,8 @@ class SelectionAreaControl extends StatelessWidget {
     var selectionArea = SelectionArea(
       child: createControl(control, contentCtrls.first.id, disabled,
           parentAdaptive: parentAdaptive),
-      onSelectionChanged: (selection) {
-        backend.triggerControlEvent(
-            control.id, "change", selection?.plainText ?? "");
+      onSelectionChanged: (SelectedContent? selection) {
+        backend.triggerControlEvent(control.id, "change", selection?.plainText);
       },
     );
 

--- a/packages/flet/lib/src/controls/switch.dart
+++ b/packages/flet/lib/src/controls/switch.dart
@@ -62,7 +62,7 @@ class _SwitchControlState extends State<SwitchControl> with FletStoreMixin {
     widget.backend.triggerControlEvent(
         widget.control.id,
         _focusNode.hasFocus ? "focus" : "blur",
-        _focusNode.hasFocus ? _focusNode.hasPrimaryFocus.toString() : "");
+        _focusNode.hasPrimaryFocus.toString());
   }
 
   @override

--- a/packages/flet/lib/src/controls/textfield.dart
+++ b/packages/flet/lib/src/controls/textfield.dart
@@ -84,8 +84,7 @@ class _TextFieldControlState extends State<TextFieldControl>
     setState(() {
       _focused = _shiftEnterfocusNode.hasFocus;
     });
-    widget.backend.triggerControlEvent(widget.control.id,
-        _shiftEnterfocusNode.hasFocus ? "focus" : "blur", "");
+    widget.backend.triggerControlEvent(widget.control.id, _shiftEnterfocusNode.hasFocus ? "focus" : "blur");
   }
 
   void _onFocusChange() {
@@ -93,7 +92,7 @@ class _TextFieldControlState extends State<TextFieldControl>
       _focused = _focusNode.hasFocus;
     });
     widget.backend.triggerControlEvent(
-        widget.control.id, _focusNode.hasFocus ? "focus" : "blur", "");
+        widget.control.id, _focusNode.hasFocus ? "focus" : "blur");
   }
 
   @override

--- a/packages/flet/lib/src/flet_control_backend.dart
+++ b/packages/flet/lib/src/flet_control_backend.dart
@@ -3,7 +3,7 @@ abstract class FletControlBackend {
       {bool client = true, bool server = true});
 
   void triggerControlEvent(String controlId, String eventName,
-      [String eventData = ""]);
+      [String? eventData]);
 
   void subscribeMethods(String controlId,
       Future<String?> Function(String, Map<String, String>) methodHandler);

--- a/packages/flet/lib/src/flet_server.dart
+++ b/packages/flet/lib/src/flet_server.dart
@@ -179,7 +179,7 @@ class FletServer implements FletControlBackend {
 
   @override
   void triggerControlEvent(String controlId, String eventName,
-      [String eventData = ""]) {
+      [String? eventData]) {
     _sendPageEvent(
         eventTarget: controlId, eventName: eventName, eventData: eventData);
   }
@@ -198,7 +198,7 @@ class FletServer implements FletControlBackend {
   _sendPageEvent(
       {required String eventTarget,
       required String eventName,
-      required String eventData}) {
+      String? eventData}) {
     send(Message(
         action: MessageAction.pageEventFromWeb,
         payload: PageEventFromWebRequest(

--- a/packages/flet/lib/src/protocol/page_event_from_web_request.dart
+++ b/packages/flet/lib/src/protocol/page_event_from_web_request.dart
@@ -1,7 +1,7 @@
 class PageEventFromWebRequest {
   final String eventTarget;
   final String eventName;
-  final String eventData;
+  final String? eventData;
 
   PageEventFromWebRequest(
       {required this.eventTarget,

--- a/sdk/python/packages/flet/src/flet/core/control_event.py
+++ b/sdk/python/packages/flet/src/flet/core/control_event.py
@@ -1,8 +1,10 @@
+from typing import Optional
+
 from flet.core.event import Event
 
 
 class ControlEvent(Event):
-    def __init__(self, target: str, name: str, data: str, control, page):
+    def __init__(self, target: str, name: str, data: Optional[str], control, page):
         Event.__init__(self, target=target, name=name, data=data)
 
         self.control = control

--- a/sdk/python/packages/flet/src/flet/core/event.py
+++ b/sdk/python/packages/flet/src/flet/core/event.py
@@ -1,8 +1,11 @@
+from typing import Optional
+
+
 class Event:
-    def __init__(self, target: str, name: str, data: str):
-        self.target: str = target
-        self.name: str = name
-        self.data: str = data
+    def __init__(self, target: str, name: str, data: Optional[str]):
+        self.target = target
+        self.name = name
+        self.data = data
 
     def __repr__(self):
         attrs = ", ".join(f"{k}={v!r}" for k, v in self.__dict__.items())


### PR DESCRIPTION
Resolves #4786

## Test Code

```python
import flet as ft


def main(page: ft.Page):
    page.add(
        ft.TextField(
            label="Hello",
            on_click=lambda e: print(f"Clicked: {e.data!r}"),  # None
            on_focus=lambda e: print(f"Focused: {e.data!r}"),  # None
            on_change=lambda e: print(f"Changed: {e.data!r}"),  # String
        ),
    )


ft.app(target=main)
```

## Additional details

Complementary PRs:

- https://github.com/flet-dev/flet-video/pull/2
-

## Summary by Sourcery

Make ControlEvent.data optional.

Bug Fixes:
- Fix issue where ControlEvent.data was always a string, even when no data was provided.

Enhancements:
- Improve type handling in `ControlEvent` by making `data` field optional.