### PR TITLE
fix: child controls get updated when `is_isolated=True` in Parent control

### DIFF
--- a/sdk/python/packages/flet/src/flet/core/page.py
+++ b/sdk/python/packages/flet/src/flet/core/page.py
@@ -812,7 +812,11 @@ class Page(AdaptiveControl):
 
         for control in controls:
             control.build_update_commands(
-                self._index, commands, added_controls, removed_controls, control.is_isolated()
+                self._index,
+                commands,
+                added_controls,
+                removed_controls,
+                control.is_isolated(),
             )
         return commands, added_controls, removed_controls
 

--- a/sdk/python/packages/flet/src/flet/core/page.py
+++ b/sdk/python/packages/flet/src/flet/core/page.py
@@ -812,7 +812,7 @@ class Page(AdaptiveControl):
 
         for control in controls:
             control.build_update_commands(
-                self._index, commands, added_controls, removed_controls
+                self._index, commands, added_controls, removed_controls, control.is_isolated()
             )
         return commands, added_controls, removed_controls
 


### PR DESCRIPTION
Resolves #4920

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where the `isolated` property of a control was not being respected when building update commands, ensuring that isolated controls are now correctly processed.