### PR TITLE
fix: update icon type check to use get_args for python 3.9 compatibility

### DIFF
--- a/sdk/python/packages/flet/src/flet/core/tabs.py
+++ b/sdk/python/packages/flet/src/flet/core/tabs.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional, Union, get_args
 
 from flet.core.adaptive_control import AdaptiveControl
 from flet.core.animation import AnimationValue
@@ -73,7 +73,7 @@ class Tab(AdaptiveControl):
     def before_update(self):
         super().before_update()
         self._set_attr_json("iconMargin", self.__icon_margin)
-        if isinstance(self.__icon, IconValue):
+        if isinstance(self.__icon, get_args(IconValue)):
             self._set_enum_attr("icon", self.__icon, IconEnums)
 
     # text


### PR DESCRIPTION
## Description

Fixes issue #4758

Allows tabs to work with python 3.9+ 

## Test Code

```python
import flet as ft

def main(page: ft.Page):

    t = ft.Tabs(
        selected_index=1,
        animation_duration=300,
        tabs=[
            ft.Tab(
                text="Tab 1",
                content=ft.Container(
                    content=ft.Text("This is Tab 1"), alignment=ft.alignment.center
                ),
            ),
            ft.Tab(
                tab_content=ft.Icon(ft.Icons.SEARCH),
                content=ft.Text("This is Tab 2"),
            ),
            ft.Tab(
                text="Tab 3",
                icon=ft.Icons.SETTINGS,
                content=ft.Text("This is Tab 3"),
            ),
        ],
        expand=1,
    )

    page.add(t)

ft.app(main)
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I signed the CLA.
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass locally with my changes
- [ ] I have made corresponding changes to the [documentation](https://github.com/flet-dev/website) (if applicable)

## Screenshots 

<!-- Add screenshots here if applicable. -->

## Additional details

<!-- Any additional details to be known about this PR. -->
