### PR TITLE
fix: use utf8-encoding when opening files

### DIFF
--- a/sdk/python/packages/flet-cli/src/flet_cli/__pyinstaller/macos_utils.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/__pyinstaller/macos_utils.py
@@ -107,12 +107,12 @@ def assemble_app_bundle(app_path, tar_path):
 
 
 def __load_info_plist(app_path):
-    with open(__get_plist_path(app_path), "rb") as fp:
+    with open(__get_plist_path(app_path), "rb", encoding="utf-8") as fp:
         return plistlib.load(fp)
 
 
 def __save_info_plist(app_path, pl):
-    with open(__get_plist_path(app_path), "wb") as fp:
+    with open(__get_plist_path(app_path), "wb", encoding="utf-8") as fp:
         plistlib.dump(pl, fp)
 
 

--- a/sdk/python/packages/flet-cli/src/flet_cli/__pyinstaller/win_utils.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/__pyinstaller/win_utils.py
@@ -81,7 +81,7 @@ def update_flet_view_version_info(
             k.val = copyright if copyright else ""
 
     version_info_path = str(Path(tempfile.gettempdir()).joinpath(str(uuid.uuid4())))
-    with open(version_info_path, "w") as f:
+    with open(version_info_path, "w", encoding="utf-8") as f:
         f.write(str(vs))
 
     # Remember overlay
@@ -103,7 +103,7 @@ def update_flet_view_version_info(
 
         # If the update removed the overlay data, re-append it
         if not overlay_after:
-            with open(exe_path, "ab") as exef:
+            with open(exe_path, "ab", encoding="utf-8") as exef:
                 exef.write(overlay_before)
 
     return version_info_path

--- a/sdk/python/packages/flet-cli/src/flet_cli/commands/build.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/commands/build.py
@@ -1122,7 +1122,7 @@ class Command(BaseCommand):
         assert self.get_pyproject
         assert isinstance(self.flutter_dependencies, dict)
 
-        with open(self.pubspec_path, encoding="utf8") as f:
+        with open(self.pubspec_path, encoding="utf-8") as f:
             pubspec = yaml.safe_load(f)
 
         # merge dependencies to a dest pubspec.yaml
@@ -1143,7 +1143,7 @@ class Command(BaseCommand):
                 )
 
         # save pubspec.yaml
-        with open(self.pubspec_path, "w", encoding="utf8") as f:
+        with open(self.pubspec_path, "w", encoding="utf-8") as f:
             yaml.dump(pubspec, f)
 
     def customize_icons_and_splash_images(self):
@@ -1155,7 +1155,7 @@ class Command(BaseCommand):
 
         self.status.update(f"[bold blue]Customizing app icons and splash images...")
 
-        with open(self.pubspec_path, encoding="utf8") as f:
+        with open(self.pubspec_path, encoding="utf-8") as f:
             pubspec = yaml.safe_load(f)
 
         self.assets_path = self.package_app_path.joinpath("assets")
@@ -1357,7 +1357,7 @@ class Command(BaseCommand):
         )
 
         # save pubspec.yaml
-        with open(self.pubspec_path, "w", encoding="utf8") as f:
+        with open(self.pubspec_path, "w", encoding="utf-8") as f:
             yaml.dump(pubspec, f)
 
         console.log(
@@ -1459,7 +1459,7 @@ class Command(BaseCommand):
             package_args.append(",".join(toml_dependencies))
         elif requirements_txt.exists():
             if self.verbose > 1:
-                with open(requirements_txt, "r") as f:
+                with open(requirements_txt, "r", encoding="utf-8") as f:
                     console.log(
                         f"Contents of requirements.txt: {f.read()}",
                         style=verbose2_style,

--- a/sdk/python/packages/flet-cli/src/flet_cli/commands/publish.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/commands/publish.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from flet.core.types import WebRenderer
 from flet.utils import copy_tree, is_within_directory, random_string
+
 from flet_cli.commands.base import BaseCommand
 from flet_cli.utils.project_dependencies import (
     get_poetry_dependencies,
@@ -189,7 +190,7 @@ class Command(BaseCommand):
             deps = toml_dependencies
             print(f"pyproject.toml dependencies: {deps}")
         elif requirements_txt.exists():
-            with open(requirements_txt, "r") as f:
+            with open(requirements_txt, "r", encoding="utf-8") as f:
                 deps = list(
                     filter(
                         lambda dep: not dep.startswith("#"),
@@ -202,7 +203,7 @@ class Command(BaseCommand):
             deps = [f"flet=={flet.version.version}"]
 
         temp_reqs_txt = Path(tempfile.gettempdir()).joinpath(random_string(10))
-        with open(temp_reqs_txt, "w") as f:
+        with open(temp_reqs_txt, "w", encoding="utf-8") as f:
             f.writelines(dep + "\n" for dep in deps)
 
         # pack all files in script's directory to dist/app.tar.gz

--- a/sdk/python/packages/flet-cli/src/flet_cli/utils/distros.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/utils/distros.py
@@ -15,7 +15,7 @@ def download_with_progress(url, dest_path, progress: Optional[Progress] = None):
 
         if progress:
             task = progress.add_task("Downloading...", total=total_size)
-        with open(dest_path, "wb") as out_file:
+        with open(dest_path, "wb", encoding="utf-8") as out_file:
             while chunk := response.read(block_size):
                 out_file.write(chunk)
                 if progress:

--- a/sdk/python/packages/flet-desktop/src/flet_desktop/__init__.py
+++ b/sdk/python/packages/flet-desktop/src/flet_desktop/__init__.py
@@ -48,7 +48,7 @@ async def open_flet_view_async(page_url, assets_dir, hidden):
 def close_flet_view(pid_file):
     if pid_file is not None and os.path.exists(pid_file):
         try:
-            with open(pid_file) as f:
+            with open(pid_file, encoding="utf-8") as f:
                 fvp_pid = int(f.read())
             logger.debug(f"Flet View process {fvp_pid}")
             os.kill(fvp_pid, signal.SIGKILL)

--- a/sdk/python/packages/flet-web/src/flet_web/patch_index.py
+++ b/sdk/python/packages/flet-web/src/flet_web/patch_index.py
@@ -19,7 +19,7 @@ def patch_index_html(
     use_color_emoji: bool = False,
     route_url_strategy: str = "path",
 ):
-    with open(index_path, "r") as f:
+    with open(index_path, "r", encoding="utf-8") as f:
         index = f.read()
 
     if pyodide and pyodide_script_path:
@@ -77,7 +77,7 @@ def patch_index_html(
             index,
         )
 
-    with open(index_path, "w") as f:
+    with open(index_path, "w", encoding="utf-8") as f:
         f.write(index)
 
 
@@ -89,7 +89,7 @@ def patch_manifest_json(
     background_color: Optional[str] = None,
     theme_color: Optional[str] = None,
 ):
-    with open(manifest_path, "r") as f:
+    with open(manifest_path, "r", encoding="utf-8") as f:
         manifest = json.loads(f.read())
 
     if app_name:
@@ -108,5 +108,5 @@ def patch_manifest_json(
     if theme_color:
         manifest["theme_color"] = theme_color
 
-    with open(manifest_path, "w") as f:
+    with open(manifest_path, "w", encoding="utf-8") as f:
         f.write(json.dumps(manifest, indent=2))

--- a/sdk/python/packages/flet/src/flet/core/control.py
+++ b/sdk/python/packages/flet/src/flet/core/control.py
@@ -83,9 +83,6 @@ class Control:
     def is_isolated(self) -> bool:
         return False
 
-    def build(self):
-        pass
-
     def before_update(self):
         pass
 
@@ -529,18 +526,7 @@ class Control:
     ) -> List[Command]:
         if index:
             self.page = index["page"]
-        content = self.build()
 
-        # fix for UserControl
-        if content is not None:
-            if isinstance(content, Control) and hasattr(self, "controls"):
-                self.controls = [content]
-            elif (
-                isinstance(content, List)
-                and hasattr(self, "controls")
-                and all(isinstance(control, Control) for control in content)
-            ):
-                self.controls = content
         # remove control from index
         if self.__uid and index is not None and self.__uid in index:
             del index[self.__uid]

--- a/sdk/python/packages/flet/src/flet/utils/hashing.py
+++ b/sdk/python/packages/flet/src/flet/utils/hashing.py
@@ -9,7 +9,7 @@ def sha1(input_string):
 
 def calculate_file_hash(path, blocksize=65536):
     h = hashlib.sha256()
-    with open(path, "rb") as f:
+    with open(path, "rb", encoding="utf-8") as f:
         while True:
             data = f.read(blocksize)
             if not data:

--- a/sdk/python/packages/flet/src/flet/utils/platform_utils.py
+++ b/sdk/python/packages/flet/src/flet/utils/platform_utils.py
@@ -52,7 +52,7 @@ def is_linux_server():
         # check if it's WSL
         p = "/proc/version"
         if os.path.exists(p):
-            with open(p, "r") as file:
+            with open(p, "r", encoding="utf-8") as file:
                 if "microsoft" in file.read():
                     return False  # it's WSL, not a server
         return os.environ.get("DISPLAY") is None


### PR DESCRIPTION
Resolves #4713

## Summary by Sourcery

Bug Fixes:
- Fixed issue #4713 by ensuring that files are opened using UTF-8 encoding across the codebase (Python, web, and desktop).