### PR TITLE
fix: Ensure `ListTile`'s material parent has a transparent color for proper tile `bgcolor` visibility

### DIFF
--- a/packages/flet/lib/src/controls/list_tile.dart
+++ b/packages/flet/lib/src/controls/list_tile.dart
@@ -162,7 +162,7 @@ class ListTileControl extends StatelessWidget with FletStoreMixin {
         tile = ListTileClicks(notifier: _clickNotifier, child: tile);
       }
 
-      tile = Material(child: tile);
+      tile = Material(color: Colors.transparent, child: tile);
 
       return constrainedControl(context, tile, parent, control);
     });


### PR DESCRIPTION
Resolves #4855

## Test Code

```python
import flet as ft


def main(page: ft.Page):
    page.theme_mode = ft.ThemeMode.LIGHT
    page.add(
        ft.Card(
            color=ft.Colors.RED,
            content=ft.Column(
                controls=[
                    ft.ListTile(
                        title=ft.Text("Hello"),
                    ),
                ],
            ),
        )
    )


ft.app(main)

```

## Summary by Sourcery

Bug Fixes:
- Fix the visibility of `ListTile`'s `bgcolor` when the parent has a color.