### PR TITLE
`flet build`: allow dependencies with commas and other fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 0.27.6
 
 * Fix `flet build`: allow dependencies with commas ([#5033](https://github.com/flet-dev/flet/issues/5033))
+* Show app startup screen by default ([#5036](https://github.com/flet-dev/flet/issues/5036))
+* fix: `Textfield` cursor position changes when modifying field content in `on_change` ([#5019](https://github.com/flet-dev/flet/issues/5019))
+* Remove deperecated `Control.update_async()` method ([#5005](https://github.com/flet-dev/flet/issues/5005))
 
 ## 0.27.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Show app startup screen by default ([#5036](https://github.com/flet-dev/flet/issues/5036))
 * fix: `Textfield` cursor position changes when modifying field content in `on_change` ([#5019](https://github.com/flet-dev/flet/issues/5019))
 * Remove deperecated `Control.update_async()` method ([#5005](https://github.com/flet-dev/flet/issues/5005))
+* fix: incorrect positioning of non-FAB controls assigned to page.floating_action_button ([#5049](https://github.com/flet-dev/flet/issues/5049))
 
 ## 0.27.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Flet changelog
 
+## 0.27.6
+
+* Fix `flet build`: allow dependencies with commas ([#5033](https://github.com/flet-dev/flet/issues/5033))
+
 ## 0.27.5
 
 * Added `FletApp.showAppStartupScreen` and `FletApp.appStartupScreenMessage` properties.

--- a/packages/flet/CHANGELOG.md
+++ b/packages/flet/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Show app startup screen by default ([#5036](https://github.com/flet-dev/flet/issues/5036))
 * fix: `Textfield` cursor position changes when modifying field content in `on_change` ([#5019](https://github.com/flet-dev/flet/issues/5019))
 * Remove deperecated `Control.update_async()` method ([#5005](https://github.com/flet-dev/flet/issues/5005))
+* fix: incorrect positioning of non-FAB controls assigned to page.floating_action_button ([#5049](https://github.com/flet-dev/flet/issues/5049))
 
 # 0.27.5
 

--- a/packages/flet/CHANGELOG.md
+++ b/packages/flet/CHANGELOG.md
@@ -1,6 +1,9 @@
 # 0.27.6
 
 * Fix `flet build`: allow dependencies with commas ([#5033](https://github.com/flet-dev/flet/issues/5033))
+* Show app startup screen by default ([#5036](https://github.com/flet-dev/flet/issues/5036))
+* fix: `Textfield` cursor position changes when modifying field content in `on_change` ([#5019](https://github.com/flet-dev/flet/issues/5019))
+* Remove deperecated `Control.update_async()` method ([#5005](https://github.com/flet-dev/flet/issues/5005))
 
 # 0.27.5
 

--- a/packages/flet/CHANGELOG.md
+++ b/packages/flet/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.27.6
+
+* Fix `flet build`: allow dependencies with commas ([#5033](https://github.com/flet-dev/flet/issues/5033))
+
 # 0.27.5
 
 * Added `FletApp.showAppStartupScreen` and `FletApp.appStartupScreenMessage` properties.

--- a/packages/flet/pubspec.yaml
+++ b/packages/flet/pubspec.yaml
@@ -2,7 +2,7 @@ name: flet
 description: Write entire Flutter app in Python or add server-driven UI experience into existing Flutter app.
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/flet/packages/flet
-version: 0.27.5
+version: 0.27.6
 
 # This package supports all platforms listed below.
 platforms:

--- a/sdk/python/packages/flet-cli/src/flet_cli/commands/build.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/commands/build.py
@@ -1793,9 +1793,10 @@ class Command(BaseCommand):
             package_args.extend(["-r", f"flet=={flet_version}"])
 
         # site-packages variable
-        package_env["SERIOUS_PYTHON_SITE_PACKAGES"] = str(
-            self.build_dir / "site-packages"
-        )
+        if self.package_platform != "Pyodide":
+            package_env["SERIOUS_PYTHON_SITE_PACKAGES"] = str(
+                self.build_dir / "site-packages"
+            )
 
         # flutter-packages variable
         if self.flutter_packages_temp_dir.exists():
@@ -1953,9 +1954,10 @@ class Command(BaseCommand):
         build_env = {}
 
         # site-packages variable
-        build_env["SERIOUS_PYTHON_SITE_PACKAGES"] = str(
-            self.build_dir / "site-packages"
-        )
+        if self.package_platform != "Pyodide":
+            build_env["SERIOUS_PYTHON_SITE_PACKAGES"] = str(
+                self.build_dir / "site-packages"
+            )
 
         android_signing_key_store = (
             self.options.android_signing_key_store

--- a/sdk/python/packages/flet-cli/src/flet_cli/commands/build.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/commands/build.py
@@ -1740,7 +1740,6 @@ class Command(BaseCommand):
         package_env = {}
 
         # requirements
-        package_args.append("--requirements")
         requirements_txt = self.python_app_path.joinpath("requirements.txt")
 
         toml_dependencies = (
@@ -1774,7 +1773,8 @@ class Command(BaseCommand):
                 if dev_packages_configured:
                     toml_dependencies.append("--no-cache-dir")
 
-            package_args.append(",".join(toml_dependencies))
+            for toml_dep in toml_dependencies:
+                package_args.extend(["-r", toml_dep])
 
         elif requirements_txt.exists():
             if self.verbose > 1:
@@ -1785,12 +1785,12 @@ class Command(BaseCommand):
                         style=verbose2_style,
                     )
                     hash.update(reqs_txt_contents)
-            package_args.append(f"-r,{requirements_txt}")
+            package_args.extend(["-r", "-r", "-r", str(requirements_txt)])
         else:
             flet_version = (
                 flet.version.version if flet.version.version else update_version()
             )
-            package_args.append(f"flet=={flet_version}")
+            package_args.extend(["-r", f"flet=={flet_version}"])
 
         # site-packages variable
         package_env["SERIOUS_PYTHON_SITE_PACKAGES"] = str(


### PR DESCRIPTION
Fix #5033

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where `flet build` would fail when dependencies contained commas.