### PR TITLE
fix: incorrect positioning of non-FAB controls assigned to `page.floating_action_button`

### DIFF
--- a/packages/flet/lib/src/controls/markdown.dart
+++ b/packages/flet/lib/src/controls/markdown.dart
@@ -10,7 +10,6 @@ import '../utils/box.dart';
 import '../utils/images.dart';
 import '../utils/launch_url.dart';
 import '../utils/markdown.dart';
-import '../utils/text.dart';
 import '../utils/uri.dart';
 import 'create_control.dart';
 import 'error.dart';

--- a/packages/flet/lib/src/controls/page.dart
+++ b/packages/flet/lib/src/controls/page.dart
@@ -898,7 +898,7 @@ class _ViewControlState extends State<ViewControl> with FletStoreMixin {
             } else if (ctrl.type == "bottomappbar") {
               bottomAppBar = ctrl;
               continue;
-            } else if (ctrl.type == "floatingactionbutton") {
+            } else if (ctrl.name == "fab") {
               fab = ctrl;
               continue;
             } else if (ctrl.type == "navigationbar" ||

--- a/packages/flet/lib/src/controls/page.dart
+++ b/packages/flet/lib/src/controls/page.dart
@@ -874,9 +874,7 @@ class _ViewControlState extends State<ViewControl> with FletStoreMixin {
               control.attrString("horizontalAlignment"),
               CrossAxisAlignment.start)!;
           final fabLocation = parseFloatingActionButtonLocation(
-              control,
-              "floatingActionButtonLocation",
-              FloatingActionButtonLocation.endFloat);
+              control, "floatingActionButtonLocation");
 
           Control? appBar;
           Control? cupertinoAppBar;
@@ -906,10 +904,10 @@ class _ViewControlState extends State<ViewControl> with FletStoreMixin {
               navBar = ctrl;
               continue;
             } else if (ctrl.type == "navigationdrawer" &&
-                ctrl.name == "start") {
+                ctrl.name == "drawer_start") {
               drawer = ctrl;
               continue;
-            } else if (ctrl.type == "navigationdrawer" && ctrl.name == "end") {
+            } else if (ctrl.type == "navigationdrawer" && ctrl.name == "drawer_end") {
               endDrawer = ctrl;
               continue;
             }

--- a/packages/flet/lib/src/utils/buttons.dart
+++ b/packages/flet/lib/src/utils/buttons.dart
@@ -95,8 +95,8 @@ ButtonStyle? buttonStyleFromJSON(ThemeData theme, Map<String, dynamic>? json,
   );
 }
 
-FloatingActionButtonLocation parseFloatingActionButtonLocation(
-    Control control, String propName, FloatingActionButtonLocation defValue) {
+FloatingActionButtonLocation? parseFloatingActionButtonLocation(
+    Control control, String propName, [FloatingActionButtonLocation? defValue]) {
   const Map<String, FloatingActionButtonLocation> fabLocations = {
     "centerdocked": FloatingActionButtonLocation.centerDocked,
     "centerfloat": FloatingActionButtonLocation.centerFloat,

--- a/sdk/python/packages/flet/src/flet/core/view.py
+++ b/sdk/python/packages/flet/src/flet/core/view.py
@@ -122,6 +122,7 @@ class View(ScrollableControl, AdaptiveControl):
         if self.__bottom_appbar:
             children.append(self.__bottom_appbar)
         if self.__fab:
+            self.__fab._set_attr_internal("n", "fab")
             children.append(self.__fab)
         if self.__navigation_bar:
             children.append(self.__navigation_bar)

--- a/sdk/python/packages/flet/src/flet/core/view.py
+++ b/sdk/python/packages/flet/src/flet/core/view.py
@@ -127,10 +127,10 @@ class View(ScrollableControl, AdaptiveControl):
         if self.__navigation_bar:
             children.append(self.__navigation_bar)
         if self.__drawer:
-            self.__drawer._set_attr_internal("n", "start")
+            self.__drawer._set_attr_internal("n", "drawer_start")
             children.append(self.__drawer)
         if self.__end_drawer:
-            self.__end_drawer._set_attr_internal("n", "end")
+            self.__end_drawer._set_attr_internal("n", "drawer_end")
             children.append(self.__end_drawer)
         return children + self.__controls
 


### PR DESCRIPTION
Resolves #4003

## Test Code

```python
import flet as ft


def main(page: ft.Page):
    page.floating_action_button = ft.Column(
        tight=True,
        controls=[
            ft.FloatingActionButton(icon=ft.icons.ADD),
            ft.FloatingActionButton(icon=ft.icons.REMOVE),
        ],
    )

    page.add(ft.Text("Simple Text"))


ft.app(main)
```
![image](https://github.com/user-attachments/assets/cfe7d535-e4d9-43c6-993f-741c7523185e)

## Summary by Sourcery

Fixes an issue where setting `page.floating_action_button` to a control other than a `FloatingActionButton` would result in it being displayed in the wrong position. The fix involves correctly identifying the FAB control and setting the correct names for drawer controls.

Bug Fixes:
- Fixes incorrect positioning of non-FAB controls assigned to `page.floating_action_button`.
- Fixes incorrect names for drawer controls.