### PR TITLE
Fixed integration tests: Remove tester service from page initialization

### DIFF
--- a/sdk/python/packages/flet/src/flet/testing/flet_test_app.py
+++ b/sdk/python/packages/flet/src/flet/testing/flet_test_app.py
@@ -155,7 +155,6 @@ class FletTestApp:
         async def main(page: ft.Page):
             self.__page = page
             self.__tester = Tester()
-            page.services.append(self.__tester)
             page.theme_mode = ft.ThemeMode.LIGHT
             page.update()
 


### PR DESCRIPTION
Eliminated appending the Tester service to the page's services list in FletTestApp. This may be part of a refactor or cleanup to simplify test app setup.

## Summary by Sourcery

Eliminate automatic registration of the Tester service in FletTestApp to simplify test app setup and resolve integration test failures.

Bug Fixes:
- Remove the page.services.append(self.__tester) call to prevent unwanted service injection during page initialization.

Enhancements:
- Simplify FletTestApp.start by no longer appending the Tester service to the page’s services list.