### PR TITLE
Support overridden dataclass defaults in control encoding

### DIFF
--- a/sdk/python/examples/apps/custom_controls/custom_buttons.py
+++ b/sdk/python/examples/apps/custom_controls/custom_buttons.py
@@ -1,0 +1,45 @@
+from dataclasses import dataclass, field
+from typing import Any
+
+import flet as ft
+
+
+def main(page: ft.Page):
+    @ft.control
+    class MyButton(ft.Button):
+        expand: int = field(default_factory=lambda: 1)
+        style: ft.ButtonStyle = field(
+            default_factory=lambda: ft.ButtonStyle(
+                shape=ft.RoundedRectangleBorder(radius=10)
+            )
+        )
+        bgcolor: ft.Colors = ft.Colors.BLUE_ACCENT
+        icon: Any = ft.Icons.HEADPHONES
+
+    @dataclass
+    class MyButton2(ft.Button):
+        expand: Any = 1
+        bgcolor: ft.Colors = ft.Colors.GREEN_ACCENT
+        style: ft.ButtonStyle = field(
+            default_factory=lambda: ft.ButtonStyle(
+                shape=ft.RoundedRectangleBorder(radius=20)
+            )
+        )
+        icon: ft.IconDataOrControl = ft.Icons.HEADPHONES
+
+    @ft.control
+    class MyButton3(ft.Button):
+        def init(self):
+            self.expand = 1
+            self.bgcolor = ft.Colors.RED_ACCENT
+            self.style = ft.ButtonStyle(shape=ft.RoundedRectangleBorder(radius=30))
+            self.icon = ft.Icons.HEADPHONES
+
+    page.add(
+        ft.Row([MyButton(content="1")]),
+        ft.Row([MyButton2(content="2")]),
+        ft.Row([MyButton3(content="3")]),
+    )
+
+
+ft.run(main)

--- a/sdk/python/packages/flet/src/flet/messaging/protocol.py
+++ b/sdk/python/packages/flet/src/flet/messaging/protocol.py
@@ -8,6 +8,20 @@ import msgpack
 from flet.controls.duration import Duration
 
 
+def _get_root_dataclass_field(cls, field_name):
+    """
+    Returns the field definition from the earliest dataclass in the MRO
+    that declares `field_name`. This lets us recover defaults configured
+    on base controls before subclasses override them.
+    """
+
+    for base in reversed(cls.__mro__):
+        dataclass_fields = getattr(base, "__dataclass_fields__", None)
+        if dataclass_fields and field_name in dataclass_fields:
+            return dataclass_fields[field_name]
+    return None
+
+
 def configure_encode_object_for_msgpack(control_cls):
     def encode_object_for_msgpack(obj):
         if is_dataclass(obj):
@@ -36,10 +50,18 @@ def configure_encode_object_for_msgpack(control_cls):
                 elif is_dataclass(v):
                     r[field.name] = v
                     prev_classes[field.name] = v
-                elif v is not None and (
-                    v != field.default or not isinstance(obj, control_cls)
-                ):
-                    r[field.name] = v
+                else:
+                    default_value = field.default
+                    if isinstance(obj, control_cls):
+                        root_field = _get_root_dataclass_field(
+                            obj.__class__, field.name
+                        )
+                        if root_field is not None:
+                            default_value = root_field.default
+                    if v is not None and (
+                        v != default_value or not isinstance(obj, control_cls)
+                    ):
+                        r[field.name] = v
 
             if not hasattr(obj, "_frozen"):
                 setattr(obj, "__prev_lists", prev_lists)

--- a/sdk/python/packages/flet/tests/test_patch_dataclass.py
+++ b/sdk/python/packages/flet/tests/test_patch_dataclass.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 
 import msgpack
 
-from flet.controls.base_control import BaseControl
+from flet.controls.base_control import BaseControl, control
 from flet.controls.base_page import PageMediaData
 from flet.controls.object_patch import ObjectPatch
 from flet.controls.padding import Padding
@@ -35,6 +35,21 @@ def test_simple_patch_dataclass():
     assert settings.debug
     assert isinstance(settings.config, Config)
     assert settings.config.timeout == 2.5
+
+
+def test_encode_emits_overridden_defaults():
+    @control("BaseTestControl")
+    class BaseTestControl(BaseControl):
+        foo: int = 0
+
+    @control("ChildTestControl")
+    class ChildTestControl(BaseTestControl):
+        foo: int = 5
+
+    encoder = configure_encode_object_for_msgpack(BaseControl)
+    encoded = encoder(ChildTestControl())
+
+    assert encoded["foo"] == 5
 
 
 def test_page_patch_dataclass():


### PR DESCRIPTION
This is how we can define custom control and their default property values:

```py
from dataclasses import dataclass, field
from typing import Any

import flet as ft


def main(page: ft.Page):
    @ft.control
    class MyButton(ft.Button):
        expand: int = field(default_factory=lambda: 1)
        style: ft.ButtonStyle = field(
            default_factory=lambda: ft.ButtonStyle(
                shape=ft.RoundedRectangleBorder(radius=10)
            )
        )
        bgcolor: ft.Colors = ft.Colors.BLUE_ACCENT
        icon: Any = ft.Icons.HEADPHONES

    @dataclass
    class MyButton2(ft.Button):
        expand: Any = 1
        bgcolor: ft.Colors = ft.Colors.GREEN_ACCENT
        style: ft.ButtonStyle = field(
            default_factory=lambda: ft.ButtonStyle(
                shape=ft.RoundedRectangleBorder(radius=20)
            )
        )
        icon: ft.IconDataOrControl = ft.Icons.HEADPHONES

    @ft.control
    class MyButton3(ft.Button):
        def init(self):
            self.expand = 1
            self.bgcolor = ft.Colors.RED_ACCENT
            self.style = ft.ButtonStyle(shape=ft.RoundedRectangleBorder(radius=30))
            self.icon = ft.Icons.HEADPHONES

    page.add(
        ft.Row([MyButton(content="1")]),
        ft.Row([MyButton2(content="2")]),
        ft.Row([MyButton3(content="3")]),
    )


ft.run(main)
```

Rules:
1. You should define either `@dataclass` or `@ft.control` decorator on the inherited class - both methods works the same.
2. A field, to be a class field, must have a type annotation, so `expand: int = 1` will override inherited property, but `expand = 1` won't. Not sure which type to use? Just `Any` will work, for example `expand: Any = 1`.
3. Use literal default value for simple data types, such as int, bool, str and `field(default_factory=lambda: <new_value>)` for immutable types such as class, list, dict.
4. You can set property values in `init()` method, but you won't be able to override if write `MyButton3(expand=False)`.

## Summary by Sourcery

Support correct encoding of dataclass-based controls with overridden default values and document custom control default configuration through examples.

New Features:
- Add support for emitting overridden default values when encoding dataclass-based controls that inherit from other controls.
- Provide an example app demonstrating different ways to define custom controls and their default property values using dataclasses and control decorators.

Bug Fixes:
- Fix control encoding so that defaults defined on base dataclass controls are respected while still emitting overridden defaults from subclasses.

Tests:
- Add a regression test ensuring that encoded output includes subclass-overridden defaults for dataclass control fields.