### PR TITLE
Handle both binary and text mode

### DIFF
--- a/sdk/python/packages/flet-cli/src/flet_cli/commands/run.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/commands/run.py
@@ -337,7 +337,7 @@ class Handler(FileSystemEventHandler):
 
     def print_output(self, p):
         while True:
-            line = p.stdout.readline()
+            line = p.stdout.readline().decode("utf-8", errors="replace")
             if not line:
                 break
             line = line.rstrip("\r\n")

--- a/sdk/python/packages/flet-cli/src/flet_cli/commands/run.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/commands/run.py
@@ -337,10 +337,13 @@ class Handler(FileSystemEventHandler):
 
     def print_output(self, p):
         while True:
-            line = p.stdout.readline().decode("utf-8", errors="replace")
-            if not line:
+            raw = p.stdout.readline()
+            if not raw:
                 break
-            line = line.rstrip("\r\n")
+
+            line = raw.decode("utf-8", errors="replace") if isinstance(raw, bytes) else raw
+            line = line.rstrip("\r\n")            
+
             if line.startswith(self.page_url_prefix):
                 if not self.page_url:
                     self.page_url = line[len(self.page_url_prefix) + 1 :]


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

<!-- If this PR fixes an open issue, please link to the issue here. Ex: Fixes #4562 -->

## Test Code

```python
# Test code for the review of this PR
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I signed the CLA.
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass locally with my changes
- [ ] I have made corresponding changes to the [documentation](https://github.com/flet-dev/website) (if applicable)

## Screenshots 

<!-- Add screenshots here if applicable. -->

## Additional details

<!-- Any additional details to be known about this PR. -->

## Summary by Sourcery

Enhance the run command’s output handling to correctly process both binary and text streams from subprocess stdout.

Enhancements:
- Decode binary stdout using UTF-8 with replacement on errors and handle text lines uniformly.
- Normalize line endings by stripping '\r\n' after decoding or reading text.