### PR TITLE
Change the type alias from a class to a real rename

### DIFF
--- a/sdk/python/packages/flet/src/flet/core/dropdown.py
+++ b/sdk/python/packages/flet/src/flet/core/dropdown.py
@@ -151,10 +151,9 @@ class Option(Control):
             self._set_enum_attr("trailingIcon", value, IconEnums)
 
 
-class DropdownOption(Option):
-    """Alias for Option"""
-
-
+DropdownOption = Option
+    
+    
 class Dropdown(FormFieldControl):
     """
     A dropdown control that allows users to select a single option from a list of options.


### PR DESCRIPTION
## Description

Type hints would fail if the DropdownOptions were set from a function. With this the linter can work as expected with the type. 

## Test Code

```python
# Test code for the review of this PR
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I signed the CLA.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes
- [ ] I have made corresponding changes to the [documentation](https://github.com/flet-dev/website) (if applicable)

## Summary by Sourcery

Simplify the DropdownOption type alias by directly renaming it to Option to improve type hinting and linter compatibility

Bug Fixes:
- Fixed type hinting issues with DropdownOptions when set from a function

Enhancements:
- Simplified type alias definition for DropdownOption