### PR TITLE
New update remove_control_payload.dart

### DIFF
--- a/packages/flet/lib/src/protocol/remove_control_payload.dart
+++ b/packages/flet/lib/src/protocol/remove_control_payload.dart
@@ -4,5 +4,9 @@ class RemoveControlPayload {
   RemoveControlPayload({required this.ids});
 
   factory RemoveControlPayload.fromJson(Map<String, dynamic> json) =>
-      RemoveControlPayload(ids: List<String>.from(json['ids'] ?? []));
+      RemoveControlPayload(
+        ids: (json['ids'] as List<dynamic>? ?? [])
+            .whereType<String>()
+            .toList(),
+      );
 }


### PR DESCRIPTION
Ensure the control ids list contains only String values when deserializing from JSON, discarding null id values to prevent sporadic runtime errors of type:

[ERROR:flutter/runtime/dart_vm_initializer.cc(40)] Unhandled Exception: type 'Null' is not a subtype of type 'String'
                                                                                                    #0      new List.from (dart:core-patch/array_patch.dart:30)
                                                                                                    #1      new RemoveControlPayload.fromJson (package:flet/src/protocol/remove_control_payload.dart:7)
                                                                                                    #2      appReducer (package:flet/src/reducers.dart:376)
                                                                                                    #3      Store._createReduceAndNotify.<anonymous closure> (package:redux/src/store.dart:235)
                                                                                                    #4      Store.dispatch (package:redux/src/store.dart:267)
                                                                                                    #5      FletServer._onMessage (package:flet/src/flet_server.dart:265)
                                                                                                    #6      FletTcpSocketServerProtocol._onMessage (package:flet/src/flet_server_protocol_tcp_socket.dart:125)
                                                                                                    #7      FletTcpSocketServerProtocol.connect.<anonymous closure> (package:flet/src/flet_server_protocol_tcp_socket.dart:94)
                                                                                                    #8      _RootZone.runUnaryGuarded (dart:async/zone.dart:1778)
                                                                                                    #9      _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:381)
                                                                                                    #10     _BufferingStreamSubscription._add (dart:async/stream_impl.dart:312)
                                                                                                    #11     _SyncStreamControllerDispatch._sendData (dart:async/stream_controller.dart:798)
                                                                                                    #12     _StreamController._add (dart:async/stream_controller.dart:663)
                                                                                                    #13     _StreamController.add (dart:async/stream_controller.dart:618)
                                                                                                    #14     _Socket._onData (dart:io-patch/socket_patch.dart:2904)
                                                                                                    #15     _RootZone.runUnaryGuarded (dart:async/zone.dart:1778)
                                                                                                    #16     _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:381)
                                                                                                    #17     _BufferingStreamSubscription._add (dart:async/stream_impl.dart:312)
                                                                                                    #18     _SyncStreamControllerDispatch._sendData (dart:async/stream_controller.dart:798)
                                                                                                    #19     _StreamController._add (dart:async/stream_controller.dart:663)
                                                                                                    #20     _StreamController.add (dart:async/stream_controller.dart:618)
                                                                                                    #21     new _RawSocket.<anonymous closure> (dart:io-patch/socket_patch.dart:2323)
                                                                                                    #22     _NativeSocket.issueReadEvent.issue (dart:io-patch/socket_patch.dart:1646)
                                                                                                    #23     _microtaskLoop (dart:async/schedule_microtask.dart:40)
                                                                                                    #24     _startMicrotaskLoop (dart:async/schedule_microtask.dart:49)

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

<!-- If this PR fixes an open issue, please link to the issue here. Ex: Fixes #4562 -->

## Test Code

```python
# Test code for the review of this PR
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I signed the CLA.
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass locally with my changes
- [ ] I have made corresponding changes to the [documentation](https://github.com/flet-dev/website) (if applicable)

## Screenshots 

<!-- Add screenshots here if applicable. -->

## Additional details

<!-- Any additional details to be known about this PR. -->

## Summary by Sourcery

Bug Fixes:
- Ensure RemoveControlPayload.fromJson discards null or non-string ids to avoid type 'Null' errors