### PR TITLE
feat: Implement `Container.dark_theme` property

### DIFF
--- a/packages/flet/lib/src/controls/create_control.dart
+++ b/packages/flet/lib/src/controls/create_control.dart
@@ -183,7 +183,6 @@ Widget createControl(Control? parent, String id, bool parentDisabled,
 
       // wrap into theme widget
       ThemeData? parentTheme = (themeMode == null) ? Theme.of(context) : null;
-
       buildTheme(Brightness? brightness) {
         return Theme(
             data: parseTheme(
@@ -202,9 +201,11 @@ Widget createControl(Control? parent, String id, bool parentDisabled,
               return buildTheme(media.displayBrightness);
             });
       } else {
-        return buildTheme((themeMode == ThemeMode.light)
+        return buildTheme(themeMode == ThemeMode.light
             ? Brightness.light
-            : ((themeMode == ThemeMode.dark) ? Brightness.dark : null));
+            : themeMode == ThemeMode.dark
+                ? Brightness.dark
+                : parentTheme?.brightness);
       }
     },
   );

--- a/packages/flet/lib/src/controls/create_control.dart
+++ b/packages/flet/lib/src/controls/create_control.dart
@@ -173,9 +173,8 @@ Widget createControl(Control? parent, String id, bool parentDisabled,
           parentAdaptive, nextChild, FletAppServices.of(context).server);
 
       // no theme defined? return widget!
-      var themeMode = ThemeMode.values.firstWhereOrNull((t) =>
-          t.name.toLowerCase() ==
-          controlView.control.attrString("themeMode", "")!.toLowerCase());
+      var themeMode =
+          parseThemeMode(controlView.control.attrString("themeMode"));
       if (id == "page" ||
           (controlView.control.attrString("theme") == null &&
               themeMode == null)) {

--- a/packages/flet/lib/src/controls/create_control.dart
+++ b/packages/flet/lib/src/controls/create_control.dart
@@ -172,11 +172,12 @@ Widget createControl(Control? parent, String id, bool parentDisabled,
       widget ??= createWidget(controlKey, controlView, parent, parentDisabled,
           parentAdaptive, nextChild, FletAppServices.of(context).server);
 
-      // no theme defined? return widget!
+      // no theme defined? return widget
       var themeMode =
           parseThemeMode(controlView.control.attrString("themeMode"));
       if (id == "page" ||
           (controlView.control.attrString("theme") == null &&
+              controlView.control.attrString("darkTheme") == null &&
               themeMode == null)) {
         return widget;
       }

--- a/packages/flet/lib/src/controls/create_control.dart
+++ b/packages/flet/lib/src/controls/create_control.dart
@@ -186,7 +186,10 @@ Widget createControl(Control? parent, String id, bool parentDisabled,
 
       buildTheme(Brightness? brightness) {
         return Theme(
-            data: parseTheme(controlView.control, "theme", brightness,
+            data: parseTheme(
+                controlView.control,
+                brightness == Brightness.dark ? "darkTheme" : "theme",
+                brightness,
                 parentTheme: parentTheme),
             child: widget!);
       }

--- a/packages/flet/lib/src/controls/search_anchor.dart
+++ b/packages/flet/lib/src/controls/search_anchor.dart
@@ -81,8 +81,6 @@ class _SearchAnchorControlState extends State<SearchAnchorControl> {
     debugPrint("SearchAnchor build: ${widget.control.id}");
     bool disabled = widget.control.isDisabled || widget.parentDisabled;
 
-    debugPrint(widget.control.attrs.toString());
-
     var value = widget.control.attrString("value", "");
     if (value != null && value != _controller.text) {
       WidgetsBinding.instance.addPostFrameCallback((_) {

--- a/packages/flet/lib/src/utils/theme.dart
+++ b/packages/flet/lib/src/utils/theme.dart
@@ -61,6 +61,15 @@ CupertinoThemeData fixCupertinoTheme(
               .copyWith(color: theme.colorScheme.onSurface)));
 }
 
+ThemeMode? parseThemeMode(String? value, [ThemeMode? defValue]) {
+  if (value == null) {
+    return defValue;
+  }
+  return ThemeMode.values.firstWhereOrNull(
+          (e) => e.name.toLowerCase() == value.toLowerCase()) ??
+      defValue;
+}
+
 ThemeData parseTheme(Control control, String propName, Brightness? brightness,
     {ThemeData? parentTheme}) {
   dynamic j;
@@ -76,7 +85,6 @@ ThemeData themeFromJson(Map<String, dynamic>? json, Brightness? brightness,
   ThemeData? theme = parentTheme;
 
   var primarySwatch = parseColor(null, json?["primary_swatch"]);
-
   var colorSchemeSeed = parseColor(null, json?["color_scheme_seed"]);
 
   if (colorSchemeSeed != null) {

--- a/sdk/python/packages/flet/src/flet/core/container.py
+++ b/sdk/python/packages/flet/src/flet/core/container.py
@@ -100,6 +100,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         url: Optional[str] = None,
         url_target: Optional[UrlTarget] = None,
         theme: Optional[Theme] = None,
+        dark_theme: Optional[Theme] = None,
         theme_mode: Optional[ThemeMode] = None,
         color_filter: Optional[ColorFilter] = None,
         ignore_interactions: Optional[bool] = None,
@@ -204,6 +205,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         self.url = url
         self.url_target = url_target
         self.theme = theme
+        self.dark_theme = dark_theme
         self.theme_mode = theme_mode
         self.color_filter = color_filter
         self.ignore_interactions = ignore_interactions
@@ -237,6 +239,7 @@ class Container(ConstrainedControl, AdaptiveControl):
         self._set_attr_json("blur", self.__blur)
         self._set_attr_json("shadow", self.__shadow if self.__shadow else None)
         self._set_attr_json("theme", self.__theme)
+        self._set_attr_json("darkTheme", self.__dark_theme)
         self._set_attr_json("colorFilter", self.__color_filter)
         self._set_attr_json("image", self.__image)
         self._set_attr_json("foregroundDecoration", self.__foreground_decoration)
@@ -582,6 +585,15 @@ class Container(ConstrainedControl, AdaptiveControl):
     @theme.setter
     def theme(self, value: Optional[Theme]):
         self.__theme = value
+
+    # dark_theme
+    @property
+    def dark_theme(self) -> Optional[Theme]:
+        return self.__dark_theme
+
+    @dark_theme.setter
+    def dark_theme(self, value: Optional[Theme]):
+        self.__dark_theme = value
 
     # theme_mode
     @property


### PR DESCRIPTION
Resolves #4857

## Test Code

```python
import flet as ft

light_theme = ft.Theme(search_bar_theme=ft.SearchBarTheme(bgcolor=ft.Colors.RED))
dark_theme = ft.Theme(search_bar_theme=ft.SearchBarTheme(bgcolor=ft.Colors.BLUE))


def main(page: ft.Page):
    page.theme_mode = ft.ThemeMode.LIGHT
    page.theme = light_theme
    page.dark_theme = dark_theme

    def handle_page_theme_mode_change(e):
        v = e.control.controls[e.control.selected_index].value
        page.theme_mode = v if v != "null" else None
        page.update()

    def handle_container_theme_mode_change(e):
        v = e.control.controls[e.control.selected_index].value
        c.theme_mode = v if v != "null" else None
        page.update()

    page.add(
        ft.CupertinoSlidingSegmentedButton(
            selected_index=0,
            on_change=handle_page_theme_mode_change,
            controls=[
                ft.Text("light"),
                ft.Text("system"),
                ft.Text("dark"),
                ft.Text("null"),
            ],
        ),
        ft.SearchBar(bar_hint_text="Based off Page theme"),
        ft.CupertinoSlidingSegmentedButton(
            selected_index=0,
            on_change=handle_container_theme_mode_change,
            controls=[
                ft.Text("light"),
                ft.Text("system"),
                ft.Text("dark"),
                ft.Text("null"),
            ],
        ),
        c := ft.Container(
            content=ft.SearchBar(bar_hint_text="Based off parent Container theme"),
            theme_mode=ft.ThemeMode.LIGHT,
            theme=light_theme,
            dark_theme=dark_theme,
        ),
    )


ft.app(main)
```

## Summary by Sourcery

New Features:
- Introduce the `dark_theme` property to the `Container` control, enabling distinct theming for light and dark modes.