### PR TITLE
fix: broken code in `Page.__on_authorize_async`

### DIFF
--- a/sdk/python/packages/flet/src/flet/core/page.py
+++ b/sdk/python/packages/flet/src/flet/core/page.py
@@ -1071,7 +1071,7 @@ class Page(AdaptiveControl):
                 self.close_in_app_web_view()
             else:
                 # activate desktop window
-                self.window_to_front()
+                self.window.to_front()
         login_evt = LoginEvent(
             error=d.get("error"),
             error_description=d.get("error_description"),


### PR DESCRIPTION
Fix https://github.com/flet-dev/examples/issues/200

## Summary by Sourcery

Bug Fixes:
- Corrected the method for bringing the window to the front during authorization process by using `self.window.to_front()` instead of `self.window_to_front()`