### PR TITLE
Auto update control

### DIFF
--- a/sdk/python/packages/flet/src/flet/core/control.py
+++ b/sdk/python/packages/flet/src/flet/core/control.py
@@ -624,3 +624,13 @@ class Control:
             )
             + ")"
         )
+
+    # auto-update control
+    def __setattr__(self, name, value):
+        super().__setattr__(name, value)
+        try:
+            if self.__page is not None and self.__page.auto_update:
+                if "_Control__attrs" in self.__dict__ and name in self.__attrs:
+                    self.update()
+        except:
+            pass

--- a/sdk/python/packages/flet/src/flet/core/page.py
+++ b/sdk/python/packages/flet/src/flet/core/page.py
@@ -566,6 +566,8 @@ class Page(AdaptiveControl):
 
         self.__lock = threading.Lock() if not is_pyodide() else NopeLock()
 
+        self.__auto_update = False
+
         self.__views = [View()]
         self.__default_view = self.__views[0]
         self._controls = self.__default_view.controls
@@ -1304,6 +1306,15 @@ class Page(AdaptiveControl):
             control.update()
         else:
             raise ValueError(f"{control.__class__.__qualname__} has no open attribute")
+
+    # auto-update
+    @property
+    def auto_update(self) -> PagePlatform:
+        return self.__auto_update
+
+    @auto_update.setter
+    def auto_update(self, value: bool) -> None:
+        self.__auto_update = value
 
     # query
     @property


### PR DESCRIPTION
## Description

auto-update control when any property changed

Added: `auto_update` property to `Page` class
Fixes #3329

## Test Code

```python
import flet as ft


def main(page: ft.Page):
    page.auto_update = True
    ref = ft.Ref[ft.Container]()

    def on_click():
        ref.current.bgcolor = ft.Colors.ORANGE
        # ref.current.update() # uncomment this if `page.auto_update` is False

    page.add(
        ft.Container(
            ref=ref,
            width=400,
            height=400,
            bgcolor=ft.Colors.INDIGO,
            on_click=lambda _: on_click(),
        )
    )


ft.app(main)
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] I signed the CLA.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes

## Screenshots 

<!-- Add screenshots here if applicable. -->

## Additional details

<!-- Any additional details to be known about this PR. -->

## Summary by Sourcery

Introduce auto-update functionality for controls on property change. Set `page.auto_update = True` to enable this feature. This addresses issue #3329.

New Features:
- Added `auto_update` property to the `Page` class to automatically update controls when their properties change.

Tests:
- Added test code to verify the functionality of the `auto_update` property.