### PR TITLE
fix: `Textfield` cursor position changes when modifying field content in `on_change`

### DIFF
--- a/packages/flet/lib/src/controls/textfield.dart
+++ b/packages/flet/lib/src/controls/textfield.dart
@@ -125,7 +125,8 @@ class _TextFieldControlState extends State<TextFieldControl>
         _value = value;
         _controller.value = TextEditingValue(
           text: value,
-          selection: TextSelection.collapsed(offset: value.length),
+          selection: TextSelection.collapsed(
+              offset: value.length), // preserve cursor position at the end
         );
       }
 

--- a/packages/flet/lib/src/controls/textfield.dart
+++ b/packages/flet/lib/src/controls/textfield.dart
@@ -84,7 +84,8 @@ class _TextFieldControlState extends State<TextFieldControl>
     setState(() {
       _focused = _shiftEnterfocusNode.hasFocus;
     });
-    widget.backend.triggerControlEvent(widget.control.id, _shiftEnterfocusNode.hasFocus ? "focus" : "blur");
+    widget.backend.triggerControlEvent(
+        widget.control.id, _shiftEnterfocusNode.hasFocus ? "focus" : "blur");
   }
 
   void _onFocusChange() {
@@ -122,7 +123,10 @@ class _TextFieldControlState extends State<TextFieldControl>
       String value = widget.control.attrs["value"] ?? "";
       if (_value != value) {
         _value = value;
-        _controller.text = value;
+        _controller.value = TextEditingValue(
+          text: value,
+          selection: TextSelection.collapsed(offset: value.length),
+        );
       }
 
       var prefixControls =


### PR DESCRIPTION
Resolves #5015

## Test code
```python
import flet as ft


class Test(ft.TextField):
    def __init__(self, page: ft.Page):
        super().__init__()
        self.page = page
        self.len_date = 0
        self.on_change = self.scadenza

    def scadenza(self, e):
        text = e.control.value
        if len(text) > self.len_date:
            if len(text) == 2:
                e.control.value = text + "-"
            if len(text) == 5:
                e.control.value = text + "-"
            if len(text) > 10:
                e.control.value = text[0:10]
        else:
            if len(text) == 5:
                e.control.value = text[0:4]
            if len(text) == 2:
                e.control.value = text[0:1]

        self.len_date = len(e.control.value)
        self.page.update()


def main(page: ft.Page):
    page.theme_mode = ft.ThemeMode.LIGHT
    test = Test(page)
    page.add(test)


ft.app(target=main)
``` 