### PR TITLE
Fix: do not remove `flutter-packages` on re-build if `dev_packages` configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Flet changelog
 
+## 0.27.4
+
+* Fix: do not remove `flutter-packages` on re-build if `dev_packages` configured.
+
 ## 0.27.3
 
 * Fixes to make `flet build` work in CI environment ([#4993](https://github.com/flet-dev/flet/issues/4993))

--- a/packages/flet/CHANGELOG.md
+++ b/packages/flet/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.27.4
+
+* Fix: do not remove `flutter-packages` on re-build if `dev_packages` configured.
+
 # 0.27.3
 
 * Fixes to make `flet build` work in CI environment ([#4993](https://github.com/flet-dev/flet/issues/4993))

--- a/packages/flet/pubspec.yaml
+++ b/packages/flet/pubspec.yaml
@@ -2,7 +2,7 @@ name: flet
 description: Write entire Flutter app in Python or add server-driven UI experience into existing Flutter app.
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/flet/packages/flet
-version: 0.27.3
+version: 0.27.4
 
 # This package supports all platforms listed below.
 platforms:


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevents the removal of the `flutter-packages` directory on re-builds when `dev_packages` are configured.