### PR TITLE
v1: replace `:::note` by `Note:` for mkdocs

### DIFF
--- a/packages/flet/lib/src/controls/canvas.dart
+++ b/packages/flet/lib/src/controls/canvas.dart
@@ -266,7 +266,7 @@ class FletCustomPainter extends CustomPainter {
       return path;
     }
     for (var elem in (j as List)) {
-      var type = elem["type"];
+      var type = elem["_type"];
       if (type == "moveto") {
         path.moveTo(parseDouble(elem["x"], 0)!, parseDouble(elem["y"], 0)!);
       } else if (type == "lineto") {

--- a/packages/flet/lib/src/utils/borders.dart
+++ b/packages/flet/lib/src/utils/borders.dart
@@ -77,7 +77,8 @@ OutlinedBorder? parseOutlinedBorder(dynamic value, ThemeData? theme,
   var borderSide =
       parseBorderSide(value["side"], theme, defaultValue: defaultBorderSide)!;
   var borderRadius = parseBorderRadius(value["radius"], defaultBorderRadius)!;
-  String type = value["type"];
+
+  var type = value["_type"];
   switch (type.toLowerCase()) {
     case "roundedrectangle":
       return RoundedRectangleBorder(

--- a/packages/flet/lib/src/utils/drawing.dart
+++ b/packages/flet/lib/src/utils/drawing.dart
@@ -52,7 +52,7 @@ ui.Gradient? parsePaintGradient(Map<dynamic, dynamic>? value, ThemeData? theme,
     [ui.Gradient? defaultValue]) {
   if (value == null) return defaultValue;
 
-  String type = value["type"];
+  var type = value["_type"];
   var colorStops = parseGradientStops(value["color_stops"]);
   var colors = parseColors(value["colors"], theme);
   var tileMode = parseTileMode(value["tile_mode"], TileMode.clamp)!;

--- a/packages/flet/lib/src/utils/gradient.dart
+++ b/packages/flet/lib/src/utils/gradient.dart
@@ -8,10 +8,11 @@ import 'alignment.dart';
 import 'colors.dart';
 import 'numbers.dart';
 
-Gradient? parseGradient(dynamic value, ThemeData theme) {
-  if (value == null) return null;
+Gradient? parseGradient(dynamic value, ThemeData theme,
+    [Gradient? defaultValue]) {
+  if (value == null) return defaultValue;
 
-  String type = value["type"];
+  var type = value["_type"];
   var colors = parseColors(value["colors"], theme);
   var stops = parseGradientStops(value["stops"]);
   var rotation = parseRotation(value["rotation"]);
@@ -43,7 +44,7 @@ Gradient? parseGradient(dynamic value, ThemeData theme) {
         tileMode: parseTileMode(value["tile_mode"], TileMode.clamp)!,
         transform: rotation);
   }
-  return null;
+  return defaultValue;
 }
 
 List<Color> parseColors(dynamic value, ThemeData? theme) {

--- a/packages/flet/lib/src/utils/keys.dart
+++ b/packages/flet/lib/src/utils/keys.dart
@@ -34,7 +34,7 @@ ControlKey? parseKey(dynamic value) {
   if (value == null) return null;
 
   if (value is Map) {
-    String type = value["type"];
+    var type = value["_type"];
     if (type == "value") {
       return ControlValueKey(value["value"]);
     } else if (type == "scroll") {

--- a/sdk/python/packages/flet/src/flet/controls/buttons.py
+++ b/sdk/python/packages/flet/src/flet/controls/buttons.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 
 from flet.controls.alignment import OptionalAlignment
@@ -40,7 +40,8 @@ class OutlinedBorder:
     """
     The border outline's color and weight.
     """
-    type: str = ""
+
+    _type: Optional[str] = field(init=False, repr=False, compare=False, default=None)
 
 
 @dataclass
@@ -50,7 +51,7 @@ class StadiumBorder(OutlinedBorder):
     """
 
     def __post_init__(self):
-        self.type = "stadium"
+        self._type = "stadium"
 
 
 @dataclass
@@ -66,7 +67,7 @@ class RoundedRectangleBorder(OutlinedBorder):
     """
 
     def __post_init__(self):
-        self.type = "roundedRectangle"
+        self._type = "roundedRectangle"
 
 
 @dataclass
@@ -78,7 +79,7 @@ class CircleBorder(OutlinedBorder):
     eccentricity: Number = 0.0
 
     def __post_init__(self):
-        self.type = "circle"
+        self._type = "circle"
 
 
 @dataclass
@@ -94,7 +95,7 @@ class BeveledRectangleBorder(OutlinedBorder):
     """
 
     def __post_init__(self):
-        self.type = "beveledRectangle"
+        self._type = "beveledRectangle"
 
 
 @dataclass
@@ -110,7 +111,7 @@ class ContinuousRectangleBorder(OutlinedBorder):
     """
 
     def __post_init__(self):
-        self.type = "continuousRectangle"
+        self._type = "continuousRectangle"
 
 
 @dataclass

--- a/sdk/python/packages/flet/src/flet/controls/core/canvas/path.py
+++ b/sdk/python/packages/flet/src/flet/controls/core/canvas/path.py
@@ -19,37 +19,42 @@ class Path(Shape):
 
     @dataclass(kw_only=True)
     class PathElement:
-        type: str = ""
+        _type: Optional[str] = field(
+            init=False, repr=False, compare=False, default=None
+        )
 
     @dataclass
     class MoveTo(PathElement):
         """
         Starts a new sub-path at the given point (`x`,`y`).
         """
+
         x: float
         y: float
 
         def __post_init__(self):
-            self.type = "moveto"
+            self._type = "moveto"
 
     @dataclass
     class LineTo(PathElement):
         """
-        Adds a straight line segment from the current point to the given point 
+        Adds a straight line segment from the current point to the given point
         (`x`,`y`).
         """
+
         x: float
         y: float
 
         def __post_init__(self):
-            self.type = "lineto"
+            self._type = "lineto"
 
     @dataclass
     class QuadraticTo(PathElement):
         """
-        Adds a bezier segment that curves from the current point to the given point 
+        Adds a bezier segment that curves from the current point to the given point
         (`x`,`y`), using the control points (`cp1x`,`cp1y`) and the weight `w`.
         """
+
         cp1x: float
         cp1y: float
         x: float
@@ -62,14 +67,15 @@ class Path(Shape):
         """
 
         def __post_init__(self):
-            self.type = "conicto"
+            self._type = "conicto"
 
     @dataclass
     class CubicTo(PathElement):
         """
-        Adds a cubic bezier segment that curves from the current point to the given 
+        Adds a cubic bezier segment that curves from the current point to the given
         point (`x`,`y`), using the control points (`cp1x`,`cp1y`) and (`cp2x`,`cp2y`).
         """
+
         cp1x: float
         cp1y: float
         cp2x: float
@@ -78,31 +84,33 @@ class Path(Shape):
         y: float
 
         def __post_init__(self):
-            self.type = "cubicto"
+            self._type = "cubicto"
 
     @dataclass
     class SubPath(PathElement):
         """
         Adds the sub-path described by `elements` to the given point (`x`,`y`).
         """
+
         elements: list["Path.PathElement"]
         x: float
         y: float
 
         def __post_init__(self):
-            self.type = "subpath"
+            self._type = "subpath"
 
     @dataclass
     class Arc(PathElement):
         """
-        Adds a new sub-path with one arc segment that consists of the arc that follows 
-        the edge of the oval bounded by the given rectangle with top left corner at `x` 
-        and `y` and dimensions `width` and `height`, from `start_angle` radians around 
-        the oval up to `start_angle` + `sweep_angle` radians around the oval, with zero 
-        radians being the point on the right hand side of the oval that crosses the 
-        horizontal line that intersects the center of the rectangle and with positive 
+        Adds a new sub-path with one arc segment that consists of the arc that follows
+        the edge of the oval bounded by the given rectangle with top left corner at `x`
+        and `y` and dimensions `width` and `height`, from `start_angle` radians around
+        the oval up to `start_angle` + `sweep_angle` radians around the oval, with zero
+        radians being the point on the right hand side of the oval that crosses the
+        horizontal line that intersects the center of the rectangle and with positive
         angles going clockwise around the oval.
         """
+
         x: float
         """
         Top-left corner `x` of the rectangle bounding the arc.
@@ -129,23 +137,24 @@ class Path(Shape):
         """
 
         def __post_init__(self):
-            self.type = "arc"
+            self._type = "arc"
 
     @dataclass
     class ArcTo(PathElement):
         """
-        Appends up to four conic curves weighted to describe an oval of `radius` and 
+        Appends up to four conic curves weighted to describe an oval of `radius` and
         rotated by `rotation` (measured in degrees and clockwise).
 
-        The first curve begins from the last point in the path and the last ends at `x` 
-        and `y`. The curves follow a path in a direction determined by `clockwise` 
-        (bool) and `large_arc` (bool) in such a way that the sweep angle is always less 
+        The first curve begins from the last point in the path and the last ends at `x`
+        and `y`. The curves follow a path in a direction determined by `clockwise`
+        (bool) and `large_arc` (bool) in such a way that the sweep angle is always less
         than 360 degrees.
 
-        A simple line is appended if either either radii are zero or the last point in 
-        the path (`x`,`y`). The radii are scaled to fit the last path point if both are 
+        A simple line is appended if either either radii are zero or the last point in
+        the path (`x`,`y`). The radii are scaled to fit the last path point if both are
         greater than zero but too small to describe an arc.
         """
+
         x: float
         """
         Destination `x` coordinate of arc endpoint.
@@ -172,14 +181,15 @@ class Path(Shape):
         """
 
         def __post_init__(self):
-            self.type = "arcto"
+            self._type = "arcto"
 
     @dataclass
     class Oval(PathElement):
         """
-        Adds a new sub-path that consists of a curve that forms the ellipse that fills 
+        Adds a new sub-path that consists of a curve that forms the ellipse that fills
         the given rectangle.
         """
+
         x: float
         """
         The x-axis coordinate of the top-left of the bounding rectangle.
@@ -198,13 +208,14 @@ class Path(Shape):
         """
 
         def __post_init__(self):
-            self.type = "oval"
+            self._type = "oval"
 
     @dataclass
     class Rect(PathElement):
         """
         Adds a rectangle as a new sub-path.
         """
+
         x: float
         """
         The x-axis coordinate of the top-left of the rectangle.
@@ -227,7 +238,7 @@ class Path(Shape):
         """
 
         def __post_init__(self):
-            self.type = "rect"
+            self._type = "rect"
 
     @dataclass
     class Close(PathElement):
@@ -237,7 +248,7 @@ class Path(Shape):
         """
 
         def __post_init__(self):
-            self.type = "close"
+            self._type = "close"
 
     elements: list[PathElement] = field(default_factory=list)
     """
@@ -249,4 +260,3 @@ class Path(Shape):
     A style to draw a path with. The value of this property is the instance of
     [`Paint`](https://flet.dev/docs/reference/types/paint) class.
     """
-

--- a/sdk/python/packages/flet/src/flet/controls/cupertino/cupertino_date_picker.py
+++ b/sdk/python/packages/flet/src/flet/controls/cupertino/cupertino_date_picker.py
@@ -143,13 +143,12 @@ class CupertinoDatePicker(ConstrainedControl):
   
     Value is of type [`CupertinoDatePickerDateOrder`](https://flet.dev/docs/reference/types/cupertinodatepickerdateorder).
   
-    :::note
-    The final order in which the columns are displayed is also influenced by 
-    the `date_picker_mode`. For example, when using 
-    `date_picker_mode=CupertinoDatePickerMode.MONTH_YEAR`, 
-    both `CupertinoDatePickerDateOrder.DAY_MONTH_YEAR` and 
-    `CupertinoDatePickerDateOrder.MONTH_DAY_YEAR` will result in the month|year order.
-    :::
+    Note:
+        The final order in which the columns are displayed is also influenced by 
+        the `date_picker_mode`. For example, when using 
+        `date_picker_mode=CupertinoDatePickerMode.MONTH_YEAR`, 
+        both `CupertinoDatePickerDateOrder.DAY_MONTH_YEAR` and 
+        `CupertinoDatePickerDateOrder.MONTH_DAY_YEAR` will result in the month|year order.
     """
 
     on_change: OptionalControlEventHandler["CupertinoDatePicker"] = None
@@ -168,51 +167,51 @@ class CupertinoDatePicker(ConstrainedControl):
             value = self.value
 
         assert self.item_extent > 0, "item_extent must be strictly greater than 0"
-        assert self.minute_interval > 0 and 60 % self.minute_interval == 0, (
-            "minute_interval must be a positive integer factor of 60"
-        )
+        assert (
+            self.minute_interval > 0 and 60 % self.minute_interval == 0
+        ), "minute_interval must be a positive integer factor of 60"
 
         if self.date_picker_mode == CupertinoDatePickerMode.DATE_AND_TIME:
             if self.first_date:
-                assert value >= self.first_date, (
-                    f"value ({value}) can't be before first_date ({self.first_date})"
-                )
+                assert (
+                    value >= self.first_date
+                ), f"value ({value}) can't be before first_date ({self.first_date})"
             if self.last_date:
-                assert value <= self.last_date, (
-                    f"value ({value}) can't be after last_date ({self.last_date})"
-                )
+                assert (
+                    value <= self.last_date
+                ), f"value ({value}) can't be after last_date ({self.last_date})"
 
         if self.date_picker_mode in [
             CupertinoDatePickerMode.DATE,
             CupertinoDatePickerMode.MONTH_YEAR,
         ]:
-            assert 1 <= self.minimum_year <= value.year, (
-                f"value.year ({value.year}) can't be less than minimum_year "
-            )
+            assert (
+                1 <= self.minimum_year <= value.year
+            ), f"value.year ({value.year}) can't be less than minimum_year "
             f"({self.minimum_year})"
 
             if self.maximum_year:
-                assert value.year <= self.maximum_year, (
-                    f"value.year ({value.year}) can't be greater than maximum_year "
-                )
+                assert (
+                    value.year <= self.maximum_year
+                ), f"value.year ({value.year}) can't be greater than maximum_year "
                 f"({self.maximum_year})"
 
             if self.first_date:
-                assert value >= self.first_date, (
-                    f"value ({value}) can't be before first_date ({self.first_date})"
-                )
+                assert (
+                    value >= self.first_date
+                ), f"value ({value}) can't be before first_date ({self.first_date})"
 
             if self.last_date:
-                assert value <= self.last_date, (
-                    f"value ({value}) can't be after last_date ({self.last_date})"
-                )
+                assert (
+                    value <= self.last_date
+                ), f"value ({value}) can't be after last_date ({self.last_date})"
 
         if self.date_picker_mode != CupertinoDatePickerMode.DATE:
-            assert not self.show_day_of_week, (
-                "show_day_of_week is only supported in CupertinoDatePickerMode.DATE mode"
-            )
+            assert (
+                not self.show_day_of_week
+            ), "show_day_of_week is only supported in CupertinoDatePickerMode.DATE mode"
 
-        assert value.minute % self.minute_interval == 0, (
-            f"value.minute ({value.minute}) must be divisible by minute_interval "
-        )
+        assert (
+            value.minute % self.minute_interval == 0
+        ), f"value.minute ({value.minute}) must be divisible by minute_interval "
         f"({self.minute_interval})"

--- a/sdk/python/packages/flet/src/flet/controls/gradients.py
+++ b/sdk/python/packages/flet/src/flet/controls/gradients.py
@@ -88,8 +88,7 @@ class Gradient:
     and a color equal to the last color in `colors` is implied.
     """
 
-    # type: str = ""
-    type: str = field(default="", init=False, repr=False)
+    _type: Optional[str] = field(init=False, repr=False, compare=False, default=None)
 
 
 @dataclass
@@ -113,7 +112,7 @@ class LinearGradient(Gradient):
     """
 
     def __post_init__(self):
-        self.type = "linear"
+        self._type = "linear"
 
 
 @dataclass
@@ -157,7 +156,7 @@ class RadialGradient(Gradient):
     """
 
     def __post_init__(self):
-        self.type = "radial"
+        self._type = "radial"
 
 
 @dataclass
@@ -190,5 +189,5 @@ class SweepGradient(Gradient):
     """
 
     def __post_init__(self):
-        self.type = "sweep"
+        self._type = "sweep"
 

--- a/sdk/python/packages/flet/src/flet/controls/keys.py
+++ b/sdk/python/packages/flet/src/flet/controls/keys.py
@@ -1,11 +1,11 @@
-from dataclasses import dataclass
-from typing import Union
+from dataclasses import dataclass, field
+from typing import Optional, Union
 
 
 @dataclass()
 class Key:
     value: Union[str, int, float, bool]
-    type: str = ""
+    _type: Optional[str] = field(init=False, repr=False, compare=False, default=None)
 
     def __str__(self) -> str:
         return str(self.value)
@@ -14,10 +14,10 @@ class Key:
 @dataclass
 class ValueKey(Key):
     def __post_init__(self):
-        self.type = "value"
+        self._type = "value"
 
 
 @dataclass
 class ScrollKey(Key):
     def __post_init__(self):
-        self.type = "scroll"
+        self._type = "scroll"

--- a/sdk/python/packages/flet/src/flet/controls/material/container.py
+++ b/sdk/python/packages/flet/src/flet/controls/material/container.py
@@ -331,10 +331,9 @@ class Container(ConstrainedControl, AdaptiveControl):
 
     Event handler argument is of type [`TapEvent`](https://flet.dev/docs/reference/types/tapevent).
 
-    :::info
-    If `ink` is `True`, `e` will be plain `ControlEvent` with empty `data` instead of 
-    `ContainerTapEvent`.
-    :::
+    Info:
+        If `ink` is `True`, `e` will be plain `ControlEvent` with empty `data` instead of 
+        `ContainerTapEvent`.
 
     A simple usage example:
 

--- a/sdk/python/packages/flet/src/flet/controls/painting.py
+++ b/sdk/python/packages/flet/src/flet/controls/painting.py
@@ -32,8 +32,7 @@ class PaintingStyle(Enum):
 
 @dataclass(kw_only=True)
 class PaintGradient:
-    # type: str = ""
-    type: str = field(default="", init=False, repr=False)
+    _type: Optional[str] = field(init=False, repr=False, compare=False, default=None)
 
 
 @dataclass
@@ -82,7 +81,7 @@ class PaintLinearGradient(PaintGradient):
     """
 
     def __post_init__(self):
-        self.type = "linear"
+        self._type = "linear"
 
 
 @dataclass
@@ -145,7 +144,7 @@ class PaintRadialGradient(PaintGradient):
     """
 
     def __post_init__(self):
-        self.type = "radial"
+        self._type = "radial"
 
 
 @dataclass
@@ -205,7 +204,7 @@ class PaintSweepGradient(PaintGradient):
     """
 
     def __post_init__(self):
-        self.type = "sweep"
+        self._type = "sweep"
 
 
 @dataclass

--- a/sdk/python/packages/flet/src/flet/controls/scrollable_control.py
+++ b/sdk/python/packages/flet/src/flet/controls/scrollable_control.py
@@ -135,10 +135,9 @@ class ScrollableControl(Control):
         ft.app(main)
         ```
 
-        :::note
-        `scroll_to()` method won't work with `ListView` and `GridView` controls
-        building their items dynamically.
-        :::
+        Note:
+            `scroll_to()` method won't work with `ListView` and `GridView` controls
+            building their items dynamically.
 
         `duration` is scrolling animation duration in milliseconds. Defaults to `0` -
         no animation.
@@ -213,10 +212,9 @@ class ScrollableControl(Control):
         ft.app(main)
         ```
 
-        :::note
-        `scroll_to()` method won't work with `ListView` and `GridView` controls
-        building their items dynamically.
-        :::
+        Note:
+            `scroll_to()` method won't work with `ListView` and `GridView` controls
+            building their items dynamically.
 
         `duration` is scrolling animation duration in milliseconds. Defaults to `0` -
         no animation.

--- a/sdk/python/packages/flet/src/flet/controls/services/file_picker.py
+++ b/sdk/python/packages/flet/src/flet/controls/services/file_picker.py
@@ -86,7 +86,7 @@ class FilePickerFile:
 
 
 @dataclass
-class FilePickerUploadEvent(Event['FilePicker']):
+class FilePickerUploadEvent(Event["FilePicker"]):
     file_name: str
     """
     The name of the uploaded file.
@@ -204,39 +204,38 @@ class FilePicker(Service):
         * `allowed_extensions` - the allowed file extensions. Has effect only if
         `file_type` is `FilePickerFileType.CUSTOM`.
 
-        :::info
-        To save a file from the web, you don't need to use the FilePicker object.
+        Info:
+            To save a file from the web, you don't need to use the FilePicker object.
 
-        You can instead provides an API endpoint `/download/:filename` that returns the
-        file content, and then use
-        [`page.launch_url`](/docs/controls/page#launch_urlurl) to open the url, which
-        will trigger the browser's save file dialog.
+            You can instead provides an API endpoint `/download/:filename` that returns the
+            file content, and then use
+            [`page.launch_url`](/docs/controls/page#launch_urlurl) to open the url, which
+            will trigger the browser's save file dialog.
 
-        Take [FastAPI](https://flet.dev/docs/publish/web/dynamic-website#advanced-fastapi-scenarios)
-        as an example, you can use the following code to implement the endpoint:
+            Take [FastAPI](https://flet.dev/docs/publish/web/dynamic-website#advanced-fastapi-scenarios)
+            as an example, you can use the following code to implement the endpoint:
 
-        ```python
-        from fastapi import FastAPI, Response
-        from fastapi.responses import FileResponse
+            ```python
+            from fastapi import FastAPI, Response
+            from fastapi.responses import FileResponse
 
-        app = flet_fastapi.app(main)
+            app = flet_fastapi.app(main)
 
-        @app.get("/download/{filename}")
-        def download(filename: str):
-            path = prepare_file(filename)
-            return FileResponse(path)
-        ```
+            @app.get("/download/{filename}")
+            def download(filename: str):
+                path = prepare_file(filename)
+                return FileResponse(path)
+            ```
 
-        and then use `page.launch_url("/download/myfile.txt")` to open the url, for
-        instance, when a button is clicked.
+            and then use `page.launch_url("/download/myfile.txt")` to open the url, for
+            instance, when a button is clicked.
 
-        ```python
-        ft.ElevatedButton(
-            "Download myfile",
-            on_click=lambda _: page.launch_url("/download/myfile.txt"),
-        )
-        ```
-        :::
+            ```python
+            ft.ElevatedButton(
+                "Download myfile",
+                on_click=lambda _: page.launch_url("/download/myfile.txt"),
+            )
+            ```
         """
         return await self._invoke_method_async(
             "save_file",

--- a/sdk/python/packages/flet/tests/test_base_control.py
+++ b/sdk/python/packages/flet/tests/test_base_control.py
@@ -22,11 +22,11 @@ def test_controls_equality():
 def test_keys():
     k1 = ft.ValueKey(1)
     assert str(k1) == "1"
-    assert k1.type == "value"
+    assert k1._type == "value"
 
     k2 = ft.ScrollKey("section_a")
     assert str(k2) == "section_a"
-    assert k2.type == "scroll"
+    assert k2._type == "scroll"
 
     t1 = ft.Text("A", key=ft.ValueKey("1"))
     t2 = ft.Text("A", key=ft.ValueKey("1"))


### PR DESCRIPTION
With `:::note`, mkdocs thinks it is supposed to import a package/class, thereby failing to build+deploy.
Needed for flet-charts/MatplotlibChart, which inherits from `Container`.

## Summary by Sourcery

Standardize internal type representation and update docstrings

Enhancements:
- Replace public `type` fields with private `_type` in dataclass models for shapes, gradients, painting, borders, and controls
- Update parsing functions to use `_type` and introduce default fallback for gradient parsing
- Refactor assertion formatting in CupertinoDatePicker for consistent style

Documentation:
- Convert mkdocs `:::note` and `:::info` admonitions to inline `Note:` and `Info:` blocks in docstrings