### PR TITLE
Switch to tomllib/tomli for pyproject.toml parsing

### DIFF
--- a/sdk/python/packages/flet-cli/pyproject.toml
+++ b/sdk/python/packages/flet-cli/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "watchdog >=4.0.0",
     "packaging >=25.0",
     "qrcode >=7.4.2",
-    "toml >=0.10.2",
+    "tomli >= 1.1.0 ; python_version < '3.11'",
     "cookiecutter >=2.6.0"
 ]
 

--- a/sdk/python/packages/flet-cli/src/flet_cli/utils/pyproject_toml.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/utils/pyproject_toml.py
@@ -1,7 +1,11 @@
+import sys
 from pathlib import Path
 from typing import Any, Optional
 
-import toml
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 
 def load_pyproject_toml(project_dir: Path):
@@ -9,7 +13,7 @@ def load_pyproject_toml(project_dir: Path):
     pyproject_toml_file = project_dir.joinpath("pyproject.toml")
     if pyproject_toml_file.exists():
         with pyproject_toml_file.open("r", encoding="utf-8") as f:
-            pyproject_toml = toml.loads(f.read())
+            pyproject_toml = tomllib.loads(f.read())
 
     def get_pyproject(setting: Optional[str] = None):
         if not setting:


### PR DESCRIPTION
Replaces the toml dependency with tomli for Python <3.11 and tomllib for Python >=3.11. Updates pyproject.toml and utility code to use the appropriate library for parsing pyproject.toml files, ensuring compatibility with newer Python versions.

Fix #5701

## Summary by Sourcery

Switch to tomllib/tomli for parsing pyproject.toml and remove the external toml dependency

Enhancements:
- Add conditional import of tomllib for Python >=3.11 and tomli for older versions
- Update parsing logic to use tomllib alias instead of toml.loads

Build:
- Replace the toml dependency in pyproject.toml with tomli for Python <3.11