### PR TITLE
feat: implement button themes (for `ElevatedButton`, `OutlinedButton`, `TextButton`, `FilledButton`, `IconButton `)

### DIFF
--- a/packages/flet/lib/src/utils/others.dart
+++ b/packages/flet/lib/src/utils/others.dart
@@ -1,9 +1,13 @@
+import 'dart:convert';
 import 'dart:ui';
 
 import 'package:collection/collection.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+
+import '../models/control.dart';
+import 'numbers.dart';
 
 Clip? parseClip(String? value, [Clip? defaultValue]) {
   if (value == null) {
@@ -71,6 +75,27 @@ SliderInteraction? parseSliderInteraction(String? value,
   return SliderInteraction.values.firstWhereOrNull(
           (e) => e.name.toLowerCase() == value.toLowerCase()) ??
       defValue;
+}
+
+Size? parseSize(Control control, String propName, [Size? defValue]) {
+  var v = control.attrString(propName, null);
+  if (v == null) {
+    return defValue;
+  }
+
+  final j1 = json.decode(v);
+  return sizeFromJson(j1, defValue);
+}
+
+Size? sizeFromJson(Map<String, dynamic>? json, [Size? defValue]) {
+  if (json == null) return defValue;
+
+  final width = parseDouble(json['width']);
+  final height = parseDouble(json['height']);
+
+  if (width == null || height == null) return defValue;
+
+  return Size(width, height);
 }
 
 SnackBarBehavior? parseSnackBarBehavior(String? value,

--- a/packages/flet/lib/src/utils/theme.dart
+++ b/packages/flet/lib/src/utils/theme.dart
@@ -84,8 +84,8 @@ ThemeData themeFromJson(Map<String, dynamic>? json, Brightness? brightness,
     ThemeData? parentTheme) {
   ThemeData? theme = parentTheme;
 
-  var primarySwatch = parseColor(null, json?["primary_swatch"]);
-  var colorSchemeSeed = parseColor(null, json?["color_scheme_seed"]);
+  var primarySwatch = parseColor(theme, json?["primary_swatch"]);
+  var colorSchemeSeed = parseColor(theme, json?["color_scheme_seed"]);
 
   if (colorSchemeSeed != null) {
     primarySwatch = null;
@@ -172,6 +172,14 @@ ThemeData themeFromJson(Map<String, dynamic>? json, Brightness? brightness,
     ),
     dataTableTheme: parseDataTableTheme(theme, json?["data_table_theme"]),
     buttonTheme: parseButtonTheme(theme, json?["button_theme"]),
+    elevatedButtonTheme:
+        parseElevatedButtonTheme(theme, json?["elevated_button_theme"]),
+    outlinedButtonTheme:
+        parseOutlinedButtonTheme(theme, json?["outlined_button_theme"]),
+    textButtonTheme: parseTextButtonTheme(theme, json?["text_button_theme"]),
+    filledButtonTheme:
+        parseFilledButtonTheme(theme, json?["filled_button_theme"]),
+    iconButtonTheme: parseIconButtonTheme(theme, json?["icon_button_theme"]),
     segmentedButtonTheme: parseSegmentedButtonTheme(
       theme,
       json?["segmented_button_theme"],
@@ -195,52 +203,52 @@ ColorScheme? parseColorScheme(ThemeData theme, Map<String, dynamic>? j) {
     return null;
   }
   return theme.colorScheme.copyWith(
-    primary: parseColor(null, j["primary"]),
-    onPrimary: parseColor(null, j["on_primary"]),
-    primaryContainer: parseColor(null, j["primary_container"]),
-    onPrimaryContainer: parseColor(null, j["on_primary_container"]),
-    secondary: parseColor(null, j["secondary"]),
-    onSecondary: parseColor(null, j["on_secondary"]),
-    secondaryContainer: parseColor(null, j["secondary_container"]),
-    onSecondaryContainer: parseColor(null, j["on_secondary_container"]),
-    tertiary: parseColor(null, j["tertiary"]),
-    onTertiary: parseColor(null, j["on_tertiary"]),
-    tertiaryContainer: parseColor(null, j["tertiary_container"]),
-    onTertiaryContainer: parseColor(null, j["on_tertiary_container"]),
-    error: parseColor(null, j["error"]),
-    onError: parseColor(null, j["on_error"]),
-    errorContainer: parseColor(null, j["error_container"]),
-    onErrorContainer: parseColor(null, j["on_error_container"]),
-    surface: parseColor(null, j["surface"]),
-    onSurface: parseColor(null, j["on_surface"]),
-    surfaceContainerHighest: parseColor(null, j["surface_variant"]),
-    onSurfaceVariant: parseColor(null, j["on_surface_variant"]),
-    outline: parseColor(null, j["outline"]),
-    outlineVariant: parseColor(null, j["outline_variant"]),
-    shadow: parseColor(null, j["shadow"]),
-    scrim: parseColor(null, j["scrim"]),
-    inverseSurface: parseColor(null, j["inverse_surface"]),
-    onInverseSurface: parseColor(null, j["on_inverse_surface"]),
-    inversePrimary: parseColor(null, j["inverse_primary"]),
-    surfaceTint: parseColor(null, j["surface_tint"]),
-    onPrimaryFixed: parseColor(null, j["on_primary_fixed"]),
-    onSecondaryFixed: parseColor(null, j["on_secondary_fixed"]),
-    onTertiaryFixed: parseColor(null, j["on_tertiary_fixed"]),
-    onPrimaryFixedVariant: parseColor(null, j["on_primary_fixed_variant"]),
-    onSecondaryFixedVariant: parseColor(null, j["on_secondary_fixed_variant"]),
-    onTertiaryFixedVariant: parseColor(null, j["on_tertiary_fixed_variant"]),
-    primaryFixed: parseColor(null, j["primary_fixed"]),
-    secondaryFixed: parseColor(null, j["secondary_fixed"]),
-    tertiaryFixed: parseColor(null, j["tertiary_fixed"]),
-    primaryFixedDim: parseColor(null, j["primary_fixed_dim"]),
-    secondaryFixedDim: parseColor(null, j["secondary_fixed_dim"]),
-    surfaceBright: parseColor(null, j["surface_bright"]),
-    surfaceContainer: parseColor(null, j["surface_container"]),
-    surfaceContainerHigh: parseColor(null, j["surface_container_high"]),
-    surfaceContainerLow: parseColor(null, j["surface_container_low"]),
-    surfaceContainerLowest: parseColor(null, j["surface_container_lowest"]),
-    surfaceDim: parseColor(null, j["surface_dim"]),
-    tertiaryFixedDim: parseColor(null, j["tertiary_fixed_dim"]),
+    primary: parseColor(theme, j["primary"]),
+    onPrimary: parseColor(theme, j["on_primary"]),
+    primaryContainer: parseColor(theme, j["primary_container"]),
+    onPrimaryContainer: parseColor(theme, j["on_primary_container"]),
+    secondary: parseColor(theme, j["secondary"]),
+    onSecondary: parseColor(theme, j["on_secondary"]),
+    secondaryContainer: parseColor(theme, j["secondary_container"]),
+    onSecondaryContainer: parseColor(theme, j["on_secondary_container"]),
+    tertiary: parseColor(theme, j["tertiary"]),
+    onTertiary: parseColor(theme, j["on_tertiary"]),
+    tertiaryContainer: parseColor(theme, j["tertiary_container"]),
+    onTertiaryContainer: parseColor(theme, j["on_tertiary_container"]),
+    error: parseColor(theme, j["error"]),
+    onError: parseColor(theme, j["on_error"]),
+    errorContainer: parseColor(theme, j["error_container"]),
+    onErrorContainer: parseColor(theme, j["on_error_container"]),
+    surface: parseColor(theme, j["surface"]),
+    onSurface: parseColor(theme, j["on_surface"]),
+    surfaceContainerHighest: parseColor(theme, j["surface_variant"]),
+    onSurfaceVariant: parseColor(theme, j["on_surface_variant"]),
+    outline: parseColor(theme, j["outline"]),
+    outlineVariant: parseColor(theme, j["outline_variant"]),
+    shadow: parseColor(theme, j["shadow"]),
+    scrim: parseColor(theme, j["scrim"]),
+    inverseSurface: parseColor(theme, j["inverse_surface"]),
+    onInverseSurface: parseColor(theme, j["on_inverse_surface"]),
+    inversePrimary: parseColor(theme, j["inverse_primary"]),
+    surfaceTint: parseColor(theme, j["surface_tint"]),
+    onPrimaryFixed: parseColor(theme, j["on_primary_fixed"]),
+    onSecondaryFixed: parseColor(theme, j["on_secondary_fixed"]),
+    onTertiaryFixed: parseColor(theme, j["on_tertiary_fixed"]),
+    onPrimaryFixedVariant: parseColor(theme, j["on_primary_fixed_variant"]),
+    onSecondaryFixedVariant: parseColor(theme, j["on_secondary_fixed_variant"]),
+    onTertiaryFixedVariant: parseColor(theme, j["on_tertiary_fixed_variant"]),
+    primaryFixed: parseColor(theme, j["primary_fixed"]),
+    secondaryFixed: parseColor(theme, j["secondary_fixed"]),
+    tertiaryFixed: parseColor(theme, j["tertiary_fixed"]),
+    primaryFixedDim: parseColor(theme, j["primary_fixed_dim"]),
+    secondaryFixedDim: parseColor(theme, j["secondary_fixed_dim"]),
+    surfaceBright: parseColor(theme, j["surface_bright"]),
+    surfaceContainer: parseColor(theme, j["surface_container"]),
+    surfaceContainerHigh: parseColor(theme, j["surface_container_high"]),
+    surfaceContainerLow: parseColor(theme, j["surface_container_low"]),
+    surfaceContainerLowest: parseColor(theme, j["surface_container_lowest"]),
+    surfaceDim: parseColor(theme, j["surface_dim"]),
+    tertiaryFixedDim: parseColor(theme, j["tertiary_fixed_dim"]),
   );
 }
 
@@ -278,12 +286,12 @@ ButtonThemeData? parseButtonTheme(ThemeData theme, Map<String, dynamic>? j) {
   }
 
   return theme.buttonTheme.copyWith(
-    buttonColor: parseColor(null, j["button_color"]),
-    disabledColor: parseColor(null, j["disabled_color"]),
-    hoverColor: parseColor(null, j["hover_color"]),
-    focusColor: parseColor(null, j["focus_color"]),
-    highlightColor: parseColor(null, j["highlight_color"]),
-    splashColor: parseColor(null, j["splash_color"]),
+    buttonColor: parseColor(theme, j["button_color"]),
+    disabledColor: parseColor(theme, j["disabled_color"]),
+    hoverColor: parseColor(theme, j["hover_color"]),
+    focusColor: parseColor(theme, j["focus_color"]),
+    highlightColor: parseColor(theme, j["highlight_color"]),
+    splashColor: parseColor(theme, j["splash_color"]),
     colorScheme: parseColorScheme(theme, j["color_scheme"]),
     alignedDropdown: parseBool(j["aligned_dropdown"]),
     height: parseDouble(j["height"]),
@@ -291,6 +299,201 @@ ButtonThemeData? parseButtonTheme(ThemeData theme, Map<String, dynamic>? j) {
     shape: outlinedBorderFromJSON(j["shape"]),
     padding: edgeInsetsFromJson(j["padding"]),
   );
+}
+
+ElevatedButtonThemeData? parseElevatedButtonTheme(
+    ThemeData theme, Map<String, dynamic>? j) {
+  if (j == null) {
+    return null;
+  }
+
+  TextStyle? parseTextStyle(String propName) {
+    return j[propName] != null ? textStyleFromJson(theme, j[propName]) : null;
+  }
+
+  return ElevatedButtonThemeData(
+      style: ElevatedButton.styleFrom(
+    iconColor: parseColor(theme, j["icon_color"]),
+    foregroundColor: parseColor(theme, j["foreground_color"]),
+    backgroundColor: parseColor(theme, j["bgcolor"]),
+    shadowColor: parseColor(theme, j["shadow_color"]),
+    disabledBackgroundColor: parseColor(theme, j["disabled_bgcolor"]),
+    disabledForegroundColor: parseColor(theme, j["disabled_foreground_color"]),
+    disabledIconColor: parseColor(theme, j["disabled_icon_color"]),
+    overlayColor: parseColor(theme, j["overlay_color"]),
+    surfaceTintColor: parseColor(theme, j["surface_tint_color"]),
+    elevation: parseDouble(j["elevation"]),
+    padding: edgeInsetsFromJson(j["padding"]),
+    enableFeedback: parseBool(j["enable_feedback"]),
+    disabledMouseCursor: parseMouseCursor(j["disabled_mouse_cursor"]),
+    enabledMouseCursor: parseMouseCursor(j["enabled_mouse_cursor"]),
+    shape: outlinedBorderFromJSON(j["shape"]),
+    textStyle: parseTextStyle("text_style"),
+    visualDensity: parseVisualDensity(j["visual_density"]),
+    side: borderSideFromJSON(theme, j["border_side"]),
+    animationDuration: durationFromJSON(j["animation_duration"]),
+    alignment: alignmentFromJson(j["alignment"]),
+    iconSize: parseDouble(j["icon_size"]),
+    fixedSize: sizeFromJson(j["fixed_size"]),
+    maximumSize: sizeFromJson(j["maximum_size"]),
+    minimumSize: sizeFromJson(j["minimum_size"]),
+  ));
+}
+
+OutlinedButtonThemeData? parseOutlinedButtonTheme(
+    ThemeData theme, Map<String, dynamic>? j) {
+  if (j == null) {
+    return null;
+  }
+
+  TextStyle? parseTextStyle(String propName) {
+    return j[propName] != null ? textStyleFromJson(theme, j[propName]) : null;
+  }
+
+  return OutlinedButtonThemeData(
+      style: OutlinedButton.styleFrom(
+    iconColor: parseColor(theme, j["icon_color"]),
+    foregroundColor: parseColor(theme, j["foreground_color"]),
+    backgroundColor: parseColor(theme, j["bgcolor"]),
+    shadowColor: parseColor(theme, j["shadow_color"]),
+    disabledBackgroundColor: parseColor(theme, j["disabled_bgcolor"]),
+    disabledForegroundColor: parseColor(theme, j["disabled_foreground_color"]),
+    disabledIconColor: parseColor(theme, j["disabled_icon_color"]),
+    overlayColor: parseColor(theme, j["overlay_color"]),
+    surfaceTintColor: parseColor(theme, j["surface_tint_color"]),
+    elevation: parseDouble(j["elevation"]),
+    padding: edgeInsetsFromJson(j["padding"]),
+    enableFeedback: parseBool(j["enable_feedback"]),
+    disabledMouseCursor: parseMouseCursor(j["disabled_mouse_cursor"]),
+    enabledMouseCursor: parseMouseCursor(j["enabled_mouse_cursor"]),
+    shape: outlinedBorderFromJSON(j["shape"]),
+    textStyle: parseTextStyle("text_style"),
+    visualDensity: parseVisualDensity(j["visual_density"]),
+    side: borderSideFromJSON(theme, j["border_side"]),
+    animationDuration: durationFromJSON(j["animation_duration"]),
+    alignment: alignmentFromJson(j["alignment"]),
+    iconSize: parseDouble(j["icon_size"]),
+    fixedSize: sizeFromJson(j["fixed_size"]),
+    maximumSize: sizeFromJson(j["maximum_size"]),
+    minimumSize: sizeFromJson(j["minimum_size"]),
+  ));
+}
+
+TextButtonThemeData? parseTextButtonTheme(
+    ThemeData theme, Map<String, dynamic>? j) {
+  if (j == null) {
+    return null;
+  }
+
+  TextStyle? parseTextStyle(String propName) {
+    return j[propName] != null ? textStyleFromJson(theme, j[propName]) : null;
+  }
+
+  return TextButtonThemeData(
+      style: TextButton.styleFrom(
+    iconColor: parseColor(theme, j["icon_color"]),
+    foregroundColor: parseColor(theme, j["foreground_color"]),
+    backgroundColor: parseColor(theme, j["bgcolor"]),
+    shadowColor: parseColor(theme, j["shadow_color"]),
+    disabledBackgroundColor: parseColor(theme, j["disabled_bgcolor"]),
+    disabledForegroundColor: parseColor(theme, j["disabled_foreground_color"]),
+    disabledIconColor: parseColor(theme, j["disabled_icon_color"]),
+    overlayColor: parseColor(theme, j["overlay_color"]),
+    surfaceTintColor: parseColor(theme, j["surface_tint_color"]),
+    elevation: parseDouble(j["elevation"]),
+    padding: edgeInsetsFromJson(j["padding"]),
+    enableFeedback: parseBool(j["enable_feedback"]),
+    disabledMouseCursor: parseMouseCursor(j["disabled_mouse_cursor"]),
+    enabledMouseCursor: parseMouseCursor(j["enabled_mouse_cursor"]),
+    shape: outlinedBorderFromJSON(j["shape"]),
+    textStyle: parseTextStyle("text_style"),
+    visualDensity: parseVisualDensity(j["visual_density"]),
+    side: borderSideFromJSON(theme, j["border_side"]),
+    animationDuration: durationFromJSON(j["animation_duration"]),
+    alignment: alignmentFromJson(j["alignment"]),
+    iconSize: parseDouble(j["icon_size"]),
+    fixedSize: sizeFromJson(j["fixed_size"]),
+    maximumSize: sizeFromJson(j["maximum_size"]),
+    minimumSize: sizeFromJson(j["minimum_size"]),
+  ));
+}
+
+FilledButtonThemeData? parseFilledButtonTheme(
+    ThemeData theme, Map<String, dynamic>? j) {
+  if (j == null) {
+    return null;
+  }
+
+  TextStyle? parseTextStyle(String propName) {
+    return j[propName] != null ? textStyleFromJson(theme, j[propName]) : null;
+  }
+
+  return FilledButtonThemeData(
+      style: FilledButton.styleFrom(
+    iconColor: parseColor(theme, j["icon_color"]),
+    foregroundColor: parseColor(theme, j["foreground_color"]),
+    backgroundColor: parseColor(theme, j["bgcolor"]),
+    shadowColor: parseColor(theme, j["shadow_color"]),
+    disabledBackgroundColor: parseColor(theme, j["disabled_bgcolor"]),
+    disabledForegroundColor: parseColor(theme, j["disabled_foreground_color"]),
+    disabledIconColor: parseColor(theme, j["disabled_icon_color"]),
+    overlayColor: parseColor(theme, j["overlay_color"]),
+    surfaceTintColor: parseColor(theme, j["surface_tint_color"]),
+    elevation: parseDouble(j["elevation"]),
+    padding: edgeInsetsFromJson(j["padding"]),
+    enableFeedback: parseBool(j["enable_feedback"]),
+    disabledMouseCursor: parseMouseCursor(j["disabled_mouse_cursor"]),
+    enabledMouseCursor: parseMouseCursor(j["enabled_mouse_cursor"]),
+    shape: outlinedBorderFromJSON(j["shape"]),
+    textStyle: parseTextStyle("text_style"),
+    visualDensity: parseVisualDensity(j["visual_density"]),
+    side: borderSideFromJSON(theme, j["border_side"]),
+    animationDuration: durationFromJSON(j["animation_duration"]),
+    alignment: alignmentFromJson(j["alignment"]),
+    iconSize: parseDouble(j["icon_size"]),
+    fixedSize: sizeFromJson(j["fixed_size"]),
+    maximumSize: sizeFromJson(j["maximum_size"]),
+    minimumSize: sizeFromJson(j["minimum_size"]),
+  ));
+}
+
+IconButtonThemeData? parseIconButtonTheme(
+    ThemeData theme, Map<String, dynamic>? j) {
+  if (j == null) {
+    return null;
+  }
+
+  TextStyle? parseTextStyle(String propName) {
+    return j[propName] != null ? textStyleFromJson(theme, j[propName]) : null;
+  }
+
+  return IconButtonThemeData(
+      style: IconButton.styleFrom(
+    foregroundColor: parseColor(theme, j["foreground_color"]),
+    backgroundColor: parseColor(theme, j["bgcolor"]),
+    shadowColor: parseColor(theme, j["shadow_color"]),
+    disabledBackgroundColor: parseColor(theme, j["disabled_bgcolor"]),
+    disabledForegroundColor: parseColor(theme, j["disabled_foreground_color"]),
+    overlayColor: parseColor(theme, j["overlay_color"]),
+    surfaceTintColor: parseColor(theme, j["surface_tint_color"]),
+    focusColor: parseColor(theme, j["focus_color"]),
+    highlightColor: parseColor(theme, j["highlight_color"]),
+    hoverColor: parseColor(theme, j["hover_color"]),
+    elevation: parseDouble(j["elevation"]),
+    padding: edgeInsetsFromJson(j["padding"]),
+    enableFeedback: parseBool(j["enable_feedback"]),
+    disabledMouseCursor: parseMouseCursor(j["disabled_mouse_cursor"]),
+    enabledMouseCursor: parseMouseCursor(j["enabled_mouse_cursor"]),
+    shape: outlinedBorderFromJSON(j["shape"]),
+    visualDensity: parseVisualDensity(j["visual_density"]),
+    side: borderSideFromJSON(theme, j["border_side"]),
+    animationDuration: durationFromJSON(j["animation_duration"]),
+    alignment: alignmentFromJson(j["alignment"]),
+    iconSize: parseDouble(j["icon_size"]),
+    fixedSize: sizeFromJson(j["fixed_size"]),
+    maximumSize: sizeFromJson(j["maximum_size"]),
+    minimumSize: sizeFromJson(j["minimum_size"]),
+  ));
 }
 
 DataTableThemeData? parseDataTableTheme(

--- a/sdk/python/packages/flet/src/flet/__init__.py
+++ b/sdk/python/packages/flet/src/flet/__init__.py
@@ -14,6 +14,7 @@ from flet.core import (
     margin,
     padding,
     painting,
+    size,
     transform,
 )
 from flet.core.adaptive_control import AdaptiveControl
@@ -264,7 +265,6 @@ from flet.core.page import (
     ViewPopEvent,
     Window,
     WindowEvent,
-    WindowEventType,
     WindowResizeEvent,
     context,
 )
@@ -308,6 +308,7 @@ from flet.core.semantics import Semantics
 from flet.core.semantics_service import Assertiveness, SemanticsService
 from flet.core.shader_mask import ShaderMask
 from flet.core.shake_detector import ShakeDetector
+from flet.core.size import Size
 from flet.core.slider import Slider, SliderInteraction
 from flet.core.snack_bar import DismissDirection, SnackBar, SnackBarBehavior
 from flet.core.stack import Stack, StackFit

--- a/sdk/python/packages/flet/src/flet/__init__.py
+++ b/sdk/python/packages/flet/src/flet/__init__.py
@@ -350,13 +350,17 @@ from flet.core.theme import (
     DatePickerTheme,
     DialogTheme,
     DividerTheme,
+    ElevatedButtonTheme,
     ExpansionTileTheme,
+    FilledButtonTheme,
     FloatingActionButtonTheme,
+    IconButtonTheme,
     IconTheme,
     ListTileTheme,
     NavigationBarTheme,
     NavigationDrawerTheme,
     NavigationRailTheme,
+    OutlinedButtonTheme,
     PageTransitionsTheme,
     PageTransitionTheme,
     PopupMenuTheme,
@@ -371,6 +375,7 @@ from flet.core.theme import (
     SwitchTheme,
     SystemOverlayStyle,
     TabsTheme,
+    TextButtonTheme,
     TextTheme,
     Theme,
     TimePickerTheme,
@@ -426,6 +431,7 @@ from flet.core.types import (
     VerticalAlignment,
     VisualDensity,
     WebRenderer,
+    WindowEventType,
 )
 from flet.core.vertical_divider import VerticalDivider
 from flet.core.video import (

--- a/sdk/python/packages/flet/src/flet/core/size.py
+++ b/sdk/python/packages/flet/src/flet/core/size.py
@@ -1,0 +1,73 @@
+from dataclasses import dataclass
+
+from flet.core.types import Number
+
+__all__ = [
+    "Size",
+    "copy",
+    "square",
+    "from_width",
+    "from_height",
+    "from_radius",
+    "zero",
+    "infinite",
+]
+
+
+@dataclass(frozen=True)
+class Size:
+    """
+    A class representing a 2D size with width and height.
+    """
+
+    width: float
+    height: float
+
+    @property
+    def aspect_ratio(self) -> float:
+        """Returns the aspect ratio (width / height)."""
+        if self.height != 0.0:
+            return self.width / self.height
+        if self.width > 0.0:
+            return float("inf")
+        if self.width < 0.0:
+            return float("-inf")
+        return 0.0
+
+    def is_infinite(self) -> bool:
+        """Checks if either dimension is infinite."""
+        return self.width == float("inf") or self.height == float("inf")
+
+    def is_finite(self) -> bool:
+        """Checks if both dimensions are finite."""
+        return self.width != float("inf") and self.height != float("inf")
+
+
+def copy(source: "Size") -> Size:
+    """Creates a copy of the given Size object."""
+    return Size(source.width, source.height)
+
+
+def square(dimension: Number) -> Size:
+    """Creates a square Size where width and height are the same."""
+    return Size(dimension, dimension)
+
+
+def from_width(width: Number) -> Size:
+    """Creates a Size with the given width and an infinite height."""
+    return Size(width, float("inf"))
+
+
+def from_height(height: Number) -> Size:
+    """Creates a Size with the given height and an infinite width."""
+    return Size(float("inf"), height)
+
+
+def from_radius(radius: Number) -> Size:
+    """Creates a square Size whose width and height are twice the given radius."""
+    return Size(radius * 2.0, radius * 2.0)
+
+
+# Constants
+zero = Size(0.0, 0.0)
+infinite = Size(float("inf"), float("inf"))

--- a/sdk/python/packages/flet/src/flet/core/theme.py
+++ b/sdk/python/packages/flet/src/flet/core/theme.py
@@ -7,11 +7,11 @@ from flet.core.border import BorderSide
 from flet.core.border_radius import BorderRadius
 from flet.core.box import BoxConstraints, BoxDecoration, BoxShadow
 from flet.core.buttons import ButtonStyle, OutlinedBorder
-from flet.core.control import OptionalNumber
 from flet.core.menu_bar import MenuStyle
 from flet.core.navigation_bar import NavigationBarLabelBehavior
 from flet.core.navigation_rail import NavigationRailLabelType
 from flet.core.popup_menu_button import PopupMenuPosition
+from flet.core.size import Size
 from flet.core.slider import SliderInteraction
 from flet.core.snack_bar import DismissDirection, SnackBarBehavior
 from flet.core.text_style import TextStyle
@@ -31,6 +31,7 @@ from flet.core.types import (
     MouseCursor,
     NotchShape,
     OffsetValue,
+    OptionalNumber,
     PaddingValue,
     ThemeVisualDensity,
     VisualDensity,
@@ -210,6 +211,79 @@ class DialogTheme:
     clip_behavior: Optional[ClipBehavior] = None
     barrier_color: Optional[ColorValue] = None
     inset_padding: Optional[PaddingValue] = None
+
+
+@dataclass
+class ElevatedButtonTheme:
+    bgcolor: Optional[ColorValue] = None
+    foreground_color: Optional[ColorValue] = None
+    icon_color: Optional[ColorValue] = None
+    shadow_color: Optional[ColorValue] = None
+    disabled_bgcolor: Optional[ColorValue] = None
+    disabled_foreground_color: Optional[ColorValue] = None
+    disabled_icon_color: Optional[ColorValue] = None
+    overlay_color: Optional[ColorValue] = None
+    surface_tint_color: Optional[ColorValue] = None
+    elevation: OptionalNumber = None
+    padding: Optional[PaddingValue] = None
+    enable_feedback: Optional[bool] = None
+    disabled_mouse_cursor: Optional[MouseCursor] = None
+    enabled_mouse_cursor: Optional[MouseCursor] = None
+    shape: Optional[OutlinedBorder] = None
+    text_style: Optional[TextStyle] = None
+    visual_density: Union[None, ThemeVisualDensity, VisualDensity] = None
+    border_side: Optional[BorderSide] = None
+    animation_duration: Optional[DurationValue] = None
+    alignment: Optional[Alignment] = None
+    icon_size: OptionalNumber = None
+    fixed_size: Optional[Size] = None
+    maximum_size: Optional[Size] = None
+    minimum_size: Optional[Size] = None
+
+
+@dataclass
+class OutlinedButtonTheme(ElevatedButtonTheme):
+    pass
+
+
+@dataclass
+class TextButtonTheme(ElevatedButtonTheme):
+    pass
+
+
+@dataclass
+class FilledButtonTheme(ElevatedButtonTheme):
+    pass
+
+
+@dataclass
+class IconButtonTheme:
+    # from ElevatedButtonTheme (excluding icon_color, disabled_icon_color, text_style)
+    bgcolor: Optional[ColorValue] = None
+    foreground_color: Optional[ColorValue] = None
+    shadow_color: Optional[ColorValue] = None
+    disabled_bgcolor: Optional[ColorValue] = None
+    disabled_foreground_color: Optional[ColorValue] = None
+    overlay_color: Optional[ColorValue] = None
+    surface_tint_color: Optional[ColorValue] = None
+    elevation: OptionalNumber = None
+    padding: Optional[PaddingValue] = None
+    enable_feedback: Optional[bool] = None
+    disabled_mouse_cursor: Optional[MouseCursor] = None
+    enabled_mouse_cursor: Optional[MouseCursor] = None
+    shape: Optional[OutlinedBorder] = None
+    visual_density: Union[None, ThemeVisualDensity, VisualDensity] = None
+    border_side: Optional[BorderSide] = None
+    animation_duration: Optional[DurationValue] = None
+    alignment: Optional[Alignment] = None
+    icon_size: OptionalNumber = None
+    fixed_size: Optional[Size] = None
+    maximum_size: Optional[Size] = None
+    minimum_size: Optional[Size] = None
+    # Icon Button Theme
+    focus_color: Optional[ColorValue] = None
+    highlight_color: Optional[ColorValue] = None
+    hover_color: Optional[ColorValue] = None
 
 
 @dataclass
@@ -846,6 +920,11 @@ class Theme:
     dialog_theme: Optional[DialogTheme] = None
     divider_theme: Optional[DividerTheme] = None
     # dropdown_menu_theme: Optional[DropdownMenuTheme] = None
+    elevated_button_theme: Optional[ElevatedButtonTheme] = None
+    outlined_button_theme: Optional[OutlinedButtonTheme] = None
+    text_button_theme: Optional[TextButtonTheme] = None
+    filled_button_theme: Optional[FilledButtonTheme] = None
+    icon_button_theme: Optional[IconButtonTheme] = None
     expansion_tile_theme: Optional[ExpansionTileTheme] = None
     floating_action_button_theme: Optional[FloatingActionButtonTheme] = None
     icon_theme: Optional[IconTheme] = None

--- a/sdk/python/packages/flet/src/flet/core/theme.py
+++ b/sdk/python/packages/flet/src/flet/core/theme.py
@@ -36,6 +36,7 @@ from flet.core.types import (
     ThemeVisualDensity,
     VisualDensity,
 )
+from flet.utils.deprecated import deprecated_class, deprecated_property
 
 try:
     from typing import Literal
@@ -883,6 +884,11 @@ class DataTableTheme:
     heading_cell_cursor: ControlStateValue[MouseCursor] = None
 
 
+@deprecated_class(
+    "Use ElevatedButtonTheme, OutlinedButtonTheme, TextButtonTheme, FilledButtonTheme or IconButtonTheme instead.",
+    version="0.27.0",
+    delete_version="0.30.0",
+)
 @dataclass
 class ButtonTheme:
     button_color: Optional[ColorValue] = None
@@ -968,3 +974,12 @@ class Theme:
     time_picker_theme: Optional[TimePickerTheme] = None
     tooltip_theme: Optional[TooltipTheme] = None
     visual_density: Union[VisualDensity, ThemeVisualDensity] = None
+
+    def __post_init__(self):
+        if self.button_theme:
+            deprecated_property(
+                "button_theme",
+                "Use elevated_button_theme, outlined_button_theme, text_button_theme, filled_button_theme or icon_button_theme instead.",
+                version="0.27.0",
+                delete_version="0.30.0",
+            )


### PR DESCRIPTION
From discord: https://discord.com/channels/981374556059086931/1000264673284857866/1338507789483380778

## Test Code

```python
import flet as ft


def main(page: ft.Page):
    page.theme = page.dark_theme = ft.Theme(
        elevated_button_theme=ft.ElevatedButtonTheme(
            bgcolor=ft.Colors.ERROR,
            foreground_color=ft.Colors.ERROR_CONTAINER,
            fixed_size=ft.Size(200, 50),
        ),
        outlined_button_theme=ft.OutlinedButtonTheme(
            bgcolor=ft.Colors.ERROR,
            foreground_color=ft.Colors.ERROR_CONTAINER,
            fixed_size=ft.Size(200, 50),
        ),
        text_button_theme=ft.TextButtonTheme(
            bgcolor=ft.Colors.ERROR,
            foreground_color=ft.Colors.ERROR_CONTAINER,
            fixed_size=ft.Size(200, 50),
        ),
        filled_button_theme=ft.FilledButtonTheme(
            bgcolor=ft.Colors.ERROR,
            foreground_color=ft.Colors.ERROR_CONTAINER,
            fixed_size=ft.Size(200, 50),
        ),
        icon_button_theme=ft.IconButtonTheme(
            bgcolor=ft.Colors.ERROR,
            foreground_color=ft.Colors.ERROR_CONTAINER,
            hover_color=ft.Colors.BLUE,
        ),
    )
    page.add(
        ft.ElevatedButton("ElevatedButton"),
        ft.OutlinedButton("OutlinedButton"),
        ft.TextButton("TextButton"),
        ft.FilledButton("FilledButton"),
        ft.IconButton(ft.Icons.ADD),
    )


ft.app(main)
```

## Summary by Sourcery

New Features:
- Added support for theming individual button types, including ElevatedButton, OutlinedButton, TextButton, FilledButton, and IconButton.