### PR TITLE
fix: `Dropdown.expand` has no effect

### DIFF
--- a/packages/flet/lib/src/controls/dropdown.dart
+++ b/packages/flet/lib/src/controls/dropdown.dart
@@ -68,7 +68,6 @@ class _DropdownControlState extends State<DropdownControl> with FletStoreMixin {
     debugPrint("DropdownMenu build: ${widget.control.id}");
     return withControls(widget.control.childIds, (context, itemsView) {
       debugPrint("DropdownMenuFletControlState build: ${widget.control.id}");
-
       bool disabled = widget.control.isDisabled || widget.parentDisabled;
       bool editable = widget.control.attrBool("editable", false)!;
       bool autofocus = widget.control.attrBool("autofocus", false)!;
@@ -317,6 +316,8 @@ class _DropdownControlState extends State<DropdownControl> with FletStoreMixin {
         helperText: widget.control.attrString("helperText"),
         //inputFormatters: inputFormatters,
         //expandedInsets: parseEdgeInsets(widget.control, "expandedInsets"),
+        expandedInsets:
+            widget.control.attrInt("expand") != null ? EdgeInsets.zero : null,
         menuStyle: MenuStyle(
           backgroundColor: parseWidgetStateColor(
               Theme.of(context), widget.control, "bgcolor"),


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

<!-- If this PR fixes an open issue, please link to the issue here. Ex: Fixes #4562 -->
fixes #5040 

## Test Code

```python
# Test code for the review of this PR
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I signed the CLA.
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass locally with my changes
- [ ] I have made corresponding changes to the [documentation](https://github.com/flet-dev/website) (if applicable)

## Screenshots 

<!-- Add screenshots here if applicable. -->

## Additional details

<!-- Any additional details to be known about this PR. -->

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where Dropdown controls with expand set do not have zero insets.