### PR TITLE
UTF-8 encoding for pyproject.toml

### DIFF
--- a/sdk/python/packages/flet-cli/src/flet_cli/utils/pyproject_toml.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/utils/pyproject_toml.py
@@ -8,7 +8,7 @@ def load_pyproject_toml(project_dir: Path):
     pyproject_toml: Optional[dict[str, Any]] = {}
     pyproject_toml_file = project_dir.joinpath("pyproject.toml")
     if pyproject_toml_file.exists():
-        with pyproject_toml_file.open("r") as f:
+        with pyproject_toml_file.open("r", encoding="utf-8") as f:
             pyproject_toml = toml.loads(f.read())
 
     def get_pyproject(setting: Optional[str] = None):


### PR DESCRIPTION
## Description
UTF-8 encoding for pyproject.toml when parsed with flet-cli

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

<!-- If this PR fixes an open issue, please link to the issue here. Ex: Fixes #4562 -->

## Test Code

```python
# Test code for the review of this PR
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I signed the CLA.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes
- [x] I have made corresponding changes to the [documentation](https://github.com/flet-dev/website) (if applicable)

## Summary by Sourcery

Bug Fixes:
- Ensure pyproject.toml files are read with UTF-8 encoding to prevent potential encoding-related parsing issues