### PR TITLE
fix: apply default Tooltip decoration values

### DIFF
--- a/packages/flet/lib/src/utils/box.dart
+++ b/packages/flet/lib/src/utils/box.dart
@@ -63,7 +63,7 @@ BoxDecoration? parseBoxDecoration(dynamic value, BuildContext context,
 
   var shape = parseBoxShape(value["shape"], BoxShape.rectangle)!;
   var borderRadius = parseBorderRadius(value["border_radius"]);
-  var color = parseColor(value["color"], theme);
+  var color = parseColor(value["bgcolor"], theme);
   var gradient = parseGradient(value["gradient"], theme);
   var blendMode = parseBlendMode(value["blend_mode"]);
 

--- a/packages/flet/lib/src/utils/tooltip.dart
+++ b/packages/flet/lib/src/utils/tooltip.dart
@@ -34,14 +34,25 @@ Tooltip? parseTooltip(dynamic value, BuildContext context, Widget widget) {
 
   /// The tooltip shape defaults to a rounded rectangle with a border radius of
   /// 4.0. Tooltips will also default to an opacity of 90%
+  var defaultDecoration = BoxDecoration(
+    borderRadius: BorderRadius.circular(4.0),
+    color: parseColor(
+        value["bgcolor"],
+        theme,
+        theme.brightness == Brightness.light
+            ? Colors.grey[700]
+            : Colors.white));
   var decoration = parseBoxDecoration(value["decoration"], context);
-  decoration?.copyWith(
-      color: parseColor(
-          value["bgcolor"],
-          theme,
-          theme.brightness == Brightness.light
-              ? Colors.grey[700]
-              : Colors.white)!);
+  var finalDecoration = defaultDecoration.copyWith(
+    color: decoration?.color,
+    borderRadius: decoration?.borderRadius,
+    border: decoration?.border,
+    boxShadow: decoration?.boxShadow,
+    gradient: decoration?.gradient,
+    image: decoration?.image,
+    shape: decoration?.shape,
+    backgroundBlendMode: decoration?.backgroundBlendMode,
+  );
   return Tooltip(
     message: value["message"],
     enableFeedback: parseBool(value["enable_feedback"]),
@@ -51,7 +62,7 @@ Tooltip? parseTooltip(dynamic value, BuildContext context, Widget widget) {
     exitDuration: parseDuration(value["exit_duration"]),
     preferBelow: parseBool(value["prefer_below"]),
     padding: parseEdgeInsets(value["padding"]),
-    decoration: decoration,
+    decoration: finalDecoration,
     textStyle: parseTextStyle(value["text_style"], theme),
     verticalOffset: parseDouble(value["vertical_offset"]),
     margin: parseEdgeInsets(value["margin"]),


### PR DESCRIPTION
## Description

This PR addresses this issue -> #5568 

The original problem was that when creating a `BoxDecoration` for a `Tooltip`, default values were being set, but they were not saved anywhere. 
<img width="422" height="145" alt="image" src="https://github.com/user-attachments/assets/41c64b5f-0a9a-4050-9990-75e759078c0a" />

After I started saving it in a separate variable and passing it to the `decoration` attribute, I was able to get the colors specified in `tooltip.decoration`, but I still couldn’t get the `tooltip.bgcolor`.

The solution was to create a default value, like `defaultBoxDecoration`, and provide it to `parseBoxDecoration`.
After that, I noticed that the key being parsed from Flet is named `color`, even though in the Flet widget, the background color property is called `bgcolor`.


## Test Code

```python
import flet as ft


def main(page: ft.Page):
    page.add(
        ft.Text(
            value="Hover to see the tooltip",
            tooltip=ft.Tooltip(
                message="This is a tooltip with green bgcolor",
                padding=20,
                text_style=ft.TextStyle(size=20, color=ft.Colors.WHITE),
                bgcolor=ft.Colors.GREEN,
            ),
        ),
    )


ft.run(main)

```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I signed the CLA.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes
- [ ] I have made corresponding changes to the [documentation](https://github.com/flet-dev/website) (if applicable)

## Screenshots
<img width="1022" height="907" alt="изображение" src="https://github.com/user-attachments/assets/188a211f-cdbd-4205-9a14-39580fa05fff" />


<!-- Add screenshots here if applicable. -->

## Additional details

<!-- Any additional details to be known about this PR. -->

## Summary by Sourcery

Ensure Tooltip decorations use proper default values by introducing and passing a default BoxDecoration and updating the parser to honor fallback properties.

Bug Fixes:
- Restore default border radius and background color for Tooltip decorations by creating and applying a default BoxDecoration.
- Fix parsing of background color using the "bgcolor" key instead of incorrectly using "color".

Enhancements:
- Extend parseBoxDecoration to accept a default BoxDecoration and use its borderRadius and color when parsing values.