### PR TITLE
Update Ref to support initialization and assign optional value

### DIFF
--- a/sdk/python/packages/flet/src/flet/controls/ref.py
+++ b/sdk/python/packages/flet/src/flet/controls/ref.py
@@ -6,13 +6,13 @@ __all__ = ["Ref"]
 
 
 class Ref(Generic[T]):
-    def __init__(self):
-        self._current: Optional[weakref.ref[T]] = None
+    def __init__(self, value: T = None):
+        self._current: Optional[weakref.ref[T]] = weakref.ref(value) if value is not None else None
 
     @property
     def current(self) -> Optional[T]:
         return self._current() if self._current is not None else None
 
     @current.setter
-    def current(self, value: T):
-        self._current = weakref.ref(value)
+    def current(self, value: Optional[T]):
+        self._current = weakref.ref(value) if value is not None else None

--- a/sdk/python/packages/flet/src/flet/controls/ref.py
+++ b/sdk/python/packages/flet/src/flet/controls/ref.py
@@ -6,13 +6,13 @@ __all__ = ["Ref"]
 
 
 class Ref(Generic[T]):
-    def __init__(self, value: T = None):
-        self._current: Optional[weakref.ref[T]] = weakref.ref(value) if value is not None else None
+    def __init__(self, value: Optional[T] = None):
+        self.current = value
 
     @property
     def current(self) -> Optional[T]:
-        return self._current() if self._current is not None else None
+        return self._ref() if self._ref else None
 
     @current.setter
     def current(self, value: Optional[T]):
-        self._current = weakref.ref(value) if value is not None else None
+        self._ref = weakref.ref(value) if value is not None else None


### PR DESCRIPTION
## Description

Support initialize `Ref` with value directly, and allow re-assign `None` for intent clarify if needed.

## Example code

In some scenarios, one control was created without known ref or the ref unavailable, but will be referenced in future.
It is more concise to direct initialize a ref with value rather than in a separate assignment statement.

```python
# factory method to create and return a flet control
def control_factory(control_type: str) -> ft.Control:
    match control_type:
        case pattern_1:
            return ft.TextField(...)  # no ref here
        case pattern_2:
            return ft.Switch(...)
        case pattern_3:
            return ft.Slider(...)
        case ...:
            ......

controls: list[ft.Ref] = []  # list of ref to use later
control: ft.Control = control_factory(...)  # <-- create control in factory, with no ref passing into factory
# control_ref = ft.Ref()
# control_ref.current = control
control_ref = ft.Ref(control)  # <-- initialize directly instead of passing ref variable into factory or assigning it in another statement
controls.append(control_ref)

......
controls[i].current = None  # <-- later, no need to ref to control, but keep ref itself for some reason
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix: `TypeError: cannot create weak reference to 'NoneType' object` when passing None to setter.
- [x] New feature: initialize Ref

## Summary by Sourcery

Enable direct Ref initialization with a value and optional None assignment to explicitly clear the reference

New Features:
- Allow initializing Ref with an optional initial value via constructor
- Enable clearing a Ref by assigning None to its current property