### PR TITLE
Remove deperecated method

### DIFF
--- a/sdk/python/packages/flet/src/flet/core/control.py
+++ b/sdk/python/packages/flet/src/flet/core/control.py
@@ -327,12 +327,6 @@ class Control:
         ), f"{self.__class__.__qualname__} Control must be added to the page first"
         self.__page.update(self)
 
-    async def update_async(self) -> None:
-        assert (
-            self.__page
-        ), f"{self.__class__.__qualname__} Control must be added to the page"
-        await self.__page.update_async(self)
-
     def clean(self) -> None:
         assert (
             self.__page


### PR DESCRIPTION
## Description

`page.update_async` has already been removed.
Therefore, `control.update_async` should also be deleted.
#4479

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I signed the CLA.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes
- [ ] I have made corresponding changes to the [documentation](https://github.com/flet-dev/website) (if applicable)

## Summary by Sourcery

Chores:
- Removes the deprecated `update_async` method from the `Control` class.