### PR TITLE
Source common.sh in CI workflow for flet package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,7 @@ jobs:
         shell: bash
         working-directory: packages/flet
         run: |
+          source "$SCRIPTS/common.sh"
           mkdir -p "$HOME/.config/dart"
           printf %s "$PUB_DEV_TOKEN" | base64 --decode > "$HOME/.config/dart/pub-credentials.json"
 


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update flet package CI job to source the shared common.sh script at the start of its Dart configuration step.