### PR TITLE
Prevent UnicodeDecodeError when relaying child stdout – decode with errors="replace"

### DIFF
--- a/sdk/python/packages/flet-cli/src/flet_cli/commands/run.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/commands/run.py
@@ -337,7 +337,7 @@ class Handler(FileSystemEventHandler):
 
     def print_output(self, p):
         while True:
-            line = p.stdout.readline()
+            line = p.stdout.readline().decode("utf-8", errors="replace")
             if not line:
                 break
             line = line.rstrip("\r\n")


### PR DESCRIPTION
`flet_cli/commands/run.py` crashed whenever the spawned process wrote non-UTF-8 bytes to stdout (e.g. OpenCV, C printf, binary progress bars).

What & Why:
Running flet run on long-lived apps that spawn helper processes (e.g. camera capture, FFmpeg, OpenCV) eventually blows up with

`UnicodeDecodeError: 'utf-8' codec can't decode byte 0x91 in position …`

because `print_output()` assumes `p.stdout.readline()` always returns valid UTF-8. Native libraries often write raw bytes directly to FD 1, bypassing Python’s I/O wrappers, so invalid sequences slip through and crash the thread.

Fix
`line = p.stdout.readline().decode("utf-8", errors="replace")`

errors="replace" converts any bad byte to �, guaranteeing the read never raises.

Behaviour is unchanged for valid UTF-8; the only difference is that the CLI now lives instead of dying.

## Summary by Sourcery

Bug Fixes:
- Decode stdout lines with errors="replace" to avoid crashes on non-UTF-8 bytes