### PR TITLE
fix: grey screen displayed when scale-transforming

### DIFF
--- a/packages/flet/lib/src/controls/create_control.dart
+++ b/packages/flet/lib/src/controls/create_control.dart
@@ -1153,7 +1153,7 @@ Widget _scaledControl(
   var animation = parseAnimation(control, "animateScale");
   if (animation != null) {
     return AnimatedScale(
-        scale: scaleDetails?.scale! ?? 1.0,
+        scale: scaleDetails?.scale ?? 1.0,
         alignment: scaleDetails?.alignment ?? Alignment.center,
         duration: animation.duration,
         curve: animation.curve,


### PR DESCRIPTION
Resolves  #4759

## Test Code

```python
import flet as ft


def main(page: ft.Page):
    c = ft.Container(
        width=100,
        height=100,
        bgcolor="blue",
        border_radius=5,
        opacity=1,
        scale=ft.transform.Scale(scale_x=1, scale_y=1, scale=2),
        offset=ft.transform.Offset(0, 0),
        animate_scale=ft.animation.Animation(500, curve=ft.AnimationCurve.LINEAR),
    )

    def animate(e):
        c.scale = (
            ft.transform.Scale(scale_x=1, scale_y=0)
            if c.scale == ft.transform.Scale(scale_x=1, scale_y=1, scale=2)
            else ft.transform.Scale(scale_x=1, scale_y=1, scale=2)
        )
        print(c.scale)
        page.update()

    page.vertical_alignment = ft.MainAxisAlignment.CENTER
    page.horizontal_alignment = ft.CrossAxisAlignment.CENTER
    page.spacing = 30
    page.add(
        c,
        ft.ElevatedButton(
            "Animate! with scale_x and scale_y \n↕expand", on_click=animate
        ),
    )


ft.app(target=main)
```

## Summary by Sourcery

Bug Fixes:
- Fix grey screen displayed when scale-transforming a Container by ensuring the scale value defaults to 1.0 when not explicitly set in the Scale transform constructor or via the scale property