### PR TITLE
feat: `FilePicker.upload()` supports modifying filenames before upload

### DIFF
--- a/packages/flet/lib/src/controls/file_picker.dart
+++ b/packages/flet/lib/src/controls/file_picker.dart
@@ -193,7 +193,7 @@ class _FilePickerControlState extends State<FilePickerControl>
             sendEvent();
           });
         }
-        // saveFile
+        // getDirectoryPath
         else if (state?.toLowerCase() == "getdirectorypath" && !kIsWeb) {
           FilePicker.platform
               .getDirectoryPath(
@@ -223,7 +223,7 @@ class _FilePickerControlState extends State<FilePickerControl>
   Future uploadFiles(String filesJson, FletServer server, Uri pageUri) async {
     var uj = json.decode(filesJson);
     var uploadFiles = (uj as List).map((u) => FilePickerUploadFile(
-        id: parseInt(u["id"], -1)!,
+        id: parseInt(u["id"], -1)!, // -1 = invalid
         name: u["name"],
         uploadUrl: u["upload_url"],
         method: u["method"]));

--- a/packages/flet/lib/src/controls/file_picker.dart
+++ b/packages/flet/lib/src/controls/file_picker.dart
@@ -236,7 +236,6 @@ class _FilePickerControlState extends State<FilePickerControl>
           _files!.firstWhereOrNull((f) => f.name == uf.name); // by name
 
       if (file != null) {
-        debugPrint("Uploading ${uf.name}");
         try {
           await uploadFile(
               file, server, getFullUploadUrl(pageUri, uf.uploadUrl), uf.method);
@@ -245,7 +244,7 @@ class _FilePickerControlState extends State<FilePickerControl>
           sendProgress(server, file.name, null, e.toString());
         }
       } else {
-        debugPrint("Error: File '${uf.name}' (ID: ${uf.id}) not found.");
+        debugPrint("Error: File '${uf.name}' (id: ${uf.id}) not found.");
       }
     }
   }

--- a/packages/flet/lib/src/controls/file_picker.dart
+++ b/packages/flet/lib/src/controls/file_picker.dart
@@ -10,6 +10,7 @@ import '../flet_app_services.dart';
 import '../flet_control_backend.dart';
 import '../flet_server.dart';
 import '../models/control.dart';
+import '../utils/numbers.dart';
 import '../utils/platform.dart';
 import '../utils/strings.dart';
 import 'flet_store_mixin.dart';
@@ -27,23 +28,32 @@ class FilePickerResultEvent {
 }
 
 class FilePickerFile {
+  final int id;
   final String name;
   final String? path;
   final int size;
 
-  FilePickerFile({required this.name, required this.path, required this.size});
+  FilePickerFile(
+      {required this.id,
+      required this.name,
+      required this.path,
+      required this.size});
 
   Map<String, dynamic> toJson() =>
-      <String, dynamic>{'name': name, 'path': path, 'size': size};
+      <String, dynamic>{'id': id, 'name': name, 'path': path, 'size': size};
 }
 
 class FilePickerUploadFile {
+  final int id;
   final String name;
   final String uploadUrl;
   final String method;
 
   FilePickerUploadFile(
-      {required this.name, required this.uploadUrl, required this.method});
+      {required this.id,
+      required this.name,
+      required this.uploadUrl,
+      required this.method});
 }
 
 class FilePickerUploadProgressEvent {
@@ -119,17 +129,23 @@ class _FilePickerControlState extends State<FilePickerControl>
             !isDesktopPlatform()) {
           resetDialogState();
         }
+
         widget.backend.triggerControlEvent(
-            widget.control.id,
-            "result",
-            json.encode(FilePickerResultEvent(
-                path: _path,
-                files: _files
-                    ?.map((f) => FilePickerFile(
-                        name: f.name,
-                        path: kIsWeb ? null : f.path,
-                        size: f.size))
-                    .toList())));
+          widget.control.id,
+          "result",
+          json.encode(FilePickerResultEvent(
+            path: _path,
+            files: _files?.asMap().entries.map((entry) {
+              PlatformFile f = entry.value;
+              return FilePickerFile(
+                id: entry.key, // use entry's index as id
+                name: f.name,
+                path: kIsWeb ? null : f.path,
+                size: f.size,
+              );
+            }).toList(),
+          )),
+        );
       }
 
       if (_state != state) {
@@ -154,7 +170,7 @@ class _FilePickerControlState extends State<FilePickerControl>
                   allowMultiple: allowMultiple,
                   withData: false,
                   withReadStream: true)
-              .then((result) {
+              .then((FilePickerResult? result) {
             debugPrint("pickFiles() completed");
             _files = result?.files;
             sendEvent();
@@ -207,17 +223,29 @@ class _FilePickerControlState extends State<FilePickerControl>
   Future uploadFiles(String filesJson, FletServer server, Uri pageUri) async {
     var uj = json.decode(filesJson);
     var uploadFiles = (uj as List).map((u) => FilePickerUploadFile(
-        name: u["name"], uploadUrl: u["upload_url"], method: u["method"]));
+        id: parseInt(u["id"], -1)!,
+        name: u["name"],
+        uploadUrl: u["upload_url"],
+        method: u["method"]));
+
     for (var uf in uploadFiles) {
-      var file = _files!.firstWhereOrNull((f) => f.name == uf.name);
+      var file = ((uf.id >= 0 && uf.id < _files!.length)
+              ? _files![uf.id]
+              : null) // by id
+          ??
+          _files!.firstWhereOrNull((f) => f.name == uf.name); // by name
+
       if (file != null) {
+        debugPrint("Uploading ${uf.name}");
         try {
           await uploadFile(
               file, server, getFullUploadUrl(pageUri, uf.uploadUrl), uf.method);
-          _files!.remove(file);
+          _files!.remove(file); // Remove the uploaded file
         } catch (e) {
           sendProgress(server, file.name, null, e.toString());
         }
+      } else {
+        debugPrint("Error: File '${uf.name}' (ID: ${uf.id}) not found.");
       }
     }
   }

--- a/sdk/python/packages/flet/src/flet/core/file_picker.py
+++ b/sdk/python/packages/flet/src/flet/core/file_picker.py
@@ -34,6 +34,7 @@ class FilePickerFileType(Enum):
 class FilePickerUploadFile:
     name: str
     upload_url: str
+    id: int = None
     method: str = field(default="PUT")
 
 
@@ -42,6 +43,7 @@ class FilePickerFile:
     name: str
     path: str
     size: int
+    id: int
 
 
 class FilePickerResultEvent(ControlEvent):


### PR DESCRIPTION
Resolves #5037

## Test Code
```python
import random

import flet as ft


def main(page: ft.Page):
    def pick_files_result(e: ft.FilePickerResultEvent):
        selected_files.value = (
            ", ".join(map(lambda f: f.name, e.files)) if e.files else "Cancelled!"
        )
        selected_files.update()

    def upload_files(e):
        upload_list = []
        if fp.result is not None and fp.result.files is not None:
            for f in fp.result.files:
                new_name = f"{random.randint(1, 1000)}_{f.name}"
                upload_list.append(
                    ft.FilePickerUploadFile(
                        name=new_name,
                        upload_url=page.get_upload_url(new_name, 600),
                        id=f.id,
                    )
                )
            fp.upload(upload_list)

    fp = ft.FilePicker(on_result=pick_files_result)
    page.overlay.append(fp)

    page.add(
        ft.Row(
            [
                ft.ElevatedButton("Upload", on_click=upload_files),
                ft.ElevatedButton(
                    "Pick files",
                    icon=ft.Icons.UPLOAD_FILE,
                    on_click=lambda _: fp.pick_files(allow_multiple=True),
                ),
                selected_files := ft.Text(),
            ]
        )
    )


ft.app(main, upload_dir="uploads")
```

## Summary by Sourcery

New Features:
- The `FilePicker.upload()` method now supports specifying a new name for each file in the upload list, allowing modification of filenames before upload.