### PR TITLE
fix: add `Image.clear_cache` to trigger image refresh

### DIFF
--- a/packages/flet/lib/src/controls/image.dart
+++ b/packages/flet/lib/src/controls/image.dart
@@ -12,7 +12,7 @@ import '../utils/numbers.dart';
 import '../widgets/error.dart';
 import 'base_controls.dart';
 
-class ImageControl extends StatelessWidget {
+class ImageControl extends StatefulWidget {
   final Control control;
 
   static const String svgTag = " xmlns=\"http://www.w3.org/2000/svg\"";
@@ -23,43 +23,73 @@ class ImageControl extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
-    debugPrint("Image build: ${control.id}");
+  State<ImageControl> createState() => _ImageControlState();
+}
 
-    var src = control.getString("src", "")!;
-    var srcBase64 = control.getString("src_base64", "")!;
-    var srcBytes = (control.get("src_bytes") as Uint8List?) ?? Uint8List(0);
+class _ImageControlState extends State<ImageControl> {
+  @override
+  void initState() {
+    super.initState();
+    widget.control.addInvokeMethodListener(_invokeMethod);
+  }
+
+  Future<dynamic> _invokeMethod(String name, dynamic args) async {
+    debugPrint("Image.$name($args)");
+    switch (name) {
+      case "clear_cache":
+        imageCache.clear();
+      default:
+        throw Exception("Unknown Image method: $name");
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.control.removeInvokeMethodListener(_invokeMethod);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    debugPrint("Image build: ${widget.control.id}");
+
+    var src = widget.control.getString("src", "")!;
+    var srcBase64 = widget.control.getString("src_base64", "")!;
+    var srcBytes =
+        (widget.control.get("src_bytes") as Uint8List?) ?? Uint8List(0);
     if (src == "" && srcBase64 == "" && srcBytes.isEmpty) {
       return const ErrorControl(
           "Image must have either \"src\" or \"src_base64\" or \"src_bytes\" specified.");
     }
-    var errorContent = control.buildWidget("error_content");
+    var errorContent = widget.control.buildWidget("error_content");
 
     Widget? image = buildImage(
       context: context,
       src: src,
       srcBase64: srcBase64,
       srcBytes: srcBytes,
-      width: control.getDouble("width"),
-      height: control.getDouble("height"),
-      cacheWidth: control.getInt("cache_width"),
-      cacheHeight: control.getInt("cache_height"),
-      antiAlias: control.getBool("anti_alias", false)!,
-      repeat: control.getImageRepeat("repeat", ImageRepeat.noRepeat)!,
-      fit: control.getBoxFit("fit"),
-      colorBlendMode: control.getBlendMode("color_blend_mode"),
-      color: control.getColor("color", context),
-      semanticsLabel: control.getString("semantics_label"),
-      gaplessPlayback: control.getBool("gapless_playback"),
-      excludeFromSemantics: control.getBool("exclude_from_semantics", false)!,
-      filterQuality:
-          control.getFilterQuality("filter_quality", FilterQuality.medium)!,
-      disabled: control.disabled,
+      width: widget.control.getDouble("width"),
+      height: widget.control.getDouble("height"),
+      cacheWidth: widget.control.getInt("cache_width"),
+      cacheHeight: widget.control.getInt("cache_height"),
+      antiAlias: widget.control.getBool("anti_alias", false)!,
+      repeat: widget.control.getImageRepeat("repeat", ImageRepeat.noRepeat)!,
+      fit: widget.control.getBoxFit("fit"),
+      colorBlendMode: widget.control.getBlendMode("color_blend_mode"),
+      color: widget.control.getColor("color", context),
+      semanticsLabel: widget.control.getString("semantics_label"),
+      gaplessPlayback: widget.control.getBool("gapless_playback"),
+      excludeFromSemantics:
+          widget.control.getBool("exclude_from_semantics", false)!,
+      filterQuality: widget.control
+          .getFilterQuality("filter_quality", FilterQuality.medium)!,
+      disabled: widget.control.disabled,
       errorCtrl: errorContent,
     );
     return LayoutControl(
-        control: control,
-        child: _clipCorners(image, control.getBorderRadius("border_radius")));
+        control: widget.control,
+        child: _clipCorners(
+            image, widget.control.getBorderRadius("border_radius")));
   }
 
   Widget _clipCorners(Widget image, BorderRadius? borderRadius) {

--- a/sdk/python/packages/flet/src/flet/controls/core/image.py
+++ b/sdk/python/packages/flet/src/flet/controls/core/image.py
@@ -43,19 +43,16 @@ class Image(LayoutControl):
     [Here](https://github.com/flet-dev/examples/blob/main/python/controls/information-displays/image/image-base64.py)
     is an example.
 
-    /// details | Tip
-        type: tip
-
-    - Use `base64` command (on Linux, macOS or WSL) to convert file to Base64 format:
-        ```bash
-        base64 -i <image.png> -o <image-base64.txt>
-        ```
-
-    - On Windows you can use PowerShell to encode string into Base64 format:
-        ```posh
-        [convert]::ToBase64String((Get-Content -path "your_file_path" -Encoding byte))
-        ```
-    ///
+    Tip:
+        - Use `base64` command (on Linux, macOS or WSL) to convert
+            file to Base64 format:
+            ```bash
+            base64 -i <image.png> -o <image-base64.txt>
+            ```
+        - On Windows you can use PowerShell to encode string into Base64 format:
+            ```posh
+            [convert]::ToBase64String((Get-Content -path "your_file_path" -Encoding byte))
+            ```
     """
 
     src_bytes: Optional[bytes] = None
@@ -149,3 +146,16 @@ class Image(LayoutControl):
     def init(self):
         super().init()
         self._internals["skip_properties"] = ["width", "height"]
+
+    async def clear_cache(self):
+        """
+        Evicts all pending and keepAlive entries from the cache.
+
+        This is useful if, for instance, an image source (for example, a file) has been
+        updated and therefore the new image must be obtained.
+
+        Note:
+            Images which have not finished loading yet will not be removed from
+            the cache, and when they complete they will be inserted as normal.
+        """
+        await self._invoke_method("clear_cache")


### PR DESCRIPTION
Fix #5521

## Code
```py
def main(page: ft.Page):
    page.horizontal_alignment = page.vertical_alignment = "center"

    async def clear_image_cache():
        await img.clear_cache()
        print("cleared")

    page.add(
        img := ft.Image(src="img.png"),
        ft.Button("Clear Image cache", on_click=clear_image_cache),
    )
```

## Summary by Sourcery

Implement a new clear_cache feature for the Image control by converting it to a StatefulWidget in Flutter to handle invocation events and adding a corresponding async method in the Python SDK, and tidy up Base64 usage documentation.

New Features:
- Implement image.clear_cache invocation on the Flutter side to clear the image cache
- Add async clear_cache method to the Python Image control to trigger cache eviction

Enhancements:
- Convert Flutter ImageControl from StatelessWidget to StatefulWidget to support method listeners
- Reformat Python Image docstring Base64 usage instructions for improved readability