### PR TITLE
v1: Fix component updates on Dart side

### DIFF
--- a/packages/flet/lib/src/models/control.dart
+++ b/packages/flet/lib/src/models/control.dart
@@ -426,18 +426,19 @@ class Control extends ChangeNotifier {
   static dynamic _transformIfControl(
       dynamic value, Control? parent, FletBackend backend) {
     //debugPrint("_transformIfControl: $value");
-    if (value is Map && value.containsKey("_c")) {
-      return Control.fromMap(value, backend, parent: parent);
-    } else if (value is List &&
-        value.isNotEmpty &&
-        value.first is Map &&
-        (value.first as Map).containsKey("_c")) {
-      return value.map((e) {
-        if (e is Map) {
-          return Control.fromMap(e, backend, parent: parent);
-        }
-        return e;
-      }).toList();
+    if (value is Map) {
+      if (value.containsKey("_c")) {
+        return Control.fromMap(value, backend, parent: parent);
+      }
+      return value.map(
+        (key, entryValue) =>
+            MapEntry(key, _transformIfControl(entryValue, parent, backend)),
+      );
+    }
+    if (value is List) {
+      return value
+          .map((element) => _transformIfControl(element, parent, backend))
+          .toList(growable: true);
     }
     return value;
   }


### PR DESCRIPTION
Fix #5750

Working example of a "Shape drawer":

```py
from dataclasses import dataclass, field

import flet as ft
from flet import canvas

POINT_RADIUS = 4
PAINT = ft.Paint(
    style=ft.PaintingStyle.STROKE,
    color=ft.Colors.RED,
    stroke_width=2,
)


@dataclass
class Point:
    x: float = 0
    y: float = 0


@dataclass
@ft.observable
class Polygon:
    points: list[Point] = field(default_factory=list)


@dataclass
@ft.observable
class State:
    polygons: list[Polygon] = field(default_factory=list[Polygon])


@ft.component
def PolygonView(polygon: Polygon) -> canvas.Path:
    return canvas.Path(
        elements=[
            canvas.Path.MoveTo(
                point.x,
                point.y,
            )
            if i == 0
            else canvas.Path.LineTo(
                point.x,
                point.y,
            )
            for i, point in enumerate(polygon.points)
        ]
        + [canvas.Path.Close()],
        paint=PAINT,
    )


@ft.component
def App():
    state, _ = ft.use_state(
        State(
            polygons=[
                Polygon([Point(50, 50), Point(150, 50), Point(100, 150)]),
            ]
        )
    )
    # state, _ = ft.use_state(State(polygons=[Polygon()]))

    def handle_tap_down(e: ft.TapEvent):
        # add point to the top polygon
        if e.local_position is not None:
            state.polygons[-1].points.append(
                Point(x=e.local_position.x, y=e.local_position.y)
            )
            if len(state.polygons[-1].points) == 1:
                # add a temporary point to be updated on hover
                state.polygons[-1].points.append(
                    Point(x=e.local_position.x, y=e.local_position.y)
                )

    def handle_hover(e: ft.HoverEvent):
        # update position of the last point in the top polygon
        if e.local_position is not None and len(state.polygons[-1].points) > 0:
            state.polygons[-1].points[-1].x = e.local_position.x
            state.polygons[-1].points[-1].y = e.local_position.y
            state.notify()

    def handle_secondary_tap_down(e: ft.TapEvent):
        # add new polygon
        state.polygons.append(Polygon())

    return ft.GestureDetector(
        on_tap_down=handle_tap_down,
        on_secondary_tap_down=handle_secondary_tap_down,
        on_hover=handle_hover,
        content=ft.Container(
            content=canvas.Canvas(
                width=float("inf"),
                height=float("inf"),
                shapes=[PolygonView(polygon) for polygon in state.polygons],
            ),
            width=500,
            height=500,
            bgcolor=ft.Colors.GREY_300,
            alignment=ft.Alignment.TOP_LEFT,
        ),
    )


ft.run(lambda page: page.render(App))

```

## Summary by Sourcery

Refine Control._transformIfControl to traverse nested maps and lists and instantiate controls wherever "_c" keys appear

Bug Fixes:
- Fix missed control transformations in lists and nested map entries

Enhancements:
- Recursively process all map entries and list elements instead of only top-level structures