### PR TITLE
Fix: Update session with client IP and user-agent on init

### DIFF
--- a/sdk/python/packages/flet-web/src/flet_web/fastapi/flet_app.py
+++ b/sdk/python/packages/flet-web/src/flet_web/fastapi/flet_app.py
@@ -255,6 +255,11 @@ class FletApp(Connection):
             self.__session.apply_page_patch(req.page)
 
             if new_session:
+                # update IP and user-agent
+                self.__session.page.client_ip = self.client_ip
+                self.__session.page.client_user_agent = self.client_user_agent
+
+                # run before_main
                 if asyncio.iscoroutinefunction(self.__before_main):
                     await self.__before_main(self.__session.page)
                 elif callable(self.__before_main):


### PR DESCRIPTION
When creating a new session, the client's IP address and user-agent are now stored in the session's page object. This ensures accurate tracking of client information for each session.

## Summary by Sourcery

Store client IP and user-agent on the session page when initializing a new session and apply this context before executing the before_main hook.

New Features:
- Persist client IP address in the session's page object.
- Persist client user-agent in the session's page object.

Enhancements:
- Run the before_main hook after setting the session context (IP and user-agent) to ensure accurate client information is available.