### PR TITLE
Fix integration tests: Update macOS CI workflow for Python 3.13 and tool checks

### DIFF
--- a/.github/workflows/macos-integration-tests.yml
+++ b/.github/workflows/macos-integration-tests.yml
@@ -28,6 +28,7 @@ env:
   FLET_TEST_SCREENSHOTS_PIXEL_RATIO: "2.0"
   FLET_TEST_SCREENSHOTS_SIMILARITY_THRESHOLD: "99.0"
   FLET_TEST_DISABLE_FVM: "1"
+  UV_PYTHON: "3.13"
 
 jobs:
   test-macos:
@@ -53,7 +54,7 @@ jobs:
 
       - name: Show tool versions
         run: |
-          python3 --version && uv --version && pod --version && flutter --version
+          uv --version && uv run python --version && pod --version && flutter --version
 
       - name: Run integration tests (${{ matrix.suite }})
         working-directory: sdk/python


### PR DESCRIPTION
Adds UV_PYTHON environment variable set to 3.13 and updates the tool version check step to use 'uv run python --version' instead of 'python3 --version'. This ensures the workflow uses the correct Python version and improves consistency in tool invocation.

## Summary by Sourcery

Update macOS integration test workflow to use Python 3.13 and standardize tool version checks

CI:
- Set UV_PYTHON environment variable to 3.13 in the macOS CI workflow
- Replace python3 --version with uv run python --version in the Show tool versions step