### PR TITLE
support initialize Ref directly

### DIFF
--- a/sdk/python/packages/flet/src/flet/core/ref.py
+++ b/sdk/python/packages/flet/src/flet/core/ref.py
@@ -4,8 +4,8 @@ T = TypeVar("T")
 
 
 class Ref(Generic[T]):
-    def __init__(self):
-        self._current: T = None
+    def __init__(self, value: T = None):
+        self._current: T = value
 
     @property
     def current(self) -> T:


### PR DESCRIPTION
## Description
Support initialize `Ref` with value directly.

## Use case
In some scenarios, one control was created without known ref or the ref unavailable, but will be referenced in future.
It is more concise to direct initialize a ref with value rather than in a separate assignment statement.

Example:
```python
# factory method to create and return a flet control
def control_factory(control_type: str) -> ft.Control:
    match control_type:
        case pattern_1:
            return ft.TextField(...)  # no ref here
        case pattern_2:
            return ft.Switch(...)
        case pattern_3:
            return ft.Slider(...)
        case ...:
            ......

controls: list[ft.Ref] = []  # list of ref to use later
control: ft.Control = control_factory(...)  # <-- create control in factory, with no ref passing into factory
# control_ref = ft.Ref()
# control_ref.current = control
control_ref = ft.Ref(control)  # <-- initialize directly instead of passing ref into factory or assigning it in another statement
controls.append(control_ref)
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Summary by Sourcery

New Features:
- Support passing an initial value to Ref during construction instead of requiring a separate assignment.