### PR TITLE
Fix  `page.run_thread` does not receive kwargs

### DIFF
--- a/sdk/python/packages/flet/src/flet/core/page.py
+++ b/sdk/python/packages/flet/src/flet/core/page.py
@@ -901,9 +901,9 @@ class Page(AdaptiveControl):
         return future
 
     def __context_wrapper(self, handler: Callable[..., Any]) -> Wrapper:
-        def wrapper(*args):
+        def wrapper(*args,**kwargs):
             _session_page.set(self)
-            handler(*args)
+            handler(*args,**kwargs)
 
         return wrapper
 


### PR DESCRIPTION
## Description

Fixes #5318

## Test Code

```python
import flet as ft
import asyncio
import time
from datetime import datetime

async def main(page: ft.Page):
    page.add(
        text := ft.Text(f'{datetime.now()}'),
        text2 := ft.Text(f'{datetime.now()}')
    )
    async def update_time(name=None,*,end=''):
        while True:
            text.value = f'{name} is {datetime.now()} {end}'
            text.update()
            await asyncio.sleep(1)
            
    page.run_task(update_time,'Time',end='.')
    
    def update_time_sync(name=None,*,end=''):
        while True:
            text2.value = f'{name} is {datetime.now()} {end}'
            text2.update()
            time.sleep(1)
            
    page.run_thread(update_time_sync,'Time',end='.')

    
ft.app(target=main)
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Summary by Sourcery

Bug Fixes:
- Allow `page.run_thread` (and `page.run_task`) to receive keyword arguments by updating the internal wrapper to accept and forward **kwargs.