### PR TITLE
v1: Support `yield` in `main` handler

### DIFF
--- a/sdk/python/packages/flet-web/src/flet_web/fastapi/flet_app.py
+++ b/sdk/python/packages/flet-web/src/flet_web/fastapi/flet_app.py
@@ -1,4 +1,5 @@
 import asyncio
+import inspect
 import logging
 import os
 import traceback
@@ -143,6 +144,16 @@ class FletApp(Connection):
 
             if asyncio.iscoroutinefunction(self.__main):
                 await self.__main(self.__session.page)
+
+            elif inspect.isasyncgenfunction(self.__main):
+                async for _ in self.__main(self.__session.page):
+                    if UpdateBehavior.auto_update_enabled():
+                        await self.__session.auto_update(self.__session.page)
+
+            elif inspect.isgeneratorfunction(self.__main):
+                for _ in self.__main(self.__session.page):
+                    if UpdateBehavior.auto_update_enabled():
+                        await self.__session.auto_update(self.__session.page)
             else:
                 self.__main(self.__session.page)
 

--- a/sdk/python/packages/flet/src/flet/messaging/session.py
+++ b/sdk/python/packages/flet/src/flet/messaging/session.py
@@ -198,22 +198,22 @@ class Session:
                 elif inspect.isasyncgenfunction(event_handler):
                     if get_param_count(event_handler) == 0:
                         async for _ in event_handler():
-                            if UpdateBehavior.auto_update_enabled() and self.connection:
-                                await self.auto_update(self.index[control._i])
+                            if UpdateBehavior.auto_update_enabled():
+                                await self.auto_update(self.index.get(control._i))
                     else:
                         async for _ in event_handler(e):
-                            if UpdateBehavior.auto_update_enabled() and self.connection:
-                                await self.auto_update(self.index[control._i])
+                            if UpdateBehavior.auto_update_enabled():
+                                await self.auto_update(self.index.get(control._i))
 
                 elif inspect.isgeneratorfunction(event_handler):
                     if get_param_count(event_handler) == 0:
                         for _ in event_handler():
-                            if UpdateBehavior.auto_update_enabled() and self.connection:
-                                await self.auto_update(self.index[control._i])
+                            if UpdateBehavior.auto_update_enabled():
+                                await self.auto_update(self.index.get(control._i))
                     else:
                         for _ in event_handler(e):
-                            if UpdateBehavior.auto_update_enabled() and self.connection:
-                                await self.auto_update(self.index[control._i])
+                            if UpdateBehavior.auto_update_enabled():
+                                await self.auto_update(self.index.get(control._i))
 
                 elif callable(event_handler):
                     if get_param_count(event_handler) == 0:
@@ -221,8 +221,8 @@ class Session:
                     else:
                         event_handler(e)
 
-                if UpdateBehavior.auto_update_enabled() and self.connection:
-                    await self.auto_update(self.index[control._i])
+                if UpdateBehavior.auto_update_enabled():
+                    await self.auto_update(self.index.get(control._i))
 
         except Exception as ex:
             tb = traceback.format_exc()
@@ -251,9 +251,13 @@ class Session:
                 "is not registered."
             )
 
-    async def auto_update(self, control: BaseControl):
+    async def auto_update(self, control: BaseControl | None):
         while control:
-            if control.is_isolated() and not hasattr(control, "_frozen"):
+            if (
+                control.is_isolated()
+                and not hasattr(control, "_frozen")
+                and self.connection
+            ):
                 control.update()
                 break
             control = control.parent


### PR DESCRIPTION
Example:

```py
import asyncio

import flet as ft


async def main(page: ft.Page):
    page.controls.append(ft.Text("Line 1"))
    yield
    await asyncio.sleep(1)
    page.controls.append(ft.Text("Line 2"))
    yield
    await asyncio.sleep(1)
    page.controls.append(ft.Text("Line 3"))


ft.run(main)
```

## Summary by Sourcery

Support `yield` in the `main` handler by treating generator and async generator functions as valid entry points and automatically updating the UI after each yield.

New Features:
- Allow async generator and generator functions as valid `main` handlers with automatic page updates on each yield.

Enhancements:
- Extract common session-creation logic into `__get_on_session_created` for reuse across socket, web, and Pyodide servers.
- Extend event dispatch to support generator and async generator event handlers with auto-update after each iteration.
- Update `auto_update` to handle missing controls safely and enforce a valid connection before performing updates.