### PR TITLE
fix: `CupertinoSlider` raises `AssertionError` with valid values

### DIFF
--- a/packages/flet/lib/src/controls/cupertino_slider.dart
+++ b/packages/flet/lib/src/controls/cupertino_slider.dart
@@ -55,9 +55,7 @@ class _CupertinoSliderControlState extends State<CupertinoSliderControl> {
     double max = widget.control.attrDouble("max", 1)!;
     int? divisions = widget.control.attrInt("divisions");
 
-    debugPrint("CupertinoSliderControl build: ${widget.control.id}");
-
-    double value = widget.control.attrDouble("value", 0)!;
+    double value = widget.control.attrDouble("value", min)!;
     if (_value != value) {
       // verify limits
       if (value < min) {

--- a/sdk/python/packages/flet/src/flet/core/cupertino_slider.py
+++ b/sdk/python/packages/flet/src/flet/core/cupertino_slider.py
@@ -137,7 +137,7 @@ class CupertinoSlider(ConstrainedControl):
     # value
     @property
     def value(self) -> float:
-        return self._get_attr("value", data_type="float", def_value=0.0)
+        return self._get_attr("value", data_type="float", def_value=self.min or 0.0)
 
     @value.setter
     def value(self, value: OptionalNumber):

--- a/sdk/python/packages/flet/src/flet/core/cupertino_slider.py
+++ b/sdk/python/packages/flet/src/flet/core/cupertino_slider.py
@@ -122,6 +122,18 @@ class CupertinoSlider(ConstrainedControl):
     def _get_control_name(self):
         return "cupertinoslider"
 
+    def before_update(self):
+        super().before_update()
+        assert (
+            self.min is None or self.max is None or self.min <= self.max
+        ), "min must be less than or equal to max"
+        assert (
+            self.min is None or self.value is None or (self.value >= self.min)
+        ), "value must be greater than or equal to min"
+        assert (
+            self.max is None or self.value is None or (self.value <= self.max)
+        ), "value must be less than or equal to max"
+
     # value
     @property
     def value(self) -> float:
@@ -129,11 +141,6 @@ class CupertinoSlider(ConstrainedControl):
 
     @value.setter
     def value(self, value: OptionalNumber):
-        if value is not None:
-            if self.min is not None:
-                assert value >= self.min, "value must be greater than or equal to min"
-            if self.max is not None:
-                assert value <= self.max, "value must be less than or equal to max"
         self._set_attr("value", value)
 
     # min
@@ -143,9 +150,6 @@ class CupertinoSlider(ConstrainedControl):
 
     @min.setter
     def min(self, value: OptionalNumber):
-        if value is not None:
-            if self.max is not None:
-                assert value <= self.max, "min must be less than or equal to max"
         self._set_attr("min", value)
 
     # max
@@ -155,9 +159,6 @@ class CupertinoSlider(ConstrainedControl):
 
     @max.setter
     def max(self, value: OptionalNumber):
-        if value is not None:
-            if self.min is not None:
-                assert value >= self.min, "max must be greater than or equal to min"
         self._set_attr("max", value)
 
     # divisions


### PR DESCRIPTION
Resolves #4853

## Summary by Sourcery

Bug Fixes:
- Fix an `AssertionError` raised by `CupertinoSlider` when setting valid values.