### PR TITLE
Readme: Fix broken link (404) to Apps Gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ flet run --web counter.py
 * [Website](https://flet.dev)
 * [Documentation](https://docs.flet.dev)
 * [Roadmap](https://flet.dev/roadmap)
-* [Apps Gallery](https://docs.flet.dev/gallery)
+* [Apps Gallery](https://flet.dev/gallery)
 
 ## Community
 


### PR DESCRIPTION
## Description

Simple hyperlink fix in the readme.  `https://docs.flet.dev/gallery` is 404, the link was corrected to `https://flet.dev/gallery`

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

<!-- If this PR fixes an open issue, please link to the issue here. Ex: Fixes #4562 -->

## Test Code

```python
# Test code for the review of this PR
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I signed the CLA.
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass locally with my changes
- [ ] I have made corresponding changes to the [documentation](https://github.com/flet-dev/website) (if applicable)

## Screenshots 

<!-- Add screenshots here if applicable. -->

## Additional details

<!-- Any additional details to be known about this PR. -->

## Summary by Sourcery

Fix broken Apps Gallery link in README

Bug Fixes:
- Correct the Apps Gallery URL in the README to avoid the 404 error

Documentation:
- Update the hyperlink for Apps Gallery from docs.flet.dev/gallery to flet.dev/gallery in README