### PR TITLE
Refactor PageView to BasePage and update references

### DIFF
--- a/sdk/python/packages/flet/docs/controls/basepage.md
+++ b/sdk/python/packages/flet/docs/controls/basepage.md
@@ -1,0 +1,1 @@
+::: flet.BasePage

--- a/sdk/python/packages/flet/docs/controls/pageview.md
+++ b/sdk/python/packages/flet/docs/controls/pageview.md
@@ -1,1 +1,0 @@
-::: flet.PageView

--- a/sdk/python/packages/flet/mkdocs.yml
+++ b/sdk/python/packages/flet/mkdocs.yml
@@ -231,7 +231,7 @@ nav:
               - ControlBuilder: controls/controlbuilder.md
               - DialogControl: controls/dialogcontrol.md
               - MultiView: controls/multiview.md
-              - PageView: controls/pageview.md
+              - BasePage: controls/basepage.md
               - ScrollableControl: controls/scrollablecontrol.md
               - Service: controls/service.md
           - Buttons:

--- a/sdk/python/packages/flet/src/flet/__init__.py
+++ b/sdk/python/packages/flet/src/flet/__init__.py
@@ -9,6 +9,7 @@ from flet.controls.animation import (
     AnimationValue,
 )
 from flet.controls.base_control import BaseControl, control
+from flet.controls.base_page import BasePage, PageMediaData, PageResizeEvent
 from flet.controls.blur import (
     Blur,
     BlurTileMode,
@@ -350,7 +351,6 @@ from flet.controls.page import (
     RouteChangeEvent,
     ViewPopEvent,
 )
-from flet.controls.page_view import PageMediaData, PageResizeEvent, PageView
 from flet.controls.painting import (
     Paint,
     PaintGradient,
@@ -521,6 +521,7 @@ __all__ = [
     "Banner",
     "BannerTheme",
     "BaseControl",
+    "BasePage",
     "BeveledRectangleBorder",
     "BlendMode",
     "Blur",
@@ -754,7 +755,6 @@ __all__ = [
     "PageResizeEvent",
     "PageTransitionTheme",
     "PageTransitionsTheme",
-    "PageView",
     "Pagelet",
     "Paint",
     "PaintGradient",

--- a/sdk/python/packages/flet/src/flet/controls/base_control.py
+++ b/sdk/python/packages/flet/src/flet/controls/base_control.py
@@ -27,8 +27,8 @@ else:
 
 
 if TYPE_CHECKING:
+    from .base_page import BasePage
     from .page import Page
-    from .page_view import PageView
 
 __all__ = [
     "BaseControl",
@@ -141,7 +141,8 @@ class BaseControl:
         # weakref.finalize(
         #     self,
         #     lambda: controls_log.debug(
-        #         f"Control was garbage collected: {ctrl_type}({control_id} - {object_id})"
+        #         f"Control was garbage collected: {ctrl_type}({control_id} "
+        #         f"- {object_id})"
         #     ),
         # )
 
@@ -153,21 +154,25 @@ class BaseControl:
         """
         The direct ancestor(parent) of this control.
 
-        It defaults to `None` and will only have a value when this control is mounted (added to the page tree).
+        It defaults to `None` and will only have a value when this control is mounted
+        (added to the page tree).
 
-        The `Page` control (which is the root of the tree) is an exception - it always has `parent=None`.
+        The `Page` control (which is the root of the tree) is an exception - it always
+        has `parent=None`.
         """
         parent_ref = getattr(self, "_parent", None)
         return parent_ref() if parent_ref else None
 
     @property
-    def page(self) -> Optional[Union["Page", "PageView"]]:
-        """The page (of type `Page` or `PageView`) to which this control belongs to."""
-        from .page import Page, PageView
+    def page(self) -> Optional[Union["Page", "BasePage"]]:
+        """
+        The page to which this control belongs to.
+        """
+        from .page import BasePage, Page
 
         parent = self
         while parent:
-            if isinstance(parent, (Page, PageView)):
+            if isinstance(parent, (Page, BasePage)):
                 return parent
             parent = parent.parent
         return None

--- a/sdk/python/packages/flet/src/flet/controls/base_page.py
+++ b/sdk/python/packages/flet/src/flet/controls/base_page.py
@@ -78,7 +78,7 @@ class PageMediaData:
 
 
 @dataclass
-class PageResizeEvent(Event["PageView"]):
+class PageResizeEvent(Event["BasePage"]):
     """
     Event fired when the size of the containing window or browser is changed.
 
@@ -97,12 +97,12 @@ class PageResizeEvent(Event["PageView"]):
     """
 
 
-@control("PageView", isolated=True, kw_only=True)
-class PageView(AdaptiveControl):
+@control("BasePage", isolated=True, kw_only=True)
+class BasePage(AdaptiveControl):
     """
     A visual container representing a top-level view in a Flet application.
 
-    `PageView` serves as the base class for [Page][flet.Page] and
+    `BasePage` serves as the base class for [Page][flet.Page] and
     [MultiView][flet.MultiView], and provides a unified surface for rendering
     application content, app bars,
     navigation elements, dialogs, overlays, and more. It manages one
@@ -110,7 +110,7 @@ class PageView(AdaptiveControl):
     scrolling, and theming properties.
 
     Unlike lower-level layout controls (e.g., [Column][flet.Column],
-    [Container][flet.Container]), [PageView][flet.PageView] represents
+    [Container][flet.Container]), [BasePage][flet.BasePage] represents
     an entire logical view or screen of the app. It provides direct access
     to view-level controls such as [AppBar][flet.AppBar],
     [NavigationBar][flet.NavigationBar],
@@ -284,7 +284,8 @@ class PageView(AdaptiveControl):
         Moves scroll position to either absolute `offset`, relative `delta` or jump to
         the control with specified `scroll_key`.
 
-        See [`Column.scroll_to()`][flet.Column.scroll_to] for method details and examples.
+        See [`Column.scroll_to()`][flet.Column.scroll_to] for method details
+        and examples.
         """
         self.__default_view().scroll_to(
             offset=offset,

--- a/sdk/python/packages/flet/src/flet/controls/control_event.py
+++ b/sdk/python/packages/flet/src/flet/controls/control_event.py
@@ -18,7 +18,7 @@ from typing import (
 if TYPE_CHECKING:
     from .base_control import BaseControl  # noqa
     from .page import Page
-    from .page_view import PageView
+    from .base_page import BasePage
 
 __all__ = [
     "ControlEvent",
@@ -80,7 +80,7 @@ class Event(Generic[EventControlType]):
     control: EventControlType = field(repr=False)
 
     @property
-    def page(self) -> Optional[Union["Page", "PageView"]]:
+    def page(self) -> Optional[Union["Page", "BasePage"]]:
         return self.control.page
 
     @property

--- a/sdk/python/packages/flet/src/flet/controls/multi_view.py
+++ b/sdk/python/packages/flet/src/flet/controls/multi_view.py
@@ -1,17 +1,17 @@
 from typing import Any
 
 from flet.controls.base_control import control
-from flet.controls.page_view import PageView
+from flet.controls.base_page import BasePage
 
 __all__ = ["MultiView"]
 
 
 @control()
-class MultiView(PageView):
+class MultiView(BasePage):
     """
     TBD
     """
-    
+
     view_id: int
     """
     TBD

--- a/sdk/python/packages/flet/src/flet/controls/page.py
+++ b/sdk/python/packages/flet/src/flet/controls/page.py
@@ -17,6 +17,7 @@ from urllib.parse import urlparse
 from flet.auth.authorization import Authorization
 from flet.auth.oauth_provider import OAuthProvider
 from flet.controls.base_control import BaseControl, control
+from flet.controls.base_page import BasePage
 from flet.controls.context import _context_page
 from flet.controls.control import Control
 from flet.controls.control_event import (
@@ -28,7 +29,6 @@ from flet.controls.control_event import (
 from flet.controls.core.view import View
 from flet.controls.core.window import Window
 from flet.controls.multi_view import MultiView
-from flet.controls.page_view import PageView
 from flet.controls.query_string import QueryString
 from flet.controls.ref import Ref
 from flet.controls.services.browser_context_menu import BrowserContextMenu
@@ -135,7 +135,7 @@ class MultiViewRemoveEvent(Event["Page"]):
 
 
 @control("Page", isolated=True, post_init_args=2)
-class Page(PageView):
+class Page(BasePage):
     """
     Page is a container for [`View`][flet.View] controls.
 
@@ -368,7 +368,7 @@ class Page(PageView):
         ref,
         sess: "Session",
     ) -> None:
-        PageView.__post_init__(self, ref)
+        BasePage.__post_init__(self, ref)
         self._i = 1
         self.__session = weakref.ref(sess)
 
@@ -557,8 +557,8 @@ class Page(PageView):
         """
         Starts OAuth flow.
 
-        See [Authentication](https://docs.flet-docs.pages.dev/cookbook/authentication) guide
-        for more information and examples.
+        See [Authentication](https://docs.flet-docs.pages.dev/cookbook/authentication)
+        guide for more information and examples.
         """
         self.__authorization = authorization(
             provider,
@@ -633,7 +633,7 @@ class Page(PageView):
         Clears current authentication context. See
         [Authentication](https://docs.flet-docs.pages.dev/cookbook/authentication#signing-out) guide for more
         information and examples.
-        """
+        """  # noqa: E501
         self.__authorization = None
         e = ControlEvent(name="logout", control=self)
         if self.on_logout:
@@ -686,9 +686,11 @@ class Page(PageView):
 
         Args:
             url: The URL to open.
-            web_window_name: Window tab/name to open URL in. Use [`UrlTarget.SELF`][flet.UrlTarget.SELF]
-                for the same browser tab, [`UrlTarget.BLANK`][flet.UrlTarget.BLANK] for a new browser
-                tab (or in external application on mobile device), or a custom name for a named tab.
+            web_window_name: Window tab/name to open URL in. Use
+                [`UrlTarget.SELF`][flet.UrlTarget.SELF]
+                for the same browser tab, [`UrlTarget.BLANK`][flet.UrlTarget.BLANK]
+                for a new browser tab (or in external application on mobile device),
+                or a custom name for a named tab.
             web_popup_window: Display the URL in a browser popup window.
             window_width: Popup window width.
             window_height: Popup window height.

--- a/sdk/python/packages/flet/tests/test_events.py
+++ b/sdk/python/packages/flet/tests/test_events.py
@@ -1,5 +1,6 @@
 from typing import ForwardRef, get_args, get_origin
 
+from flet.controls.base_page import PageResizeEvent
 from flet.controls.control_event import ControlEvent, Event, get_event_field_type
 from flet.controls.core.column import Column
 from flet.controls.events import TapEvent
@@ -10,7 +11,6 @@ from flet.controls.material.reorderable_list_view import (
     ReorderableListView,
 )
 from flet.controls.page import Page
-from flet.controls.page_view import PageResizeEvent
 from flet.controls.scrollable_control import OnScrollEvent
 from flet.controls.types import PointerDeviceType
 from flet.messaging.connection import Connection

--- a/sdk/python/packages/flet/tests/test_from_dict.py
+++ b/sdk/python/packages/flet/tests/test_from_dict.py
@@ -2,8 +2,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
 
+from flet.controls.base_page import PageMediaData
 from flet.controls.padding import Padding
-from flet.controls.page_view import PageMediaData
 from flet.utils import from_dict
 
 

--- a/sdk/python/packages/flet/tests/test_patch_dataclass.py
+++ b/sdk/python/packages/flet/tests/test_patch_dataclass.py
@@ -2,10 +2,10 @@ from dataclasses import dataclass
 
 import msgpack
 from flet.controls.base_control import BaseControl
+from flet.controls.base_page import PageMediaData
 from flet.controls.object_patch import ObjectPatch
 from flet.controls.padding import Padding
 from flet.controls.page import Page
-from flet.controls.page_view import PageMediaData
 from flet.controls.types import Brightness, PagePlatform
 from flet.messaging.connection import Connection
 from flet.messaging.protocol import configure_encode_object_for_msgpack


### PR DESCRIPTION
Renamed PageView to BasePage throughout the codebase for clarity and consistency. Updated all imports, type hints, documentation, and test references to use BasePage, PageMediaData, and PageResizeEvent from the new module. Adjusted documentation and mkdocs navigation to reflect the change.

Close #5532

## Summary by Sourcery

Rename PageView to BasePage for clarity and consistency and update all related references across the codebase.

Enhancements:
- Rename the PageView class and its imports, __all__ exports, and subclass relationships to BasePage
- Update type hints and isinstance checks to use BasePage in base_control and control_event modules
- Adjust flet.__init__ to export BasePage instead of PageView

Documentation:
- Rename and add documentation file controls/basepage.md and remove controls/pageview.md
- Update mkdocs navigation to reference BasePage instead of PageView