### PR TITLE
Flet 0.27.5: app "loading" screens, Android splash customization 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.27.5
 
+* Added `FletApp.showAppStartupScreen` and `FletApp.appStartupScreenMessage` properties.
 * PBKDF2 iteration count increased to 600,000 ([#5023](https://github.com/flet-dev/flet/issues/5023))
 
 ## 0.27.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added `FletApp.showAppStartupScreen` and `FletApp.appStartupScreenMessage` properties.
 * Added `tool.flet.splash.icon_bgcolor` and `tool.flet.splash.icon_dark_bgcolor` settings for Android splash screen icon image.
 * Added `tool.flet.app.boot_screen` and `tool.flet.app.startup_screen` settings for customizing Flet app "loading" screens.
+* feat: `Dropdown.menu_width` property ([#5007](https://github.com/flet-dev/flet/issues/5007))
 * PBKDF2 iteration count increased to 600,000 ([#5023](https://github.com/flet-dev/flet/issues/5023))
 
 ## 0.27.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 0.27.5
 
 * Added `FletApp.showAppStartupScreen` and `FletApp.appStartupScreenMessage` properties.
+* Added `tool.flet.splash.icon_bgcolor` and `tool.flet.splash.icon_dark_bgcolor` settings for Android splash screen icon image.
+* Added `tool.flet.app.boot_screen` and `tool.flet.app.startup_screen` settings for customizing Flet app "loading" screens.
 * PBKDF2 iteration count increased to 600,000 ([#5023](https://github.com/flet-dev/flet/issues/5023))
 
 ## 0.27.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Flet changelog
 
+## 0.27.5
+
+* PBKDF2 iteration count increased to 600,000 ([#5023](https://github.com/flet-dev/flet/issues/5023))
+
 ## 0.27.4
 
 * Fix: do not remove `flutter-packages` on re-build if `dev_packages` configured.

--- a/packages/flet/CHANGELOG.md
+++ b/packages/flet/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.27.5
+
+* PBKDF2 iteration count increased to 600,000 ([#5023](https://github.com/flet-dev/flet/issues/5023))
+
 # 0.27.4
 
 * Fix: do not remove `flutter-packages` on re-build if `dev_packages` configured.

--- a/packages/flet/CHANGELOG.md
+++ b/packages/flet/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.27.5
 
+* Added `FletApp.showAppStartupScreen` and `FletApp.appStartupScreenMessage` properties.
 * PBKDF2 iteration count increased to 600,000 ([#5023](https://github.com/flet-dev/flet/issues/5023))
 
 # 0.27.4

--- a/packages/flet/CHANGELOG.md
+++ b/packages/flet/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 0.27.5
 
 * Added `FletApp.showAppStartupScreen` and `FletApp.appStartupScreenMessage` properties.
+* Added `tool.flet.splash.icon_bgcolor` and `tool.flet.splash.icon_dark_bgcolor` settings for Android splash screen icon image.
+* Added `tool.flet.app.boot_screen` and `tool.flet.app.startup_screen` settings for customizing Flet app "loading" screens.
 * PBKDF2 iteration count increased to 600,000 ([#5023](https://github.com/flet-dev/flet/issues/5023))
 
 # 0.27.4

--- a/packages/flet/CHANGELOG.md
+++ b/packages/flet/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Added `FletApp.showAppStartupScreen` and `FletApp.appStartupScreenMessage` properties.
 * Added `tool.flet.splash.icon_bgcolor` and `tool.flet.splash.icon_dark_bgcolor` settings for Android splash screen icon image.
 * Added `tool.flet.app.boot_screen` and `tool.flet.app.startup_screen` settings for customizing Flet app "loading" screens.
+* feat: `Dropdown.menu_width` property ([#5007](https://github.com/flet-dev/flet/issues/5007))
 * PBKDF2 iteration count increased to 600,000 ([#5023](https://github.com/flet-dev/flet/issues/5023))
 
 # 0.27.4

--- a/packages/flet/lib/src/controls/flet_app_control.dart
+++ b/packages/flet/lib/src/controls/flet_app_control.dart
@@ -27,6 +27,9 @@ class _FletAppControlState extends State<FletAppControl> {
     var url = widget.control.attrString("url", "")!;
     var reconnectIntervalMs = widget.control.attrInt("reconnectIntervalMs");
     var reconnectTimeoutMs = widget.control.attrInt("reconnectTimeoutMs");
+    var showAppStartupScreen = widget.control.attrBool("showAppStartupScreen");
+    var appStartupScreenMessage =
+        widget.control.attrString("appStartupScreenMessage");
 
     return constrainedControl(
         context,
@@ -34,6 +37,8 @@ class _FletAppControlState extends State<FletAppControl> {
           controlId: widget.control.id,
           reconnectIntervalMs: reconnectIntervalMs,
           reconnectTimeoutMs: reconnectTimeoutMs,
+          showAppStartupScreen: showAppStartupScreen,
+          appStartupScreenMessage: appStartupScreenMessage,
           pageUrl: url,
           assetsDir: "",
           errorsHandler: _errorsHandler,

--- a/packages/flet/lib/src/controls/page.dart
+++ b/packages/flet/lib/src/controls/page.dart
@@ -697,25 +697,29 @@ class _PageControlState extends State<PageControl> with FletStoreMixin {
         builder: (context, routesView) {
           debugPrint("_buildNavigator build");
 
-          var hideLoadingPage =
-              FletAppServices.of(context).hideLoadingPage ?? false;
+          var showAppStartupScreen =
+              FletAppServices.of(context).showAppStartupScreen ?? false;
+          var appStartupScreenMessage =
+              FletAppServices.of(context).appStartupScreenMessage ?? "";
 
           List<Page<dynamic>> pages = [];
           if (routesView.views.isEmpty) {
             pages.add(AnimatedTransitionPage(
                 fadeTransition: true,
                 duration: Duration.zero,
-                child: hideLoadingPage
-                    ? const Scaffold(
-                        body: PageMedia(),
-                      )
-                    : Stack(children: [
+                child: showAppStartupScreen
+                    ? Stack(children: [
                         const PageMedia(),
                         LoadingPage(
                           isLoading: routesView.isLoading,
-                          message: routesView.error,
+                          message: routesView.isLoading
+                              ? appStartupScreenMessage
+                              : routesView.error,
                         )
-                      ])));
+                      ])
+                    : const Scaffold(
+                        body: PageMedia(),
+                      )));
           } else {
             Widget? loadingPage;
             // offstage
@@ -739,10 +743,12 @@ class _PageControlState extends State<PageControl> with FletStoreMixin {
             }
 
             if ((routesView.isLoading || routesView.error != "") &&
-                !hideLoadingPage) {
+                showAppStartupScreen) {
               loadingPage = LoadingPage(
                 isLoading: routesView.isLoading,
-                message: routesView.error,
+                message: routesView.isLoading
+                    ? appStartupScreenMessage
+                    : routesView.error,
               );
             }
 

--- a/packages/flet/lib/src/flet_app.dart
+++ b/packages/flet/lib/src/flet_app.dart
@@ -8,7 +8,8 @@ import 'flet_app_services.dart';
 class FletApp extends StatefulWidget {
   final String pageUrl;
   final String assetsDir;
-  final bool? hideLoadingPage;
+  final bool? showAppStartupScreen;
+  final String? appStartupScreenMessage;
   final String? controlId;
   final String? title;
   final FletAppErrorsHandler? errorsHandler;
@@ -20,7 +21,8 @@ class FletApp extends StatefulWidget {
       {super.key,
       required this.pageUrl,
       required this.assetsDir,
-      this.hideLoadingPage,
+      this.showAppStartupScreen,
+      this.appStartupScreenMessage,
       this.controlId,
       this.title,
       this.errorsHandler,
@@ -48,7 +50,8 @@ class _FletAppState extends State<FletApp> {
       _pageUrl = widget.pageUrl;
       _appServices = FletAppServices(
           parentAppServices: FletAppServices.maybeOf(context),
-          hideLoadingPage: widget.hideLoadingPage,
+          showAppStartupScreen: widget.showAppStartupScreen,
+          appStartupScreenMessage: widget.appStartupScreenMessage,
           controlId: widget.controlId,
           reconnectIntervalMs: widget.reconnectIntervalMs,
           reconnectTimeoutMs: widget.reconnectTimeoutMs,

--- a/packages/flet/lib/src/flet_app_services.dart
+++ b/packages/flet/lib/src/flet_app_services.dart
@@ -11,7 +11,8 @@ import 'reducers.dart';
 
 class FletAppServices extends InheritedWidget {
   final FletAppServices? parentAppServices;
-  final bool? hideLoadingPage;
+  final bool? showAppStartupScreen;
+  final String? appStartupScreenMessage;
   final String? controlId;
   final int? reconnectIntervalMs;
   final int? reconnectTimeoutMs;
@@ -31,7 +32,8 @@ class FletAppServices extends InheritedWidget {
       required this.assetsDir,
       this.errorsHandler,
       this.parentAppServices,
-      this.hideLoadingPage,
+      this.showAppStartupScreen,
+      this.appStartupScreenMessage,
       this.controlId,
       this.reconnectIntervalMs,
       this.reconnectTimeoutMs,

--- a/packages/flet/lib/src/widgets/loading_page.dart
+++ b/packages/flet/lib/src/widgets/loading_page.dart
@@ -4,7 +4,8 @@ class LoadingPage extends StatelessWidget {
   final bool isLoading;
   final String message;
 
-  const LoadingPage({super.key, required this.isLoading, required this.message});
+  const LoadingPage(
+      {super.key, required this.isLoading, required this.message});
 
   @override
   Widget build(BuildContext context) {
@@ -24,7 +25,7 @@ class LoadingPage extends StatelessWidget {
       ];
       if (message != "") {
         children.addAll([
-          const SizedBox(height: 8),
+          const SizedBox(height: 10),
           Text(
             message,
             style: Theme.of(context).textTheme.bodySmall,

--- a/packages/flet/lib/src/widgets/loading_page.dart
+++ b/packages/flet/lib/src/widgets/loading_page.dart
@@ -64,7 +64,7 @@ class LoadingPage extends StatelessWidget {
       backgroundColor: Colors.transparent,
       body: Container(
           alignment: Alignment.center,
-          color: theme.colorScheme.surface.withOpacity(0.7),
+          color: theme.colorScheme.surface,
           child: child),
     );
   }

--- a/packages/flet/pubspec.yaml
+++ b/packages/flet/pubspec.yaml
@@ -2,7 +2,7 @@ name: flet
 description: Write entire Flutter app in Python or add server-driven UI experience into existing Flutter app.
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/flet/packages/flet
-version: 0.27.4
+version: 0.27.5
 
 # This package supports all platforms listed below.
 platforms:

--- a/sdk/python/packages/flet-cli/src/flet_cli/commands/build.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/commands/build.py
@@ -1141,6 +1141,7 @@ class Command(BaseCommand):
             "ios_team_id": ios_team_id,
             "options": {
                 "package_platform": self.package_platform,
+                "config_platform": self.config_platform,
                 "target_arch": (
                     target_arch
                     if isinstance(target_arch, list)
@@ -1784,8 +1785,10 @@ class Command(BaseCommand):
         # exclude
         exclude_list = ["build"]
 
-        app_exclude = self.options.exclude or self.get_pyproject(
-            "tool.flet.app.exclude"
+        app_exclude = (
+            self.options.exclude
+            or self.get_pyproject(f"tool.flet.{self.config_platform}.app.exclude")
+            or self.get_pyproject("tool.flet.app.exclude")
         )
         if app_exclude:
             exclude_list.extend(app_exclude)

--- a/sdk/python/packages/flet-cli/src/flet_cli/commands/build.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/commands/build.py
@@ -1587,20 +1587,43 @@ class Command(BaseCommand):
             )
 
         # splash colors
-        splash_color = self.options.splash_color or self.get_pyproject(
-            "tool.flet.splash.color"
+        splash_color = (
+            self.options.splash_color
+            or self.get_pyproject(f"tool.flet.{self.config_platform}.splash.color")
+            or self.get_pyproject("tool.flet.splash.color")
         )
         if splash_color:
             pubspec["flutter_native_splash"]["color"] = splash_color
             pubspec["flutter_native_splash"]["android_12"]["color"] = splash_color
-        splash_dark_color = self.options.splash_dark_color or self.get_pyproject(
-            "tool.flet.splash.dark_color"
+
+        splash_dark_color = (
+            self.options.splash_dark_color
+            or self.get_pyproject(f"tool.flet.{self.config_platform}.splash.dark_color")
+            or self.get_pyproject("tool.flet.splash.dark_color")
         )
         if splash_dark_color:
             pubspec["flutter_native_splash"]["color_dark"] = splash_dark_color
             pubspec["flutter_native_splash"]["android_12"][
                 "color_dark"
             ] = splash_dark_color
+
+        splash_icon_bgcolor = self.get_pyproject(
+            f"tool.flet.{self.config_platform}.splash.icon_bgcolor"
+        ) or self.get_pyproject("tool.flet.splash.icon_bgcolor")
+
+        if splash_icon_bgcolor:
+            pubspec["flutter_native_splash"]["android_12"][
+                "icon_background_color"
+            ] = splash_icon_bgcolor
+
+        splash_icon_dark_bgcolor = self.get_pyproject(
+            f"tool.flet.{self.config_platform}.splash.icon_dark_bgcolor"
+        ) or self.get_pyproject("tool.flet.splash.icon_dark_bgcolor")
+
+        if splash_icon_dark_bgcolor:
+            pubspec["flutter_native_splash"]["android_12"][
+                "icon_background_color_dark"
+            ] = splash_icon_dark_bgcolor
 
         # enable/disable splashes
         pubspec["flutter_native_splash"]["web"] = (

--- a/sdk/python/packages/flet/src/flet/core/flet_app.py
+++ b/sdk/python/packages/flet/src/flet/core/flet_app.py
@@ -20,6 +20,8 @@ class FletApp(ConstrainedControl):
         url: Optional[str] = None,
         reconnect_interval_ms: Optional[int] = None,
         reconnect_timeout_ms: Optional[int] = None,
+        show_app_startup_screen: Optional[bool] = None,
+        app_startup_screen_message: Optional[str] = None,
         on_error: OptionalControlEventCallable = None,
         #
         # ConstrainedControl
@@ -84,6 +86,8 @@ class FletApp(ConstrainedControl):
         self.url = url
         self.reconnect_interval_ms = reconnect_interval_ms
         self.reconnect_timeout_ms = reconnect_timeout_ms
+        self.show_app_startup_screen = show_app_startup_screen
+        self.app_startup_screen_message = app_startup_screen_message
         self.on_error = on_error
 
     def _get_control_name(self):
@@ -115,6 +119,24 @@ class FletApp(ConstrainedControl):
     @reconnect_timeout_ms.setter
     def reconnect_timeout_ms(self, value: Optional[int]):
         self._set_attr("reconnectTimeoutMs", value)
+
+    # show_app_startup_screen
+    @property
+    def show_app_startup_screen(self) -> bool:
+        return self._get_attr("showAppStartupScreen", data_type="bool", def_value=False)
+
+    @show_app_startup_screen.setter
+    def show_app_startup_screen(self, value: Optional[bool]):
+        self._set_attr("showAppStartupScreen", value)
+
+    # app_startup_screen_message
+    @property
+    def app_startup_screen_message(self) -> Optional[str]:
+        return self._get_attr("appStartupScreenMessage")
+
+    @app_startup_screen_message.setter
+    def app_startup_screen_message(self, value: Optional[str]):
+        self._set_attr("appStartupScreenMessage", value)
 
     # on_error
     @property

--- a/sdk/python/packages/flet/src/flet/security/__init__.py
+++ b/sdk/python/packages/flet/src/flet/security/__init__.py
@@ -17,7 +17,7 @@ def __generate_fernet_key(secret_key: str) -> bytes:
 
 
 def __generate_fernet_key_kdf(secret_key: str, salt: bytes) -> bytes:
-    kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), length=32, salt=salt, iterations=100000)
+    kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), length=32, salt=salt, iterations=600000)
     return base64.urlsafe_b64encode(kdf.derive(secret_key.encode("utf-8")))
 
 


### PR DESCRIPTION
## Summary by Sourcery

Adds the ability to customize the app loading screen and Android splash screen, and increases the PBKDF2 iteration count for enhanced security.

New Features:
- Introduces `FletApp.showAppStartupScreen` and `FletApp.appStartupScreenMessage` properties to customize the app loading screen.
- Adds `tool.flet.splash.icon_bgcolor` and `tool.flet.splash.icon_dark_bgcolor` settings for customizing the Android splash screen icon image background color.
- Adds `tool.flet.app.boot_screen` and `tool.flet.app.startup_screen` settings for customizing Flet app loading screens.
- Allows specifying platform-specific configuration for app excludes and splash screen settings in `pyproject.toml` using `tool.flet.{platform}.app.exclude` and `tool.flet.{platform}.splash.color`