### PR TITLE
feat: implement `SearchBar.blur()`

### DIFF
--- a/packages/flet/lib/src/controls/search_anchor.dart
+++ b/packages/flet/lib/src/controls/search_anchor.dart
@@ -39,6 +39,7 @@ class _SearchAnchorControlState extends State<SearchAnchorControl> {
   bool _focused = false;
   late final FocusNode _focusNode;
   String? _lastFocusValue;
+  String? _lastBlurValue;
 
   @override
   void initState() {
@@ -109,9 +110,14 @@ class _SearchAnchorControlState extends State<SearchAnchorControl> {
         widget.control.attrString("keyboardType"), TextInputType.text)!;
 
     var focusValue = widget.control.attrString("focus");
+    var blurValue = widget.control.attrString("blur");
     if (focusValue != null && focusValue != _lastFocusValue) {
       _lastFocusValue = focusValue;
       _focusNode.requestFocus();
+    }
+    if (blurValue != null && blurValue != _lastBlurValue) {
+      _lastBlurValue = blurValue;
+      _focusNode.unfocus();
     }
 
     var method = widget.control.attrString("method");

--- a/sdk/python/packages/flet/src/flet/core/search_bar.py
+++ b/sdk/python/packages/flet/src/flet/core/search_bar.py
@@ -233,6 +233,10 @@ class SearchBar(ConstrainedControl):
         self._set_attr_json("focus", str(time.time()))
         self.update()
 
+    def blur(self):
+        self._set_attr_json("blur", str(time.time()))
+        self.update()
+
     def open_view(self):
         m = {
             "n": "openView",


### PR DESCRIPTION
## Description

Resolves #4827

By default, when setting `on_tap_outside_bar`, clicking outside the bar will trigger the event but not unfocus the field. [Why?](https://main-api.flutter.dev/flutter/material/TextField/onTapOutside.html)

`SearchBar.blur()` provides the user the possibility to programmatically unfocus the bar.

## Test Code

```python
import flet as ft


def main(page: ft.Page):
    def handle_tap_outside_bar(e):
        # ...
        sb.blur()

    page.add(
        sb := ft.SearchBar(on_tap_outside_bar=handle_tap_outside_bar),
    )


ft.app(main)
```

## Summary by Sourcery

New Features:
- Added `SearchBar.blur()` method to programmatically unfocus the search bar.