### PR TITLE
Enhance use_state to support functional updates

### DIFF
--- a/sdk/python/examples/apps/declarative/set_state_with_list.py
+++ b/sdk/python/examples/apps/declarative/set_state_with_list.py
@@ -1,0 +1,36 @@
+import asyncio
+
+import flet as ft
+
+
+@ft.component
+def App():
+    items, set_items = ft.use_state(list(range(60)))
+
+    async def auto_scroll(e):
+        for i in range(60, 120):
+            await asyncio.sleep(1)
+            set_items(lambda cur, i=i: cur + [i])
+            print(f"Scrolling to line {i}")
+
+    return ft.Column(
+        controls=[
+            ft.ListView(
+                spacing=10,
+                padding=20,
+                auto_scroll=True,
+                height=300,
+                controls=[
+                    ft.Text(
+                        key=i,
+                        value=f"Line {i + 1}",
+                    )
+                    for i in items
+                ],
+            ),
+            ft.OutlinedButton("Start auto-scrolling", on_click=auto_scroll),
+        ]
+    )
+
+
+ft.run(lambda page: page.render(App))


### PR DESCRIPTION
The use_state hook now accepts updater functions, allowing state to be set based on the previous value, similar to React's useState. Updated type hints, docstrings, and internal logic to support this feature and improve clarity.

## Summary by Sourcery

Enable functional updates in the use_state hook by allowing the setter to accept updater functions or direct values, enhance related type hints and documentation, and include a new example showcasing list state updates.

New Features:
- Allow use_state setter to accept functional updater functions based on previous state
- Add example app demonstrating functional list updates with auto-scrolling

Enhancements:
- Introduce StateT and Updater type hints for use_state
- Update docstrings and type signatures to clarify setter behavior
- Refactor subscription logic with clearer naming and comments