### PR TITLE
fix: `LineChartDataPoint.tooltip` not properly rendered

### DIFF
--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -263,7 +263,7 @@ packages:
       path: "../packages/flet"
       relative: true
     source: path
-    version: "0.27.5"
+    version: "0.27.6"
   flet_ads:
     dependency: "direct main"
     description:

--- a/packages/flet/lib/src/controls/linechart.dart
+++ b/packages/flet/lib/src/controls/linechart.dart
@@ -356,9 +356,7 @@ class _LineChartControlState extends State<LineChartControl> {
                       return touchedSpots.map((spot) {
                         var dp = viewModel.dataSeries[spot.barIndex]
                             .dataPoints[spot.spotIndex];
-                        var tooltip = dp.tooltip != null
-                            ? jsonDecode(dp.tooltip!)
-                            : dp.y.toString();
+                        var tooltip = dp.tooltip ?? dp.y.toString();
                         var tooltipStyle = parseTextStyle(
                             Theme.of(context), dp.control, "tooltipStyle");
                         tooltipStyle ??= const TextStyle();


### PR DESCRIPTION
Fixes #4967

## Test Code

```python
import flet as ft

def main(page: ft.Page):
    chart = ft.LineChart([ft.LineChartData(
        data_points=[
            ft.LineChartDataPoint(0, 0),
            ft.LineChartDataPoint(1, 0, tooltip="BUG"),
            ft.LineChartDataPoint(2, 0, tooltip=None),
        ],
        point=True,
    )])
    page.add(chart)
    page.add(ft.Text('HELLO WORLD'))

ft.app(main)
```

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where the tooltip for LineChartDataPoint was not rendering correctly.