### PR TITLE
v1: Disable image upscaling in canvas image loading

### DIFF
--- a/packages/flet/lib/src/controls/canvas.dart
+++ b/packages/flet/lib/src/controls/canvas.dart
@@ -565,7 +565,7 @@ Future<void> loadCanvasImage(Control shape) async {
       throw Exception("Missing image source: 'src' or 'src_bytes'");
     }
 
-    final codec = await ui.instantiateImageCodec(bytes);
+    final codec = await ui.instantiateImageCodec(bytes, allowUpscaling: false);
     final frame = await codec.getNextFrame();
     shape.properties["_image"] = frame.image;
     shape.updateProperties({"_hash": getImageHash(shape)},


### PR DESCRIPTION
Sets allowUpscaling to false when instantiating image codec in loadCanvasImage, preventing automatic upscaling of loaded images.
