### PR TITLE
v1: rename `copy_with` to `copy`

### DIFF
--- a/sdk/python/packages/flet/src/flet/controls/alignment.py
+++ b/sdk/python/packages/flet/src/flet/controls/alignment.py
@@ -84,7 +84,7 @@ class Alignment:
     Represents the top right corner and is equivalent to `Alignment(1.0, -1.0)`.
     """
 
-    def copy_with(
+    def copy(
         self,
         *,
         x: Optional[Number] = None,

--- a/sdk/python/packages/flet/src/flet/controls/animation.py
+++ b/sdk/python/packages/flet/src/flet/controls/animation.py
@@ -69,7 +69,7 @@ class Animation:
     The curve to use for the animation.
     """
 
-    def copy_with(
+    def copy(
         self,
         *,
         duration: Optional[DurationValue] = None,
@@ -106,7 +106,7 @@ class AnimationStyle:
     The curve to use for the reverse animation.
     """
 
-    def copy_with(
+    def copy(
         self,
         *,
         duration: Optional[DurationValue] = None,

--- a/sdk/python/packages/flet/src/flet/controls/border.py
+++ b/sdk/python/packages/flet/src/flet/controls/border.py
@@ -10,11 +10,11 @@ __all__ = [
     "Border",
     "BorderSide",
     "BorderSideStrokeAlign",
-    "BorderStyle",
     "BorderSideStrokeAlignValue",
+    "BorderStyle",
     "all",
-    "symmetric",
     "only",
+    "symmetric",
 ]
 
 
@@ -66,7 +66,8 @@ class BorderSide:
     This means that it will render faster than otherwise, but it might
     double-hit pixels, giving it a slightly darker/lighter result.
 
-    To omit the border entirely, set the [`style`][flet.BorderSide.style] to `BorderStyle.NONE`.
+    To omit the border entirely, set the [`style`][flet.BorderSide.style]
+    to [`BorderStyle.NONE`][flet.BorderStyle.NONE].
     """
 
     color: ColorValue = Colors.BLACK
@@ -128,7 +129,7 @@ class BorderSide:
 
     # Instance Methods
 
-    def copy_with(
+    def copy(
         self,
         *,
         width: Optional[Number] = None,
@@ -246,7 +247,7 @@ class Border:
 
     # Instance Methods
 
-    def copy_with(
+    def copy(
         self,
         *,
         left: Optional[BorderSide] = None,
@@ -255,8 +256,7 @@ class Border:
         bottom: Optional[BorderSide] = None,
     ) -> "Border":
         """
-        Returns a copy of this `Border` instance with the given fields replaced
-        with the new values.
+        Returns a copy of this object with the specified properties overridden.
         """
         return Border(
             left=left if left is not None else self.left,

--- a/sdk/python/packages/flet/src/flet/controls/border_radius.py
+++ b/sdk/python/packages/flet/src/flet/controls/border_radius.py
@@ -9,8 +9,8 @@ __all__ = [
     "BorderRadiusValue",
     "all",
     "horizontal",
-    "vertical",
     "only",
+    "vertical",
 ]
 
 
@@ -87,7 +87,7 @@ class BorderRadius:
 
     # Instance Methods
 
-    def copy_with(
+    def copy(
         self,
         *,
         top_left: Optional[Number] = None,
@@ -96,8 +96,7 @@ class BorderRadius:
         bottom_right: Optional[Number] = None,
     ) -> "BorderRadius":
         """
-        Returns a copy of this `BorderRadius` instance with the given fields replaced
-        with the new values.
+        Returns a copy of this object with the specified properties overridden.
         """
         return BorderRadius(
             top_left=top_left if top_left is not None else self.top_left,

--- a/sdk/python/packages/flet/src/flet/controls/box.py
+++ b/sdk/python/packages/flet/src/flet/controls/box.py
@@ -16,16 +16,16 @@ from flet.controls.types import (
 )
 
 __all__ = [
-    "BoxDecoration",
-    "BoxShadow",
-    "DecorationImage",
-    "ColorFilter",
-    "FilterQuality",
     "BlurStyle",
-    "BoxShape",
     "BoxConstraints",
+    "BoxDecoration",
     "BoxFit",
+    "BoxShadow",
     "BoxShadowValue",
+    "BoxShape",
+    "ColorFilter",
+    "DecorationImage",
+    "FilterQuality",
 ]
 
 
@@ -45,7 +45,7 @@ class ColorFilter:
     The blend mode to apply to the color filter.
     """
 
-    def copy_with(
+    def copy(
         self,
         *,
         color: Optional[ColorValue] = None,
@@ -124,7 +124,7 @@ class BoxShadow:
 
     blur_style: BlurStyle = BlurStyle.NORMAL
 
-    def copy_with(
+    def copy(
         self,
         *,
         spread_radius: Optional[Number] = None,
@@ -240,7 +240,7 @@ class DecorationImage:
     Whether to paint the image in anti-aliased quality.
     """
 
-    def copy_with(
+    def copy(
         self,
         *,
         src: Optional[str] = None,
@@ -328,8 +328,10 @@ class BoxDecoration:
 
     shape: BoxShape = BoxShape.RECTANGLE
     """
-    The shape to fill the [`bgcolor`][flet.BoxDecoration.bgcolor], [`gradient`][flet.BoxDecoration.gradient],
-    and [`image`][flet.BoxDecoration.image] into and to cast as the [`shadows`][flet.BoxDecoration.shadows].
+    The shape to fill the [`bgcolor`][flet.BoxDecoration.bgcolor],
+    [`gradient`][flet.BoxDecoration.gradient], and [`image`][
+    flet.BoxDecoration.image] into and to cast as the
+    [`shadows`][flet.BoxDecoration.shadows].
     """
 
     blend_mode: Optional[BlendMode] = None
@@ -344,13 +346,14 @@ class BoxDecoration:
             or self.bgcolor is not None
             or self.gradient is not None
         ), (
-            "blend_mode applies to the BoxDecoration's background color or gradient, but no color or gradient was provided"
+            "blend_mode applies to the BoxDecoration's background color or gradient, "
+            "but no color or gradient was provided"
         )
         assert not (self.shape == BoxShape.CIRCLE and self.border_radius), (
             "border_radius must be None when shape is BoxShape.CIRCLE"
         )
 
-    def copy_with(
+    def copy(
         self,
         *,
         bgcolor: Optional[ColorValue] = None,
@@ -387,7 +390,8 @@ class BoxConstraints:
         min_width <= Size.width <= max_width
         min_height <= Size.height <= max_height
 
-    Read more about BoxConstraints [here](https://api.flutter.dev/flutter/rendering/BoxConstraints-class.html).
+    Read more about BoxConstraints
+    [here](https://api.flutter.dev/flutter/rendering/BoxConstraints-class.html).
     """
 
     min_width: Number = 0
@@ -424,7 +428,7 @@ class BoxConstraints:
             "and min_height must be less than or equal to max_height"
         )
 
-    def copy_with(
+    def copy(
         self,
         *,
         min_width: Optional[Number] = None,

--- a/sdk/python/packages/flet/src/flet/controls/buttons.py
+++ b/sdk/python/packages/flet/src/flet/controls/buttons.py
@@ -22,8 +22,8 @@ __all__ = [
     "ContinuousRectangleBorder",
     "OutlinedBorder",
     "RoundedRectangleBorder",
-    "StadiumBorder",
     "ShapeBorder",
+    "StadiumBorder",
 ]
 
 
@@ -69,7 +69,7 @@ class StadiumBorder(OutlinedBorder):
     def __post_init__(self):
         self._type = "stadium"
 
-    def copy_with(
+    def copy(
         self,
         *,
         side: Optional[BorderSide] = None,
@@ -96,7 +96,7 @@ class RoundedRectangleBorder(OutlinedBorder):
     def __post_init__(self):
         self._type = "roundedRectangle"
 
-    def copy_with(
+    def copy(
         self,
         *,
         side: Optional[BorderSide] = None,
@@ -122,7 +122,7 @@ class CircleBorder(OutlinedBorder):
     def __post_init__(self):
         self._type = "circle"
 
-    def copy_with(
+    def copy(
         self,
         *,
         side: Optional[BorderSide] = None,
@@ -148,7 +148,7 @@ class BeveledRectangleBorder(RoundedRectangleBorder):
     def __post_init__(self):
         self._type = "beveledRectangle"
 
-    def copy_with(
+    def copy(
         self,
         *,
         side: Optional[BorderSide] = None,
@@ -172,7 +172,7 @@ class ContinuousRectangleBorder(RoundedRectangleBorder):
     def __post_init__(self):
         self._type = "continuousRectangle"
 
-    def copy_with(
+    def copy(
         self,
         *,
         side: Optional[BorderSide] = None,
@@ -288,7 +288,7 @@ class ButtonStyle:
     over the button.
     """
 
-    def copy_with(
+    def copy(
         self,
         *,
         color: Optional[ControlStateValue[ColorValue]] = None,

--- a/sdk/python/packages/flet/src/flet/controls/duration.py
+++ b/sdk/python/packages/flet/src/flet/controls/duration.py
@@ -5,14 +5,14 @@ from typing import Optional, Union
 from flet.controls.types import Number
 
 __all__ = [
+    "DateTimeValue",
     "Duration",
     "DurationValue",
-    "MICROSECONDS_PER_MILLISECOND",
-    "MICROSECONDS_PER_SECOND",
-    "MICROSECONDS_PER_MINUTE",
-    "MICROSECONDS_PER_HOUR",
     "MICROSECONDS_PER_DAY",
-    "DateTimeValue",
+    "MICROSECONDS_PER_HOUR",
+    "MICROSECONDS_PER_MILLISECOND",
+    "MICROSECONDS_PER_MINUTE",
+    "MICROSECONDS_PER_SECOND",
 ]
 
 MICROSECONDS_PER_MILLISECOND = 1_000
@@ -205,7 +205,7 @@ class Duration:
 
     # Instance Methods
 
-    def copy_with(
+    def copy(
         self,
         *,
         microseconds: Optional[int] = None,

--- a/sdk/python/packages/flet/src/flet/controls/geometry.py
+++ b/sdk/python/packages/flet/src/flet/controls/geometry.py
@@ -5,8 +5,8 @@ from flet.controls.transform import Offset
 from flet.controls.types import Number
 
 __all__ = [
-    "Size",
     "Rect",
+    "Size",
 ]
 
 
@@ -39,11 +39,6 @@ class Size:
         return self.width != float("inf") and self.height != float("inf")
 
     @classmethod
-    def copy(cls, source: "Size") -> "Size":
-        """Creates a copy of the given Size object."""
-        return Size(source.width, source.height)
-
-    @classmethod
     def square(cls, dimension: Number) -> "Size":
         """Creates a square Size where width and height are the same."""
         return Size(dimension, dimension)
@@ -70,8 +65,8 @@ class Size:
     @classmethod
     def infinite(cls):
         return Size(float("inf"), float("inf"))
-        
-    def copy_with(
+
+    def copy(
         self,
         *,
         width: Optional[Number] = None,
@@ -89,7 +84,8 @@ class Size:
 @dataclass
 class Rect:
     """
-    A 2D, axis-aligned, floating-point rectangle whose coordinates are relative to a given origin.
+    A 2D, axis-aligned, floating-point rectangle whose coordinates are relative
+    to a given origin.
     """
 
     left: Number
@@ -113,8 +109,8 @@ class Rect:
     def height(self) -> Number:
         """The distance between the top and bottom edges of this rectangle."""
         return self.bottom - self.top
-        
-    def copy_with(
+
+    def copy(
         self,
         *,
         left: Optional[Number] = None,
@@ -161,7 +157,7 @@ class Rect:
             center.y - height / 2,
             center.x + width / 2,
             center.y + height / 2,
-                    )
+        )
 
     @classmethod
     def from_points(cls, a: Offset, b: Offset):
@@ -174,4 +170,4 @@ class Rect:
             min(a.y, b.y),
             max(a.x, b.x),
             max(a.y, b.y),
-                    )
+        )

--- a/sdk/python/packages/flet/src/flet/controls/material/elevated_button.py
+++ b/sdk/python/packages/flet/src/flet/controls/material/elevated_button.py
@@ -175,7 +175,7 @@ class ElevatedButton(ConstrainedControl, AdaptiveControl):
             or self.bgcolor is not None
             or self.elevation != 1
         ):
-            self._internals["style"] = (self.style or ButtonStyle()).copy_with(
+            self._internals["style"] = (self.style or ButtonStyle()).copy(
                 color=self.color,
                 bgcolor=self.bgcolor,
                 elevation=self.elevation,

--- a/sdk/python/packages/flet/src/flet/controls/painting.py
+++ b/sdk/python/packages/flet/src/flet/controls/painting.py
@@ -59,8 +59,8 @@ class PaintLinearGradient(PaintGradient):
     the stops. This list must contain at least two colors.
 
     Note:
-        If [`color_stops`][flet.PaintLinearGradient.color_stops] is not `None`, this list must have 
-        the same length as `color_stops`.
+        If [`color_stops`][flet.PaintLinearGradient.color_stops] is not `None`,
+        this list must have the same length as `color_stops`.
     """
 
     color_stops: Optional[list[Number]] = None
@@ -68,10 +68,12 @@ class PaintLinearGradient(PaintGradient):
     A list of values from `0.0` to `1.0` that denote fractions along the gradient.
 
     Note:
-        If non-none, this list must have the same length as [`colors`][flet.PaintLinearGradient.colors]. 
-        If the first value is not `0.0`, then a stop with position `0.0` and a color equal to the first color
-        in `colors` is implied. If the last value is not `1.0`, then a stop with position
-        `1.0` and a color equal to the last color in `colors` is implied.
+        If non-none, this list must have the same length as
+        [`colors`][flet.PaintLinearGradient.colors].
+        If the first value is not `0.0`, then a stop with position `0.0` and a color
+        equal to the first color in `colors` is implied. If the last value is not
+        `1.0`, then a stop with position `1.0` and a color equal to the last color
+        in `colors` is implied.
     """
 
     tile_mode: GradientTileMode = GradientTileMode.CLAMP
@@ -83,7 +85,7 @@ class PaintLinearGradient(PaintGradient):
     def __post_init__(self):
         self._type = "linear"
 
-    def copy_with(
+    def copy(
         self,
         *,
         begin: Optional[OffsetValue] = None,
@@ -166,7 +168,7 @@ class PaintRadialGradient(PaintGradient):
     def __post_init__(self):
         self._type = "radial"
 
-    def copy_with(
+    def copy(
         self,
         *,
         center: Optional[OffsetValue] = None,
@@ -252,7 +254,7 @@ class PaintSweepGradient(PaintGradient):
     def __post_init__(self):
         self._type = "sweep"
 
-    def copy_with(
+    def copy(
         self,
         *,
         center: Optional[OffsetValue] = None,
@@ -345,7 +347,7 @@ class Paint:
     TBD
     """
 
-    def copy_with(
+    def copy(
         self,
         *,
         color: Optional[ColorValue] = None,

--- a/sdk/python/packages/flet/src/flet/controls/text_style.py
+++ b/sdk/python/packages/flet/src/flet/controls/text_style.py
@@ -218,7 +218,7 @@ class TextStyle:
     text span, or, for the root text spans, with the line box.
     """
 
-    def copy_with(
+    def copy(
         self,
         *,
         size: Optional[Number] = None,
@@ -322,7 +322,7 @@ class StrutStyle:
     Defaults to `False`.
     """
 
-    def copy_with(
+    def copy(
         self,
         *,
         size: Optional[Number] = None,

--- a/sdk/python/packages/flet/src/flet/controls/transform.py
+++ b/sdk/python/packages/flet/src/flet/controls/transform.py
@@ -5,12 +5,12 @@ from flet.controls.alignment import Alignment
 from flet.controls.types import Number
 
 __all__ = [
-    "Scale",
-    "Rotate",
     "Offset",
-    "ScaleValue",
-    "RotateValue",
     "OffsetValue",
+    "Rotate",
+    "RotateValue",
+    "Scale",
+    "ScaleValue",
 ]
 
 
@@ -40,7 +40,7 @@ class Scale:
     Gives the origin of scale.
     """
 
-    def copy_with(
+    def copy(
         self,
         *,
         scale: Optional[Number] = None,
@@ -75,7 +75,7 @@ class Rotate:
     The alignment of the rotation.
     """
 
-    def copy_with(
+    def copy(
         self,
         *,
         angle: Optional[Number] = None,
@@ -106,7 +106,7 @@ class Offset:
     The vertical offset.
     """
 
-    def copy_with(
+    def copy(
         self,
         *,
         x: Optional[Number] = None,


### PR DESCRIPTION
## Summary by Sourcery

Unify the object replication API by renaming `copy_with` methods to `copy` across the SDK’s control and value classes, update `__all__` exports to reflect the renaming, and adjust docstrings for improved formatting and link consistency.

Enhancements:
- Rename `copy_with` to `copy` methods across various control, geometry, painting, border, button, transform, duration, border_radius, animation, text_style, and alignment classes
- Update `__all__` lists and import orders to include renamed methods and maintain export consistency
- Refactor docstrings and line breaks for better formatting and consistent hyperlink usage