### PR TITLE
feat: `Dropdown.menu_width` property

### DIFF
--- a/packages/flet/lib/src/controls/dropdown.dart
+++ b/packages/flet/lib/src/controls/dropdown.dart
@@ -1,9 +1,21 @@
-import 'package:flet/flet.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 
+import '../flet_control_backend.dart';
+import '../models/control.dart';
+import '../models/control_view_model.dart';
+import '../utils/borders.dart';
+import '../utils/buttons.dart';
+import '../utils/colors.dart';
+import '../utils/edge_insets.dart';
 import '../utils/form_field.dart';
+import '../utils/icons.dart';
+import '../utils/numbers.dart';
+import '../utils/text.dart';
+import '../utils/textfield.dart';
+import 'create_control.dart';
+import 'flet_store_mixin.dart';
 import 'textfield.dart';
 
 class DropdownControl extends StatefulWidget {

--- a/packages/flet/lib/src/controls/dropdown.dart
+++ b/packages/flet/lib/src/controls/dropdown.dart
@@ -1,21 +1,9 @@
+import 'package:flet/flet.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 
-import '../flet_control_backend.dart';
-import '../models/control.dart';
-import '../models/control_view_model.dart';
-import '../utils/borders.dart';
-import '../utils/buttons.dart';
-import '../utils/colors.dart';
-import '../utils/edge_insets.dart';
 import '../utils/form_field.dart';
-import '../utils/icons.dart';
-import '../utils/numbers.dart';
-import '../utils/text.dart';
-import '../utils/textfield.dart';
-import 'create_control.dart';
-import 'flet_store_mixin.dart';
 import 'textfield.dart';
 
 class DropdownControl extends StatefulWidget {
@@ -109,6 +97,7 @@ class _DropdownControlState extends State<DropdownControl> with FletStoreMixin {
           widget.control.attrColor("focusedBorderColor", context);
       var borderWidth = widget.control.attrDouble("borderWidth");
       var focusedBorderWidth = widget.control.attrDouble("focusedBorderWidth");
+      var menuWidth = widget.control.attrDouble("menuWidth") ?? double.infinity;
 
       FormFieldInputBorder inputBorder = parseFormFieldInputBorder(
         widget.control.attrString("border"),
@@ -274,7 +263,7 @@ class _DropdownControlState extends State<DropdownControl> with FletStoreMixin {
         //requestFocusOnTap: editable,
         enableFilter: widget.control.attrBool("enableFilter", false)!,
         enableSearch: widget.control.attrBool("enableSearch", true)!,
-        menuHeight: widget.control.attrDouble("maxMenuHeight"),
+        menuHeight: widget.control.attrDouble("menuHeight"),
         label: labelCtrl.isNotEmpty
             ? createControl(widget.control, labelCtrl.first.id, disabled)
             : label != null
@@ -320,6 +309,7 @@ class _DropdownControlState extends State<DropdownControl> with FletStoreMixin {
           backgroundColor: parseWidgetStateColor(
               Theme.of(context), widget.control, "bgcolor"),
           elevation: parseWidgetStateDouble(widget.control, "elevation"),
+          fixedSize: WidgetStateProperty.all(Size.fromWidth(menuWidth)),
         ),
 
         inputDecorationTheme: inputDecorationTheme,

--- a/sdk/python/packages/flet/src/flet/core/dropdown.py
+++ b/sdk/python/packages/flet/src/flet/core/dropdown.py
@@ -173,9 +173,10 @@ class Dropdown(FormFieldControl):
         enable_filter: Optional[bool] = None,
         enable_search: Optional[bool] = None,
         editable: Optional[bool] = None,
-        max_menu_height: OptionalNumber = None,
+        max_menu_height: OptionalNumber = None,  # to be discontinued
+        menu_height: OptionalNumber = None,
+        menu_width: OptionalNumber = None,
         expanded_insets: PaddingValue = None,
-        menu_style: Optional[MenuStyle] = None,
         selected_suffix: Optional[Control] = None,
         input_filter: Optional[InputFilter] = None,
         capitalization: Optional[TextCapitalization] = None,
@@ -341,6 +342,7 @@ class Dropdown(FormFieldControl):
             "enable_feedback",
             "options_fill_horizontally",
             "padding",
+            "max_menu_height",
         ]
 
         for item in deprecated_properties_list:
@@ -358,9 +360,9 @@ class Dropdown(FormFieldControl):
         self.enable_filter = enable_filter
         self.enable_search = enable_search
         self.editable = editable
-        self.max_menu_height = max_menu_height
+        self.menu_height = menu_height
+        self.menu_width = menu_width
         self.expanded_insets = expanded_insets
-        self.menu_style = menu_style
         self.capitalization = capitalization
         self.label_content = label_content
         self.leading_icon = leading_icon
@@ -430,14 +432,23 @@ class Dropdown(FormFieldControl):
     def options(self, value: Optional[List[Option]]):
         self.__options = value if value is not None else []
 
-    # max_menu_height
+    # menu_height
     @property
-    def max_menu_height(self) -> OptionalNumber:
-        return self._get_attr("maxMenuHeight", data_type="float")
+    def menu_height(self) -> OptionalNumber:
+        return self._get_attr("menuHeight", data_type="float")
 
-    @max_menu_height.setter
-    def max_menu_height(self, value: OptionalNumber):
-        self._set_attr("maxMenuHeight", value)
+    @menu_height.setter
+    def menu_height(self, value: OptionalNumber):
+        self._set_attr("menuHeight", value)
+
+    # menu_width
+    @property
+    def menu_width(self) -> OptionalNumber:
+        return self._get_attr("menuWidth", data_type="float")
+
+    @menu_width.setter
+    def menu_width(self, value: OptionalNumber):
+        self._set_attr("menuWidth", value)
 
     # editable
     @property


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

<!-- If this PR fixes an open issue, please link to the issue here. Ex: Fixes #4562 -->
Fixes #5006 

## Test Code

```python
# Test code for the review of this PR
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I signed the CLA.
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass locally with my changes
- [ ] I have made corresponding changes to the [documentation](https://github.com/flet-dev/website) (if applicable)

## Screenshots 

<!-- Add screenshots here if applicable. -->

## Additional details

<!-- Any additional details to be known about this PR. -->

## Summary by Sourcery

Adds the `menu_width` property to the Dropdown control, allowing developers to specify the width of the dropdown menu.