### PR TITLE
Make `flet build` work in CI environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Flet changelog
 
+## 0.27.3
+
+* Fixes to make `flet build` work in CI environment ([#4993](https://github.com/flet-dev/flet/issues/4993))
+
 ## 0.27.2
 
 * Error on second flet build run "Because {app} depends on flet_{package} from path which doesn't exist" ([#4955](https://github.com/flet-dev/flet/issues/4955))

--- a/packages/flet/CHANGELOG.md
+++ b/packages/flet/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.27.3
+
+* Fixes to make `flet build` work in CI environment ([#4993](https://github.com/flet-dev/flet/issues/4993))
+
 # 0.27.2
 
 * Error on second flet build run "Because {app} depends on flet_{package} from path which doesn't exist" ([#4955](https://github.com/flet-dev/flet/issues/4955))

--- a/packages/flet/pubspec.yaml
+++ b/packages/flet/pubspec.yaml
@@ -2,7 +2,7 @@ name: flet
 description: Write entire Flutter app in Python or add server-driven UI experience into existing Flutter app.
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/flet/packages/flet
-version: 0.27.2
+version: 0.27.3
 
 # This package supports all platforms listed below.
 platforms:

--- a/sdk/python/packages/flet-cli/src/flet_cli/commands/build.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/commands/build.py
@@ -731,7 +731,7 @@ class Command(BaseCommand):
         return False
 
     def install_flutter(self):
-        self.status.update(
+        self.update_status(
             f"[bold blue]Installing Flutter {MINIMAL_FLUTTER_VERSION}..."
         )
         from flet_cli.utils.flutter import install_flutter
@@ -779,7 +779,7 @@ class Command(BaseCommand):
     def install_jdk(self):
         from flet_cli.utils.jdk import install_jdk
 
-        self.status.update(f"[bold blue]Installing JDK...")
+        self.update_status(f"[bold blue]Installing JDK...")
         jdk_dir = install_jdk(self.log_stdout, progress=self.progress)
         self.env["JAVA_HOME"] = jdk_dir
 
@@ -812,7 +812,7 @@ class Command(BaseCommand):
     def install_android_sdk(self):
         from flet_cli.utils.android_sdk import AndroidSDK
 
-        self.status.update(f"[bold blue]Installing Android SDK...")
+        self.update_status(f"[bold blue]Installing Android SDK...")
         self.env["ANDROID_HOME"] = AndroidSDK(
             self.env["JAVA_HOME"], self.log_stdout, progress=self.progress
         ).install()
@@ -1213,7 +1213,7 @@ class Command(BaseCommand):
             # create a new Flutter bootstrap project directory, if non-existent
             if not second_pass:
                 self.flutter_dir.mkdir(parents=True, exist_ok=True)
-                self.status.update(
+                self.update_status(
                     f'[bold blue]Creating Flutter bootstrap project from {template_url} with ref "{template_ref}"...'
                 )
 
@@ -1268,7 +1268,7 @@ class Command(BaseCommand):
             shutil.move(self.flutter_packages_temp_dir, self.flutter_packages_dir)
 
         if self.flutter_packages_dir.exists():
-            self.status.update(f"[bold blue]Registering Flutter user extensions...")
+            self.update_status(f"[bold blue]Registering Flutter user extensions...")
 
             for fp in os.listdir(self.flutter_packages_dir):
                 if (self.flutter_packages_dir / fp / "pubspec.yaml").exists():
@@ -1407,7 +1407,7 @@ class Command(BaseCommand):
         if hash.has_changed():
 
             if copy_ops:
-                self.status.update(f"[bold blue]Customizing app icons...")
+                self.update_status(f"[bold blue]Customizing app icons...")
                 for op in copy_ops:
                     if self.verbose > 0:
                         console.log(
@@ -1422,7 +1422,7 @@ class Command(BaseCommand):
             ]
             self.save_yaml(self.pubspec_path, updated_pubspec)
 
-            self.status.update(f"[bold blue]Generating app icons...")
+            self.update_status(f"[bold blue]Generating app icons...")
 
             # icons
             icons_result = self.run(
@@ -1638,7 +1638,7 @@ class Command(BaseCommand):
         if hash.has_changed():
 
             if copy_ops:
-                self.status.update(f"[bold blue]Customizing app splash images...")
+                self.update_status(f"[bold blue]Customizing app splash images...")
                 for op in copy_ops:
                     if self.verbose > 0:
                         console.log(
@@ -1652,7 +1652,7 @@ class Command(BaseCommand):
             self.save_yaml(self.pubspec_path, updated_pubspec)
 
             # splash screens
-            self.status.update(f"[bold blue]Generating splash screens...")
+            self.update_status(f"[bold blue]Generating splash screens...")
             splash_result = self.run(
                 [
                     self.dart_exe,
@@ -1696,7 +1696,7 @@ class Command(BaseCommand):
 
         hash = HashStamp(self.build_dir / ".hash" / "package")
 
-        self.status.update(f"[bold blue]Packaging Python app...")
+        self.update_status(f"[bold blue]Packaging Python app...")
         package_args = [
             self.dart_exe,
             "run",
@@ -1911,7 +1911,7 @@ class Command(BaseCommand):
         assert self.get_pyproject
         assert self.template_data
 
-        self.status.update(
+        self.update_status(
             f"[bold blue]Building [cyan]{self.platforms[self.options.target_platform]['status_text']}[/cyan]..."
         )
         # flutter build
@@ -2027,7 +2027,7 @@ class Command(BaseCommand):
         assert self.out_dir
         assert self.assets_path
 
-        self.status.update(
+        self.update_status(
             f"[bold blue]Copying build to [cyan]{self.rel_out_dir}[/cyan] directory...",
         )
         arch = platform.machine().lower()
@@ -2153,6 +2153,12 @@ class Command(BaseCommand):
         )
         if flutter_doctor.returncode == 0 and flutter_doctor.stdout:
             console.log(flutter_doctor.stdout, style=verbose1_style)
+
+    def update_status(self, status):
+        if self.no_rich_output:
+            console.log(status)
+        else:
+            self.status.update(status)
 
     def log_stdout(self, message):
         if self.verbose > 0:

--- a/sdk/python/packages/flet-cli/src/flet_cli/commands/build.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/commands/build.py
@@ -38,9 +38,15 @@ DEFAULT_TEMPLATE_URL = "gh:flet-dev/flet-build-template"
 
 MINIMAL_FLUTTER_VERSION = version.Version("3.27.4")
 
+no_rich_output = get_bool_env_var("FLET_CLI_NO_RICH_OUTPUT")
+
 error_style = Style(color="red", bold=True)
 warning_style = Style(color="yellow", bold=True)
-console = Console(log_path=False, theme=Theme({"log.message": "green bold"}))
+console = Console(
+    log_path=False,
+    theme=Theme({"log.message": "green bold"}),
+    force_terminal=not no_rich_output,
+)
 verbose1_style = Style(dim=True, bold=False)
 verbose2_style = Style(color="bright_black", bold=False)
 
@@ -79,7 +85,7 @@ class Command(BaseCommand):
         self.flutter_packages_temp_dir = None
         self.flutter_exe = None
         self.skip_flutter_doctor = get_bool_env_var("FLET_CLI_SKIP_FLUTTER_DOCTOR")
-        self.no_rich_output = get_bool_env_var("FLET_CLI_NO_RICH_OUTPUT")
+        self.no_rich_output = no_rich_output
         self.current_platform = platform.system()
         self.platforms = {
             "windows": {

--- a/sdk/python/packages/flet-cli/src/flet_cli/utils/android_sdk.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/utils/android_sdk.py
@@ -167,7 +167,7 @@ class AndroidSDK:
                 else [
                     "cmd.exe",
                     "/C",
-                    f'"{self.sdkmanager_exe(home_dir)}" "{package_name}"',
+                    f'{self.sdkmanager_exe(home_dir)} "{package_name}"',
                 ]
             ),
             env={"ANDROID_HOME": str(home_dir)},

--- a/sdk/python/packages/flet-cli/src/flet_cli/utils/android_sdk.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/utils/android_sdk.py
@@ -14,7 +14,11 @@ ANDROID_CMDLINE_TOOLS_VERSION = "12.0"
 MINIMAL_PACKAGES = [
     "cmdline-tools;latest",
     "platform-tools",
+    "platforms;android-33",
+    "platforms;android-34",
     "platforms;android-35",
+    "ndk;25.1.8937393",
+    "cmake;3.22.1",
     "build-tools;34.0.0",
 ]
 

--- a/sdk/python/packages/flet-cli/src/flet_cli/utils/android_sdk.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/utils/android_sdk.py
@@ -166,10 +166,12 @@ class AndroidSDK:
 
         p = self.run(
             (
-                ["sh" if platform.system() != "Windows" else "cmd.exe"]
-                + ["-c", f'yes | {self.sdkmanager_exe(home_dir)} "{package_name}"']
+                ["sh", "-c", f'yes | {self.sdkmanager_exe(home_dir)} "{package_name}"']
                 if platform.system() != "Windows"
-                else [f'/C"{self.sdkmanager_exe(home_dir)} {package_name}"']
+                else [
+                    "cmd.exe",
+                    f"/C\"'{self.sdkmanager_exe(home_dir)}' '{package_name}'\"",
+                ]
             ),
             env={"ANDROID_HOME": str(home_dir)},
             capture_output=False,
@@ -184,10 +186,9 @@ class AndroidSDK:
 
         p = self.run(
             (
-                ["sh" if platform.system() != "Windows" else "cmd.exe"]
-                + ["-c", f"yes | {self.sdkmanager_exe(home_dir)} --licenses"]
+                ["sh", "-c", f"yes | {self.sdkmanager_exe(home_dir)} --licenses"]
                 if platform.system() != "Windows"
-                else [f'/C"{self.sdkmanager_exe(home_dir)} --licenses"']
+                else ["cmd.exe", f"/C\"'{self.sdkmanager_exe(home_dir)}' --licenses\""]
             ),
             env={"ANDROID_HOME": str(home_dir)},
             capture_output=False,

--- a/sdk/python/packages/flet-cli/src/flet_cli/utils/android_sdk.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/utils/android_sdk.py
@@ -159,10 +159,19 @@ class AndroidSDK:
             return 0
 
         self.log(f'Installing Android SDK package "{package_name}"')
+
+        is_windows = platform.system() == "Windows"
+        args = ["sh" if not is_windows else "cmd.exe"]
+        if not is_windows:
+            args.extend(
+                ["-c", f'yes | {self.sdkmanager_exe(home_dir)} "{package_name}"']
+            )
+        else:
+            args.extend(f'/C"{self.sdkmanager_exe(home_dir)} {package_name}"')
+
         p = self.run(
-            [self.sdkmanager_exe(home_dir), package_name],
+            args,
             env={"ANDROID_HOME": str(home_dir)},
-            input="y\n" * 10,
             capture_output=False,
         )
         if p.returncode != 0:
@@ -172,13 +181,17 @@ class AndroidSDK:
 
     def _accept_licenses(self, home_dir: Path):
         self.log("Accepting Android SDK licenses")
+
+        is_windows = platform.system() == "Windows"
+        args = ["sh" if not is_windows else "cmd.exe"]
+        if not is_windows:
+            args.extend(["-c", f"yes | {self.sdkmanager_exe(home_dir)} --licenses"])
+        else:
+            args.extend(f'/C"{self.sdkmanager_exe(home_dir)} --licenses"')
+
         p = self.run(
-            [
-                self.sdkmanager_exe(home_dir),
-                "--licenses",
-            ],
+            args,
             env={"ANDROID_HOME": str(home_dir)},
-            input="y\n" * 20,
             capture_output=False,
         )
         if p.returncode != 0:

--- a/sdk/python/packages/flet-cli/src/flet_cli/utils/android_sdk.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/utils/android_sdk.py
@@ -164,11 +164,7 @@ class AndroidSDK:
             (
                 ["sh", "-c", f'yes | {self.sdkmanager_exe(home_dir)} "{package_name}"']
                 if platform.system() != "Windows"
-                else [
-                    "cmd.exe",
-                    "/C",
-                    f'{self.sdkmanager_exe(home_dir)} "{package_name}"',
-                ]
+                else ["cmd.exe", "/C", self.sdkmanager_exe(home_dir), package_name]
             ),
             env={"ANDROID_HOME": str(home_dir)},
             capture_output=False,
@@ -185,7 +181,7 @@ class AndroidSDK:
             (
                 ["sh", "-c", f"yes | {self.sdkmanager_exe(home_dir)} --licenses"]
                 if platform.system() != "Windows"
-                else ["cmd.exe", "/C", f'"{self.sdkmanager_exe(home_dir)}" --licenses']
+                else ["cmd.exe", "/C", self.sdkmanager_exe(home_dir), "--licenses"]
             ),
             env={"ANDROID_HOME": str(home_dir)},
             capture_output=False,

--- a/sdk/python/packages/flet-cli/src/flet_cli/utils/android_sdk.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/utils/android_sdk.py
@@ -14,11 +14,7 @@ ANDROID_CMDLINE_TOOLS_VERSION = "12.0"
 MINIMAL_PACKAGES = [
     "cmdline-tools;latest",
     "platform-tools",
-    "platforms;android-33",
-    "platforms;android-34",
     "platforms;android-35",
-    "ndk;25.1.8937393",
-    "cmake;3.22.1",
     "build-tools;34.0.0",
 ]
 
@@ -170,7 +166,8 @@ class AndroidSDK:
                 if platform.system() != "Windows"
                 else [
                     "cmd.exe",
-                    f'/C""{self.sdkmanager_exe(home_dir)}" "{package_name}""',
+                    "/C",
+                    f'"{self.sdkmanager_exe(home_dir)}" "{package_name}"',
                 ]
             ),
             env={"ANDROID_HOME": str(home_dir)},
@@ -188,7 +185,7 @@ class AndroidSDK:
             (
                 ["sh", "-c", f"yes | {self.sdkmanager_exe(home_dir)} --licenses"]
                 if platform.system() != "Windows"
-                else ["cmd.exe", f'/C""{self.sdkmanager_exe(home_dir)}" --licenses"']
+                else ["cmd.exe", "/C", f'"{self.sdkmanager_exe(home_dir)}" --licenses']
             ),
             env={"ANDROID_HOME": str(home_dir)},
             capture_output=False,

--- a/sdk/python/packages/flet-cli/src/flet_cli/utils/android_sdk.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/utils/android_sdk.py
@@ -164,7 +164,15 @@ class AndroidSDK:
             (
                 ["sh", "-c", f'yes | {self.sdkmanager_exe(home_dir)} "{package_name}"']
                 if platform.system() != "Windows"
-                else ["cmd.exe", "/C", self.sdkmanager_exe(home_dir), package_name]
+                else [
+                    "cmd.exe",
+                    "/C",
+                    "echo",
+                    "y",
+                    "|",
+                    self.sdkmanager_exe(home_dir),
+                    package_name,
+                ]
             ),
             env={"ANDROID_HOME": str(home_dir)},
             capture_output=False,
@@ -181,7 +189,15 @@ class AndroidSDK:
             (
                 ["sh", "-c", f"yes | {self.sdkmanager_exe(home_dir)} --licenses"]
                 if platform.system() != "Windows"
-                else ["cmd.exe", "/C", self.sdkmanager_exe(home_dir), "--licenses"]
+                else [
+                    "cmd.exe",
+                    "/C",
+                    "echo",
+                    "y",
+                    "|",
+                    self.sdkmanager_exe(home_dir),
+                    "--licenses",
+                ]
             ),
             env={"ANDROID_HOME": str(home_dir)},
             capture_output=False,

--- a/sdk/python/packages/flet-cli/src/flet_cli/utils/android_sdk.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/utils/android_sdk.py
@@ -164,17 +164,13 @@ class AndroidSDK:
 
         self.log(f'Installing Android SDK package "{package_name}"')
 
-        is_windows = platform.system() == "Windows"
-        args = ["sh" if not is_windows else "cmd.exe"]
-        if not is_windows:
-            args.extend(
-                ["-c", f'yes | {self.sdkmanager_exe(home_dir)} "{package_name}"']
-            )
-        else:
-            args.extend(f'/C"{self.sdkmanager_exe(home_dir)} {package_name}"')
-
         p = self.run(
-            args,
+            (
+                ["sh" if platform.system() != "Windows" else "cmd.exe"]
+                + ["-c", f'yes | {self.sdkmanager_exe(home_dir)} "{package_name}"']
+                if platform.system() != "Windows"
+                else [f'/C"{self.sdkmanager_exe(home_dir)} {package_name}"']
+            ),
             env={"ANDROID_HOME": str(home_dir)},
             capture_output=False,
         )
@@ -186,15 +182,13 @@ class AndroidSDK:
     def _accept_licenses(self, home_dir: Path):
         self.log("Accepting Android SDK licenses")
 
-        is_windows = platform.system() == "Windows"
-        args = ["sh" if not is_windows else "cmd.exe"]
-        if not is_windows:
-            args.extend(["-c", f"yes | {self.sdkmanager_exe(home_dir)} --licenses"])
-        else:
-            args.extend(f'/C"{self.sdkmanager_exe(home_dir)} --licenses"')
-
         p = self.run(
-            args,
+            (
+                ["sh" if platform.system() != "Windows" else "cmd.exe"]
+                + ["-c", f"yes | {self.sdkmanager_exe(home_dir)} --licenses"]
+                if platform.system() != "Windows"
+                else [f'/C"{self.sdkmanager_exe(home_dir)} --licenses"']
+            ),
             env={"ANDROID_HOME": str(home_dir)},
             capture_output=False,
         )

--- a/sdk/python/packages/flet-cli/src/flet_cli/utils/android_sdk.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/utils/android_sdk.py
@@ -170,7 +170,7 @@ class AndroidSDK:
                 if platform.system() != "Windows"
                 else [
                     "cmd.exe",
-                    f"/C\"'{self.sdkmanager_exe(home_dir)}' '{package_name}'\"",
+                    f'/C""{self.sdkmanager_exe(home_dir)}" "{package_name}""',
                 ]
             ),
             env={"ANDROID_HOME": str(home_dir)},
@@ -188,7 +188,7 @@ class AndroidSDK:
             (
                 ["sh", "-c", f"yes | {self.sdkmanager_exe(home_dir)} --licenses"]
                 if platform.system() != "Windows"
-                else ["cmd.exe", f"/C\"'{self.sdkmanager_exe(home_dir)}' --licenses\""]
+                else ["cmd.exe", f'/C""{self.sdkmanager_exe(home_dir)}" --licenses"']
             ),
             env={"ANDROID_HOME": str(home_dir)},
             capture_output=False,

--- a/sdk/python/packages/flet-cli/src/flet_cli/utils/android_sdk.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/utils/android_sdk.py
@@ -162,7 +162,11 @@ class AndroidSDK:
 
         p = self.run(
             (
-                ["sh", "-c", f'yes | {self.sdkmanager_exe(home_dir)} "{package_name}"']
+                [
+                    "sh",
+                    "-c",
+                    f'yes | "{self.sdkmanager_exe(home_dir)}" "{package_name}"',
+                ]
                 if platform.system() != "Windows"
                 else [
                     "cmd.exe",
@@ -187,7 +191,7 @@ class AndroidSDK:
 
         p = self.run(
             (
-                ["sh", "-c", f"yes | {self.sdkmanager_exe(home_dir)} --licenses"]
+                ["sh", "-c", f'yes | "{self.sdkmanager_exe(home_dir)}" --licenses']
                 if platform.system() != "Windows"
                 else [
                     "cmd.exe",

--- a/sdk/python/packages/flet-cli/src/flet_cli/utils/android_sdk.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/utils/android_sdk.py
@@ -220,7 +220,7 @@ class AndroidSDK:
             )
         return p.stdout
 
-    def run(self, args, env=None, cwd=None, input=None, capture_output=True):
+    def run(self, args, env=None, cwd=None, capture_output=True):
 
         self.log(f"Run subprocess: {args}")
 
@@ -235,7 +235,6 @@ class AndroidSDK:
             args,
             cwd if cwd else os.getcwd(),
             env=cmd_env,
-            input=input,
             capture_output=capture_output,
             log=self.log,
         )

--- a/sdk/python/packages/flet-cli/src/flet_cli/utils/processes.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/utils/processes.py
@@ -29,7 +29,7 @@ def run(
             cwd=cwd,
             capture_output=True,
             text=True,
-            encoding="utf8",
+            encoding="utf-8",
             env=cmd_env,
             errors="replace",
         )
@@ -41,7 +41,7 @@ def run(
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
-            encoding="utf8",
+            encoding="utf-8",
             env=cmd_env,
             errors="replace",
         )

--- a/sdk/python/packages/flet-cli/src/flet_cli/utils/processes.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/utils/processes.py
@@ -31,7 +31,7 @@ def run(
             text=True,
             encoding="utf8",
             env=cmd_env,
-            errors="replace"
+            errors="replace",
         )
     else:
         process = subprocess.Popen(
@@ -43,7 +43,7 @@ def run(
             text=True,
             encoding="utf8",
             env=cmd_env,
-            errors="replace"
+            errors="replace",
         )
 
         input_iterator = (
@@ -61,7 +61,7 @@ def run(
                     log(stdout_line.rstrip())
 
                 # Check if process is waiting for input
-                if process.poll() is None and process.stdin:
+                if input and process.poll() is None and process.stdin:
                     try:
                         next_input = next(input_iterator) + "\n"
                         process.stdin.write(next_input)

--- a/sdk/python/packages/flet-cli/src/flet_cli/utils/processes.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/utils/processes.py
@@ -8,9 +8,7 @@ if is_windows():
     from ctypes import windll
 
 
-def run(
-    args, cwd, env: Optional[dict] = None, input=None, capture_output=True, log=None
-):
+def run(args, cwd, env: Optional[dict] = None, capture_output=True, log=None):
     if is_windows():
         # Source: https://stackoverflow.com/a/77374899/1435891
         # Save the current console output code page and switch to 65001 (UTF-8)
@@ -46,12 +44,6 @@ def run(
             errors="replace",
         )
 
-        input_iterator = (
-            iter(input)
-            if isinstance(input, list)
-            else iter(input.split("\n")) if isinstance(input, str) else iter([])
-        )
-
         try:
             while True:
                 stdout_line = process.stdout.readline()
@@ -59,16 +51,6 @@ def run(
                 # Log or print lines if a log function is provided
                 if stdout_line and log:
                     log(stdout_line.rstrip())
-
-                # Check if process is waiting for input
-                if input and process.poll() is None and process.stdin:
-                    try:
-                        next_input = next(input_iterator) + "\n"
-                        process.stdin.write(next_input)
-                        process.stdin.flush()
-                    except StopIteration:
-                        # If no more input, close stdin to signal end
-                        process.stdin.close()
 
                 # Break when the process ends and buffers are empty
                 if not stdout_line and process.poll() is not None:


### PR DESCRIPTION
This PR fixes Android packages installation in non-interactive environment where StdIn is not available.

Additionally, the following environment variables must be set:

* `FLET_CLI_NO_RICH_OUTPUT: 1` - disables terminal in Rich console.
* `UV_NO_PROGRESS: 1` - disables animated progress in uv
* `PYTHONUTF8: 1` - forces UTF-8 for Python

## Summary by Sourcery

Bug Fixes:
- Fixes Android packages installation in non-interactive environments where StdIn is not available by piping 'yes' to the `sdkmanager` command to accept licenses and package installations.