### PR TITLE
Remove `v0.24.0` deprecations

### DIFF
--- a/packages/flet/lib/src/controls/container.dart
+++ b/packages/flet/lib/src/controls/container.dart
@@ -70,16 +70,6 @@ class ContainerControl extends StatelessWidget with FletStoreMixin {
     bool ignoreInteractions = control.attrBool("ignoreInteractions", false)!;
     bool disabled = control.isDisabled || parentDisabled;
     bool? adaptive = control.attrBool("adaptive") ?? parentAdaptive;
-
-    // DEPRECATED START
-    var imageSrc = control.attrString("imageSrc", "")!;
-    var imageSrcBase64 = control.attrString("imageSrcBase64", "")!;
-    var imageRepeat = parseImageRepeat(
-        control.attrString("imageRepeat"), ImageRepeat.noRepeat)!;
-    var imageFit = parseBoxFit(control.attrString("imageFit"));
-    var imageOpacity = control.attrDouble("imageOpacity", 1)!;
-    // DEPRECATED END
-
     Widget? child = contentCtrls.isNotEmpty
         ? createControl(control, contentCtrls.first.id, disabled,
             parentAdaptive: adaptive)
@@ -96,14 +86,9 @@ class ContainerControl extends StatelessWidget with FletStoreMixin {
     var alignment = parseAlignment(control, "alignment");
 
     return withPageArgs((context, pageArgs) {
-      ImageProvider? image =
-          getImageProvider(imageSrc, imageSrcBase64, pageArgs);
-
       var borderRadius = parseBorderRadius(control, "borderRadius");
-
       var clipBehavior = parseClip(control.attrString("clipBehavior"),
           borderRadius != null ? Clip.antiAlias : Clip.none)!;
-
       var decorationImage =
           parseDecorationImage(Theme.of(context), control, "image", pageArgs);
       var boxDecoration = boxDecorationFromDetails(
@@ -115,13 +100,7 @@ class ContainerControl extends StatelessWidget with FletStoreMixin {
             Theme.of(context).colorScheme.primary),
         boxShadow: parseBoxShadow(Theme.of(context), control, "shadow"),
         blendMode: parseBlendMode(control.attrString("blendMode")),
-        image: decorationImage == null && image != null
-            ? DecorationImage(
-                image: image,
-                repeat: imageRepeat,
-                fit: imageFit,
-                opacity: imageOpacity)
-            : decorationImage,
+        image: decorationImage,
       );
       var boxForegroundDecoration = parseBoxDecoration(
           Theme.of(context), control, "foregroundDecoration", pageArgs);

--- a/packages/flet/lib/src/controls/cupertino_button.dart
+++ b/packages/flet/lib/src/controls/cupertino_button.dart
@@ -99,7 +99,6 @@ class _CupertinoButtonControlState extends State<CupertinoButtonControl> {
     String url = widget.control.attrString("url", "")!;
     Color disabledColor =
         widget.control.attrColor("disabledBgcolor", context) ??
-            widget.control.attrColor("disabledColor", context) ?? // deprecated
             CupertinoColors.quaternarySystemFill;
     Color? bgColor = widget.control.attrColor("bgColor", context);
     Color? color = widget.control.attrColor("color", context);

--- a/packages/flet/lib/src/controls/markdown.dart
+++ b/packages/flet/lib/src/controls/markdown.dart
@@ -40,12 +40,8 @@ class MarkdownControl extends StatelessWidget with FletStoreMixin {
     bool disabled = control.isDisabled || parentDisabled;
 
     var value = control.attrString("value", "")!;
-    var codeTheme = control.attrString("codeTheme", "")!;
     md.ExtensionSet extensionSet = parseMarkdownExtensionSet(
         control.attrString("extensionSet"), md.ExtensionSet.none)!;
-
-    TextStyle? codeStyle =
-        parseTextStyle(Theme.of(context), control, "codeStyle"); // DEPRECATED
 
     var autoFollowLinks = control.attrBool("autoFollowLinks", false)!;
     var autoFollowLinksTarget = control.attrString("autoFollowLinksTarget");
@@ -55,11 +51,10 @@ class MarkdownControl extends StatelessWidget with FletStoreMixin {
       var codeStyleSheet = parseMarkdownStyleSheet(
               control, "codeStyleSheet", Theme.of(context), pageArgs) ??
           MarkdownStyleSheet.fromTheme(Theme.of(context)).copyWith(
-              code: codeStyle ??
-                  Theme.of(context)
-                      .textTheme
-                      .bodyMedium!
-                      .copyWith(fontFamily: "monospace"));
+              code: Theme.of(context)
+                  .textTheme
+                  .bodyMedium!
+                  .copyWith(fontFamily: "monospace"));
       var mdStyleSheet = parseMarkdownStyleSheet(
           control, "mdStyleSheet", Theme.of(context), pageArgs);
       var codeTheme =

--- a/sdk/python/packages/flet/src/flet/__init__.py
+++ b/sdk/python/packages/flet/src/flet/__init__.py
@@ -429,7 +429,6 @@ from flet.core.types import (
     TabAlignment,
     TextAlign,
     ThemeMode,
-    ThemeVisualDensity,
     UrlTarget,
     VerticalAlignment,
     VisualDensity,

--- a/sdk/python/packages/flet/src/flet/core/checkbox.py
+++ b/sdk/python/packages/flet/src/flet/core/checkbox.py
@@ -21,7 +21,6 @@ from flet.core.types import (
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
-    ThemeVisualDensity,
     VisualDensity,
 )
 
@@ -79,7 +78,7 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
         splash_radius: OptionalNumber = None,
         border_side: ControlStateValue[BorderSide] = None,
         is_error: Optional[bool] = None,
-        visual_density: Union[None, ThemeVisualDensity, VisualDensity] = None,
+        visual_density: Optional[VisualDensity] = None,
         mouse_cursor: Optional[MouseCursor] = None,
         on_change: OptionalControlEventCallable = None,
         on_focus: OptionalControlEventCallable = None,
@@ -236,13 +235,13 @@ class Checkbox(ConstrainedControl, AdaptiveControl):
 
     # visual_density
     @property
-    def visual_density(self) -> Union[None, ThemeVisualDensity, VisualDensity]:
+    def visual_density(self) -> Optional[VisualDensity]:
         return self.__visual_density
 
     @visual_density.setter
-    def visual_density(self, value: Union[None, ThemeVisualDensity, VisualDensity]):
+    def visual_density(self, value: Optional[VisualDensity]):
         self.__visual_density = value
-        self._set_enum_attr("visualDensity", value, (ThemeVisualDensity, VisualDensity))
+        self._set_enum_attr("visualDensity", value, VisualDensity)
 
     # autofocus
     @property

--- a/sdk/python/packages/flet/src/flet/core/chip.py
+++ b/sdk/python/packages/flet/src/flet/core/chip.py
@@ -21,7 +21,6 @@ from flet.core.types import (
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
-    ThemeVisualDensity,
     VisualDensity,
 )
 
@@ -97,7 +96,7 @@ class Chip(ConstrainedControl):
         color: ControlStateValue[ColorValue] = None,
         click_elevation: OptionalNumber = None,
         clip_behavior: Optional[ClipBehavior] = None,
-        visual_density: Union[None, ThemeVisualDensity, VisualDensity] = None,
+        visual_density: Optional[VisualDensity] = None,
         border_side: Optional[BorderSide] = None,
         leading_size_constraints: Optional[BoxConstraints] = None,
         delete_icon_size_constraints: Optional[BoxConstraints] = None,
@@ -508,13 +507,13 @@ class Chip(ConstrainedControl):
 
     # visual_density
     @property
-    def visual_density(self) -> Union[None, ThemeVisualDensity, VisualDensity]:
+    def visual_density(self) -> Optional[VisualDensity]:
         return self.__visual_density
 
     @visual_density.setter
-    def visual_density(self, value: Union[None, ThemeVisualDensity, VisualDensity]):
+    def visual_density(self, value: Optional[VisualDensity]):
         self.__visual_density = value
-        self._set_enum_attr("visualDensity", value, (ThemeVisualDensity, VisualDensity))
+        self._set_enum_attr("visualDensity", value, VisualDensity)
 
     # clip_behavior
     @property

--- a/sdk/python/packages/flet/src/flet/core/container.py
+++ b/sdk/python/packages/flet/src/flet/core/container.py
@@ -82,11 +82,6 @@ class Container(ConstrainedControl, AdaptiveControl):
         blend_mode: Optional[BlendMode] = None,
         border: Optional[Border] = None,
         border_radius: Optional[BorderRadiusValue] = None,
-        image_src: Optional[str] = None,
-        image_src_base64: Optional[str] = None,
-        image_repeat: Optional[ImageRepeat] = None,
-        image_fit: Optional[ImageFit] = None,
-        image_opacity: OptionalNumber = None,
         shape: Optional[BoxShape] = None,
         clip_behavior: Optional[ClipBehavior] = None,
         ink: Optional[bool] = None,
@@ -190,11 +185,6 @@ class Container(ConstrainedControl, AdaptiveControl):
         self.blend_mode = blend_mode
         self.border = border
         self.border_radius = border_radius
-        self.image_src = image_src
-        self.image_src_base64 = image_src_base64
-        self.image_repeat = image_repeat
-        self.image_fit = image_fit
-        self.image_opacity = image_opacity
         self.shape = shape
         self.clip_behavior = clip_behavior
         self.ink = ink
@@ -382,50 +372,6 @@ class Container(ConstrainedControl, AdaptiveControl):
     def border_radius(self, value: Optional[BorderRadiusValue]):
         self.__border_radius = value
 
-    # image_src
-    @property
-    def image_src(self) -> Optional[str]:
-        deprecated_property(
-            name="image_src",
-            reason="Use Container.image.src instead.",
-            version="0.24.0",
-            delete_version="0.27.0",
-        )
-        return self._get_attr("imageSrc")
-
-    @image_src.setter
-    def image_src(self, value: Optional[str]):
-        self._set_attr("imageSrc", value)
-        if value is not None:
-            deprecated_property(
-                name="image_src",
-                reason="Use Container.image.src instead.",
-                version="0.24.0",
-                delete_version="0.27.0",
-            )
-
-    # image_src_base64
-    @property
-    def image_src_base64(self) -> Optional[str]:
-        deprecated_property(
-            name="image_src_base64",
-            reason="Use Container.image.src_base64 instead.",
-            version="0.24.0",
-            delete_version="0.27.0",
-        )
-        return self._get_attr("imageSrcBase64")
-
-    @image_src_base64.setter
-    def image_src_base64(self, value: Optional[str]):
-        self._set_attr("imageSrcBase64", value)
-        if value is not None:
-            deprecated_property(
-                name="image_src_base64",
-                reason="Use Container.image.src_base64 instead.",
-                version="0.24.0",
-                delete_version="0.27.0",
-            )
-
     # ignore_interactions
     @property
     def ignore_interactions(self) -> Optional[bool]:
@@ -434,72 +380,6 @@ class Container(ConstrainedControl, AdaptiveControl):
     @ignore_interactions.setter
     def ignore_interactions(self, value: Optional[str]):
         self._set_attr("ignoreInteractions", value)
-
-    # image_fit
-    @property
-    def image_fit(self) -> Optional[ImageFit]:
-        deprecated_property(
-            name="image_fit",
-            reason="Use Container.image.fit instead.",
-            version="0.24.0",
-            delete_version="0.27.0",
-        )
-
-        return self.__image_fit
-
-    @image_fit.setter
-    def image_fit(self, value: Optional[ImageFit]):
-        self.__image_fit = value
-        self._set_enum_attr("imageFit", value, ImageFit)
-        if value is not None:
-            deprecated_property(
-                name="image_fit",
-                reason="Use Container.image.fit instead.",
-                version="0.24.0",
-                delete_version="0.27.0",
-            )
-
-    # image_repeat
-    @property
-    def image_repeat(self) -> Optional[ImageRepeat]:
-        deprecated_property(
-            "image_repeat",
-            "Use Container.image.repeat instead.",
-            "0.24.0",
-            "0.27.0",
-        )
-        return self.__image_repeat
-
-    @image_repeat.setter
-    def image_repeat(self, value: Optional[ImageRepeat]):
-        self.__image_repeat = value
-        self._set_enum_attr("imageRepeat", value, ImageRepeat)
-        if value is not None:
-            deprecated_property(
-                name="image_repeat",
-                reason="Use Container.image.repeat instead.",
-                version="0.24.0",
-                delete_version="0.27.0",
-            )
-
-    # image_opacity
-    @property
-    def image_opacity(self) -> float:
-        deprecated_property(
-            "image_opacity", "Use Container.image.opacity instead.", "0.24.0", "0.27.0"
-        )
-        return self._get_attr("imageOpacity", data_type="float", def_value=1.0)
-
-    @image_opacity.setter
-    def image_opacity(self, value: OptionalNumber):
-        self._set_attr("imageOpacity", value)
-        if value is not None:
-            deprecated_property(
-                name="image_opacity",
-                reason="Use Container.image.opacity instead.",
-                version="0.24.0",
-                delete_version="0.27.0",
-            )
 
     # content
     @property

--- a/sdk/python/packages/flet/src/flet/core/cupertino_button.py
+++ b/sdk/python/packages/flet/src/flet/core/cupertino_button.py
@@ -41,7 +41,6 @@ class CupertinoButton(ConstrainedControl):
         content: Optional[Control] = None,
         bgcolor: Optional[ColorValue] = None,
         color: Optional[ColorValue] = None,
-        disabled_color: Optional[ColorValue] = None,
         disabled_bgcolor: Optional[ColorValue] = None,
         opacity_on_click: OptionalNumber = None,
         min_size: OptionalNumber = None,
@@ -118,7 +117,6 @@ class CupertinoButton(ConstrainedControl):
             data=data,
         )
 
-        self.disabled_color = disabled_color
         self.disabled_bgcolor = disabled_bgcolor
         self.text = text
         self.icon = icon
@@ -193,29 +191,6 @@ class CupertinoButton(ConstrainedControl):
     @alignment.setter
     def alignment(self, value: Optional[Alignment]):
         self.__alignment = value
-
-    # disabled_color
-    @property
-    def disabled_color(self) -> Optional[ColorValue]:
-        warnings.warn(
-            f"disabled_color is deprecated since version 0.24.0 "
-            f"and will be removed in version 0.27.0. Use disabled_bgcolor instead.",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.__disabled_color
-
-    @disabled_color.setter
-    def disabled_color(self, value: Optional[ColorValue]):
-        self.__disabled_color = value
-        self._set_enum_attr("disabledColor", value, ColorEnums)
-        if value is not None:
-            warnings.warn(
-                f"disabled_color is deprecated since version 0.24.0 "
-                f"and will be removed in version 0.27.0. Use disabled_bgcolor instead.",
-                category=DeprecationWarning,
-                stacklevel=2,
-            )
 
     # disabled_bgcolor
     @property

--- a/sdk/python/packages/flet/src/flet/core/cupertino_filled_button.py
+++ b/sdk/python/packages/flet/src/flet/core/cupertino_filled_button.py
@@ -44,7 +44,7 @@ class CupertinoFilledButton(CupertinoButton):
         icon: Optional[IconValue] = None,
         icon_color: Optional[ColorValue] = None,
         content: Optional[Control] = None,
-        disabled_color: Optional[ColorValue] = None,
+        disabled_bgcolor: Optional[ColorValue] = None,
         opacity_on_click: OptionalNumber = None,
         min_size: OptionalNumber = None,
         padding: Optional[PaddingValue] = None,
@@ -93,7 +93,7 @@ class CupertinoFilledButton(CupertinoButton):
             #
             color="onPrimary",
             bgcolor="primary",
-            disabled_color=disabled_color,
+            disabled_bgcolor=disabled_bgcolor,
             text=text,
             icon=icon,
             icon_color=icon_color,

--- a/sdk/python/packages/flet/src/flet/core/dropdown.py
+++ b/sdk/python/packages/flet/src/flet/core/dropdown.py
@@ -63,8 +63,8 @@ class Option(Control):
         for item in deprecated_properties_list:
             if eval(item) is not None:
                 warnings.warn(
-                    f"{item} is deprecated since version 0.26.0 "
-                    f"and will be removed in version 0.29.0.",
+                    f"{item} is deprecated since version 0.27.0 "
+                    f"and will be removed in version 0.30.0.",
                     category=DeprecationWarning,
                     stacklevel=2,
                 )
@@ -152,7 +152,7 @@ class Option(Control):
 
 
 class DropdownOption(Option):
-    "Alias for Option"
+    """Alias for Option"""
 
 
 class Dropdown(FormFieldControl):
@@ -549,7 +549,7 @@ class Dropdown(FormFieldControl):
     def enable_search(self) -> bool:
         return self._get_attr("enableSearch", data_type="bool", def_value=True)
 
-    @enable_filter.setter
+    @enable_search.setter
     def enable_search(self, value: Optional[bool]):
         self._set_attr("enableSearch", value)
 

--- a/sdk/python/packages/flet/src/flet/core/expansion_tile.py
+++ b/sdk/python/packages/flet/src/flet/core/expansion_tile.py
@@ -21,7 +21,6 @@ from flet.core.types import (
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
-    ThemeVisualDensity,
     VisualDensity,
 )
 
@@ -68,7 +67,7 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
         enable_feedback: Optional[bool] = None,
         show_trailing_icon: Optional[bool] = None,
         min_tile_height: OptionalNumber = None,
-        visual_density: Union[None, ThemeVisualDensity, VisualDensity] = None,
+        visual_density: Optional[VisualDensity] = None,
         on_change: OptionalControlEventCallable = None,
         #
         # ConstrainedControl
@@ -319,13 +318,13 @@ class ExpansionTile(ConstrainedControl, AdaptiveControl):
 
     # visual_density
     @property
-    def visual_density(self) -> Union[None, ThemeVisualDensity, VisualDensity]:
+    def visual_density(self) -> Optional[VisualDensity]:
         return self.__visual_density
 
     @visual_density.setter
-    def visual_density(self, value: Union[None, ThemeVisualDensity, VisualDensity]):
+    def visual_density(self, value: Optional[VisualDensity]):
         self.__visual_density = value
-        self._set_enum_attr("visualDensity", value, (ThemeVisualDensity, VisualDensity))
+        self._set_enum_attr("visualDensity", value, VisualDensity)
 
     # maintain_state
     @property

--- a/sdk/python/packages/flet/src/flet/core/icon_button.py
+++ b/sdk/python/packages/flet/src/flet/core/icon_button.py
@@ -23,7 +23,6 @@ from flet.core.types import (
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
-    ThemeVisualDensity,
     UrlTarget,
     VisualDensity,
 )
@@ -92,7 +91,7 @@ class IconButton(ConstrainedControl, AdaptiveControl):
         url: Optional[str] = None,
         url_target: Optional[UrlTarget] = None,
         mouse_cursor: Optional[MouseCursor] = None,
-        visual_density: Union[None, ThemeVisualDensity, VisualDensity] = None,
+        visual_density: Optional[VisualDensity] = None,
         size_constraints: Optional[BoxConstraints] = None,
         on_click: OptionalControlEventCallable = None,
         on_focus: OptionalControlEventCallable = None,
@@ -409,13 +408,13 @@ class IconButton(ConstrainedControl, AdaptiveControl):
 
     # visual_density
     @property
-    def visual_density(self) -> Union[None, ThemeVisualDensity, VisualDensity]:
+    def visual_density(self) -> Optional[VisualDensity]:
         return self.__visual_density
 
     @visual_density.setter
-    def visual_density(self, value: Union[None, ThemeVisualDensity, VisualDensity]):
+    def visual_density(self, value: Optional[VisualDensity]):
         self.__visual_density = value
-        self._set_enum_attr("visualDensity", value, (ThemeVisualDensity, VisualDensity))
+        self._set_enum_attr("visualDensity", value, VisualDensity)
 
     # on_click
     @property

--- a/sdk/python/packages/flet/src/flet/core/list_tile.py
+++ b/sdk/python/packages/flet/src/flet/core/list_tile.py
@@ -20,7 +20,6 @@ from flet.core.types import (
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
-    ThemeVisualDensity,
     UrlTarget,
     VisualDensity,
 )
@@ -108,7 +107,7 @@ class ListTile(ConstrainedControl, AdaptiveControl):
         icon_color: Optional[ColorValue] = None,
         text_color: Optional[ColorValue] = None,
         shape: Optional[OutlinedBorder] = None,
-        visual_density: Union[None, ThemeVisualDensity, VisualDensity] = None,
+        visual_density: Optional[VisualDensity] = None,
         mouse_cursor: Optional[MouseCursor] = None,
         title_text_style: Optional[TextStyle] = None,
         subtitle_text_style: Optional[TextStyle] = None,
@@ -506,13 +505,13 @@ class ListTile(ConstrainedControl, AdaptiveControl):
 
     # visual_density
     @property
-    def visual_density(self) -> Union[None, ThemeVisualDensity, VisualDensity]:
+    def visual_density(self) -> Optional[VisualDensity]:
         return self.__visual_density
 
     @visual_density.setter
-    def visual_density(self, value: Union[None, ThemeVisualDensity, VisualDensity]):
+    def visual_density(self, value: Optional[VisualDensity]):
         self.__visual_density = value
-        self._set_enum_attr("visualDensity", value, (ThemeVisualDensity, VisualDensity))
+        self._set_enum_attr("visualDensity", value, VisualDensity)
 
     # shape
     @property

--- a/sdk/python/packages/flet/src/flet/core/markdown.py
+++ b/sdk/python/packages/flet/src/flet/core/markdown.py
@@ -291,7 +291,6 @@ class Markdown(ConstrainedControl):
         selectable: Optional[bool] = None,
         extension_set: Optional[MarkdownExtensionSet] = None,
         code_theme: Optional[Union[MarkdownCodeTheme, MarkdownCustomCodeTheme]] = None,
-        code_style: Optional[TextStyle] = None,
         auto_follow_links: Optional[bool] = None,
         shrink_wrap: Optional[bool] = None,
         fit_content: Optional[bool] = None,
@@ -379,7 +378,6 @@ class Markdown(ConstrainedControl):
         self.selectable = selectable
         self.extension_set = extension_set
         self.code_theme = code_theme
-        self.code_style = code_style
         self.auto_follow_links = auto_follow_links
         self.auto_follow_links_target = auto_follow_links_target
         self.on_tap_link = on_tap_link
@@ -397,7 +395,6 @@ class Markdown(ConstrainedControl):
 
     def before_update(self):
         super().before_update()
-        self._set_attr_json("codeStyle", self.__code_style)
         self._set_attr_json("codeStyleSheet", self.__code_style_sheet)
         self._set_attr_json("mdStyleSheet", self.__md_style_sheet)
         self._set_attr_json(
@@ -496,28 +493,6 @@ class Markdown(ConstrainedControl):
         self, value: Optional[Union[MarkdownCodeTheme, MarkdownCustomCodeTheme]]
     ):
         self.__code_theme = value
-
-    # code_style
-    @property
-    def code_style(self) -> Optional[TextStyle]:
-        warnings.warn(
-            f"code_style is deprecated since version 0.24.0 "
-            f"and will be removed in version 0.27.0. Use code_style_sheet.code_text_style instead.",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.__code_style
-
-    @code_style.setter
-    def code_style(self, value: Optional[TextStyle]):
-        self.__code_style = value
-        if value is not None:
-            warnings.warn(
-                f"code_style is deprecated since version 0.24.0 "
-                f"and will be removed in version 0.27.0. Use code_style_sheet.code_text_style instead.",
-                category=DeprecationWarning,
-                stacklevel=2,
-            )
 
     # auto_follow_links
     @property

--- a/sdk/python/packages/flet/src/flet/core/radio.py
+++ b/sdk/python/packages/flet/src/flet/core/radio.py
@@ -19,7 +19,6 @@ from flet.core.types import (
     ResponsiveNumber,
     RotateValue,
     ScaleValue,
-    ThemeVisualDensity,
     VisualDensity,
 )
 
@@ -73,7 +72,7 @@ class Radio(ConstrainedControl, AdaptiveControl):
         focus_color: Optional[ColorValue] = None,
         splash_radius: OptionalNumber = None,
         toggleable: Optional[bool] = None,
-        visual_density: Union[None, ThemeVisualDensity, VisualDensity] = None,
+        visual_density: Optional[VisualDensity] = None,
         mouse_cursor: Optional[MouseCursor] = None,
         on_focus: OptionalControlEventCallable = None,
         on_blur: OptionalControlEventCallable = None,
@@ -219,13 +218,13 @@ class Radio(ConstrainedControl, AdaptiveControl):
 
     # visual_density
     @property
-    def visual_density(self) -> Union[None, ThemeVisualDensity, VisualDensity]:
+    def visual_density(self) -> Optional[VisualDensity]:
         return self.__visual_density
 
     @visual_density.setter
-    def visual_density(self, value: Union[None, ThemeVisualDensity, VisualDensity]):
+    def visual_density(self, value: Optional[VisualDensity]):
         self.__visual_density = value
-        self._set_enum_attr("visualDensity", value, (ThemeVisualDensity, VisualDensity))
+        self._set_enum_attr("visualDensity", value, VisualDensity)
 
     # label
     @property

--- a/sdk/python/packages/flet/src/flet/core/theme.py
+++ b/sdk/python/packages/flet/src/flet/core/theme.py
@@ -33,7 +33,8 @@ from flet.core.types import (
     OffsetValue,
     OptionalNumber,
     PaddingValue,
-    ThemeVisualDensity,
+    StrokeCap,
+    TextAlign,
     VisualDensity,
 )
 from flet.utils.deprecated import deprecated_class, deprecated_property
@@ -232,7 +233,7 @@ class ElevatedButtonTheme:
     enabled_mouse_cursor: Optional[MouseCursor] = None
     shape: Optional[OutlinedBorder] = None
     text_style: Optional[TextStyle] = None
-    visual_density: Union[None, ThemeVisualDensity, VisualDensity] = None
+    visual_density: Optional[VisualDensity] = None
     border_side: Optional[BorderSide] = None
     animation_duration: Optional[DurationValue] = None
     alignment: Optional[Alignment] = None
@@ -273,7 +274,7 @@ class IconButtonTheme:
     disabled_mouse_cursor: Optional[MouseCursor] = None
     enabled_mouse_cursor: Optional[MouseCursor] = None
     shape: Optional[OutlinedBorder] = None
-    visual_density: Union[None, ThemeVisualDensity, VisualDensity] = None
+    visual_density: Optional[VisualDensity] = None
     border_side: Optional[BorderSide] = None
     animation_duration: Optional[DurationValue] = None
     alignment: Optional[Alignment] = None
@@ -363,6 +364,8 @@ class FloatingActionButtonTheme:
     extended_icon_label_spacing: OptionalNumber = None
     extended_size_constraints: Optional[BoxConstraints] = None
     size_constraints: Optional[BoxConstraints] = None
+    large_size_constraints: Optional[BoxConstraints] = None
+    small_size_constraints: Optional[BoxConstraints] = None
 
 
 @dataclass
@@ -395,6 +398,7 @@ class AppBarTheme:
     title_spacing: OptionalNumber = None
     scroll_elevation: OptionalNumber = None
     toolbar_height: OptionalNumber = None
+    actions_padding: Optional[PaddingValue] = None
 
 
 @dataclass
@@ -414,7 +418,7 @@ class RadioTheme:
     overlay_color: ControlStateValue[ColorValue] = None
     splash_radius: OptionalNumber = None
     height: OptionalNumber = None
-    visual_density: Union[None, ThemeVisualDensity, VisualDensity] = None
+    visual_density: Optional[VisualDensity] = None
     mouse_cursor: ControlStateValue[MouseCursor] = None
 
     def __post_init__(self):
@@ -433,7 +437,7 @@ class CheckboxTheme:
     fill_color: ControlStateValue[ColorValue] = None
     splash_radius: OptionalNumber = None
     border_side: Optional[BorderSide] = None
-    visual_density: Union[None, ThemeVisualDensity, VisualDensity] = None
+    visual_density: Optional[VisualDensity] = None
     shape: Optional[OutlinedBorder] = None
     mouse_cursor: ControlStateValue[MouseCursor] = None
 
@@ -470,6 +474,7 @@ class SwitchTheme:
     track_outline_width: ControlStateValue[OptionalNumber] = None
     splash_radius: OptionalNumber = None
     mouse_cursor: ControlStateValue[MouseCursor] = None
+    padding: Optional[PaddingValue] = None
 
     def __post_init__(self):
         if not isinstance(self.thumb_color, dict):
@@ -654,7 +659,7 @@ class ListTileTheme:
     enable_feedback: Optional[bool] = None
     dense: Optional[bool] = None
     shape: Optional[OutlinedBorder] = None
-    visual_density: Union[None, ThemeVisualDensity, VisualDensity] = None
+    visual_density: Optional[VisualDensity] = None
     content_padding: Optional[PaddingValue] = None
     min_vertical_padding: Optional[PaddingValue] = None
     horizontal_spacing: OptionalNumber = None
@@ -685,6 +690,7 @@ class TooltipTheme:
     margin: Optional[MarginValue] = None
     trigger_mode: Optional[TooltipTriggerMode] = None
     decoration: Optional[BoxDecoration] = None
+    text_align: Optional[TextAlign] = None
 
 
 @dataclass
@@ -724,10 +730,23 @@ class SliderTheme:
     track_height: OptionalNumber = None
     value_indicator_stroke_color: Optional[ColorValue] = None
     interaction: Optional[SliderInteraction] = None
+    padding: Optional[PaddingValue] = None
+    track_gap: OptionalNumber = None
+    thumb_size: ControlStateValue[Size] = None
+    year_2023: Optional[bool] = None
 
     def __post_init__(self):
         if not isinstance(self.mouse_cursor, dict):
             self.mouse_cursor = {ControlState.DEFAULT: self.mouse_cursor}
+        if not isinstance(self.thumb_size, dict):
+            self.thumb_size = {ControlState.DEFAULT: self.thumb_size}
+        if self.year_2023 is not None:
+            deprecated_property(
+                name="year_2023",
+                version="0.27.0",
+                delete_version=None,  # not known for now
+                reason="Set this flag to False to opt into the 2024 Slider appearance. In the future, this flag will default to False.",
+            )
 
 
 @dataclass
@@ -737,6 +756,25 @@ class ProgressIndicatorTheme:
     linear_track_color: Optional[ColorValue] = None
     refresh_bgcolor: Optional[ColorValue] = None
     linear_min_height: OptionalNumber = None
+    border_radius: Optional[BorderRadius] = None
+    track_gap: OptionalNumber = None
+    circular_track_padding: Optional[PaddingValue] = None
+    size_constraints: Optional[BoxConstraints] = None
+    stop_indicator_color: Optional[ColorValue] = None
+    stop_indicator_radius: OptionalNumber = None
+    stroke_align: OptionalNumber = None
+    stroke_cap: Optional[StrokeCap] = None
+    stroke_width: OptionalNumber = None
+    year_2023: Optional[bool] = None
+
+    def __post_init__(self):
+        if self.year_2023 is not None:
+            deprecated_property(
+                name="year_2023",
+                version="0.27.0",
+                delete_version=None,  # not known for now
+                reason="Set this flag to False to opt into the 2024 ProgressIndicator appearance. In the future, this flag will default to False.",
+            )
 
 
 @dataclass
@@ -758,6 +796,15 @@ class PopupMenuTheme:
     def __post_init__(self):
         if not isinstance(self.mouse_cursor, dict):
             self.mouse_cursor = {ControlState.DEFAULT: self.mouse_cursor}
+        if not isinstance(self.thumb_size, dict):
+            self.thumb_size = {ControlState.DEFAULT: self.thumb_size}
+        if self.year_2023 is not None:
+            deprecated_property(
+                name="year_2023",
+                version="0.27.0",
+                delete_version=None,  # not known for now
+                reason="Set this flag to False to opt into the 2024 Slider appearance. In the future, this flag will default to False.",
+            )
 
 
 @dataclass
@@ -808,6 +855,9 @@ class SearchViewTheme:
     border_side: Optional[BorderSide] = None
     size_constraints: Optional[BoxConstraints] = None
     header_height: OptionalNumber = None
+    padding: Optional[PaddingValue] = None
+    bar_padding: Optional[PaddingValue] = None
+    shrink_wrap: Optional[bool] = None
 
 
 @dataclass
@@ -820,6 +870,7 @@ class NavigationDrawerTheme:
     tile_height: OptionalNumber = None
     label_text_style: ControlStateValue[TextStyle] = None
     indicator_shape: Optional[OutlinedBorder] = None
+    indicator_size: Optional[Size] = None
 
     def __post_init__(self):
         if not isinstance(self.label_text_style, dict):
@@ -838,6 +889,7 @@ class NavigationBarTheme:
     label_text_style: ControlStateValue[TextStyle] = None
     indicator_shape: Optional[OutlinedBorder] = None
     label_behavior: Optional[NavigationBarLabelBehavior] = None
+    label_padding: Optional[PaddingValue] = None
 
     def __post_init__(self):
         if not isinstance(self.label_text_style, dict):
@@ -973,13 +1025,20 @@ class Theme:
     text_theme: Optional[TextTheme] = None
     time_picker_theme: Optional[TimePickerTheme] = None
     tooltip_theme: Optional[TooltipTheme] = None
-    visual_density: Union[VisualDensity, ThemeVisualDensity] = None
+    visual_density: Optional[VisualDensity] = None
 
     def __post_init__(self):
         if self.button_theme:
             deprecated_property(
                 "button_theme",
                 "Use elevated_button_theme, outlined_button_theme, text_button_theme, filled_button_theme or icon_button_theme instead.",
+                version="0.27.0",
+                delete_version="0.30.0",
+            )
+        if self.dialog_bgcolor:
+            deprecated_property(
+                "dialog_bgcolor",
+                "Use dialog_theme.bgcolor instead.",
                 version="0.27.0",
                 delete_version="0.30.0",
             )

--- a/sdk/python/packages/flet/src/flet/core/types.py
+++ b/sdk/python/packages/flet/src/flet/core/types.py
@@ -361,31 +361,6 @@ class StrokeJoin(Enum):
     BEVEL = "bevel"
 
 
-class ThemeVisualDensityDeprecated(EnumMeta):
-    def __getattribute__(self, item):
-        if item in [
-            "STANDARD",
-            "COMPACT",
-            "COMFORTABLE",
-            "ADAPTIVE_PLATFORM_DENSITY",
-        ]:
-            warn(
-                "ThemeVisualDensity enum is deprecated and will be removed in version 0.27.0. "
-                "Use VisualDensity enum instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        return EnumMeta.__getattribute__(self, item)
-
-
-class ThemeVisualDensity(Enum, metaclass=ThemeVisualDensityDeprecated):
-    STANDARD = "standard"
-    COMPACT = "compact"
-    COMFORTABLE = "comfortable"
-    ADAPTIVEPLATFORMDENSITY = "adaptivePlatformDensity"
-    ADAPTIVE_PLATFORM_DENSITY = "adaptivePlatformDensity"
-
-
 class VisualDensity(Enum):
     STANDARD = "standard"
     COMPACT = "compact"

--- a/sdk/python/packages/flet/src/flet/utils/deprecated.py
+++ b/sdk/python/packages/flet/src/flet/utils/deprecated.py
@@ -1,5 +1,6 @@
 import functools
 import warnings
+from typing import Optional
 
 
 def deprecated(reason: str, version: str, delete_version: str, is_method=True):
@@ -46,10 +47,12 @@ def deprecated_class(reason: str, version: str, delete_version: str):
     return decorator
 
 
-def deprecated_property(name: str, reason: str, version: str, delete_version: str):
+def deprecated_property(
+    name: str, reason: str, version: str, delete_version: Optional[str] = None
+):
     warnings.warn(
-        f"{name} property is deprecated since version {version} "
-        f"and will be removed in version {delete_version}. {reason}",
+        f"{name} property is deprecated since version {version}"
+        f"{' and will be removed in version ' + delete_version if delete_version else ''}. {reason}",
         category=DeprecationWarning,
         stacklevel=2,
     )

--- a/sdk/python/packages/flet/tests/test_container.py
+++ b/sdk/python/packages/flet/tests/test_container.py
@@ -1,5 +1,6 @@
-import flet as ft
 from flet.core.protocol import Command
+
+import flet as ft
 
 
 def test_instance_no_attrs_set():
@@ -20,7 +21,7 @@ def test_gradient():
     c = ft.Container(
         gradient=ft.LinearGradient(
             colors=[],
-            tile_mode="mirror",
+            tile_mode=ft.GradientTileMode.MIRROR,
         )
     )
     cmd = c._build_add_commands()
@@ -61,14 +62,6 @@ def test_blend_mode_enum():
     assert cmd[0].attrs["blendmode"] == "lighten"
 
 
-def test_blend_mode_str():
-    r = ft.Container(blend_mode="darken", bgcolor=ft.Colors.RED)
-    assert isinstance(r.blend_mode, str)
-    assert isinstance(r._get_attr("blendMode"), str)
-    cmd = r._build_add_commands()
-    assert cmd[0].attrs["blendmode"] == "darken"
-
-
 def test_clip_behavior_enum():
     r = ft.Container()
     assert r.clip_behavior is None
@@ -79,36 +72,24 @@ def test_clip_behavior_enum():
     assert r.clip_behavior == ft.ClipBehavior.ANTI_ALIAS
     assert r._get_attr("clipBehavior") == "antiAlias"
 
-    r = ft.Container(clip_behavior="none")
-    assert isinstance(r.clip_behavior, str)
+    r = ft.Container(clip_behavior=ft.ClipBehavior.NONE)
+    assert isinstance(r.clip_behavior, ft.ClipBehavior)
     assert r._get_attr("clipBehavior") == "none"
 
 
 def test_image_repeat_enum():
     r = ft.Container()
-    assert r.image_repeat is None
-    assert r._get_attr("imageRepeat") is None
+    assert r.image is None
 
-    r = ft.Container(image_repeat=ft.ImageRepeat.REPEAT)
-    assert isinstance(r.image_repeat, ft.ImageRepeat)
-    assert r.image_repeat == ft.ImageRepeat.REPEAT
-    assert r._get_attr("imageRepeat") == "repeat"
-
-    r = ft.Container(image_repeat="repeatX")
-    assert isinstance(r.image_repeat, str)
-    assert r._get_attr("imageRepeat") == "repeatX"
+    r = ft.Container(image=ft.DecorationImage(repeat=ft.ImageRepeat.REPEAT))
+    assert isinstance(r.image.repeat, ft.ImageRepeat)
+    assert r.image.repeat == ft.ImageRepeat.REPEAT
 
 
 def test_image_fit_enum():
     r = ft.Container()
-    assert r.image_fit is None
-    assert r._get_attr("imageFit") is None
+    assert r.image is None
 
-    r = ft.Container(image_fit=ft.ImageFit.FILL)
-    assert isinstance(r.image_fit, ft.ImageFit)
-    assert r.image_fit == ft.ImageFit.FILL
-    assert r._get_attr("imageFit") == "fill"
-
-    r = ft.Container(image_fit="none")
-    assert isinstance(r.image_fit, str)
-    assert r._get_attr("imageFit") == "none"
+    r = ft.Container(image=ft.DecorationImage(fit=ft.ImageFit.FILL))
+    assert isinstance(r.image.fit, ft.ImageFit)
+    assert r.image.fit == ft.ImageFit.FILL

--- a/sdk/python/packages/flet/tests/test_markdown.py
+++ b/sdk/python/packages/flet/tests/test_markdown.py
@@ -26,7 +26,3 @@ def test_extension_set_enum():
     assert isinstance(r.extension_set, ft.MarkdownExtensionSet)
     assert r.extension_set == ft.MarkdownExtensionSet.COMMON_MARK
     assert r._get_attr("extensionSet") == "commonMark"
-
-    r = ft.Markdown(extension_set="none")
-    assert isinstance(r.extension_set, str)
-    assert r._get_attr("extensionSet") == "none"


### PR DESCRIPTION
## Summary by Sourcery

This PR removes deprecated properties and enums that were marked for removal in version `0.27.0` of Flet. It also updates the `Theme` class to remove deprecated properties and references to `ThemeVisualDensity`, replacing them with `VisualDensity`.

Bug Fixes:
- Fixes an issue where `enable_filter` was incorrectly aliased to `enable_search` in the `Dropdown` control.

Enhancements:
- Updates the `Theme` class to remove deprecated properties and references to `ThemeVisualDensity`, replacing them with `VisualDensity`.

Chores:
- Removes deprecated `image_src`, `image_src_base64`, `image_repeat`, `image_fit`, and `image_opacity` properties from the `Container` control, advising users to use `Container.image` instead.
- Removes the deprecated `disabled_color` property from the `CupertinoButton` control, recommending the use of `disabled_bgcolor` instead.
- Removes the deprecated `code_style` property from the `Markdown` control, suggesting the use of `code_style_sheet.code_text_style` instead.