### PR TITLE
Update TypeVar definition for covariant typing in Ref class

### DIFF
--- a/sdk/python/packages/flet/src/flet/controls/ref.py
+++ b/sdk/python/packages/flet/src/flet/controls/ref.py
@@ -1,7 +1,7 @@
 import weakref
 from typing import Generic, Optional, TypeVar
 
-T = TypeVar("T")
+T = TypeVar("T", covariant=True)
 __all__ = ["Ref"]
 
 


### PR DESCRIPTION
## Description

This PR adds `covariant=True` to the `TypeVar` definition in `Ref`.

This is added because otherwise pyright will raise error, example:
```
Argument of type "Ref[TextField]" cannot be assigned to parameter "ref" of type "Ref[BaseControl] | None" in function "__init__"
  Type "Ref[TextField]" is not assignable to type "Ref[BaseControl] | None"
    "Ref[TextField]" is not assignable to "Ref[BaseControl]"
      Type parameter "T@Ref" is invariant, but "TextField" is not the same as "BaseControl"
    "Ref[TextField]" is not assignable to "None"
```

## Test Code

```python
import flet as ft

ref = ft.Ref[ft.TextField]()
text_field = ft.TextField(ref=ref)
```

```bash
pyright .
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I signed the CLA.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes
- [x] I have made corresponding changes to the [documentation](https://github.com/flet-dev/website) (if applicable)

## Screenshots 

<!-- Add screenshots here if applicable. -->

## Additional details

<!-- Any additional details to be known about this PR. -->

## Summary by Sourcery

Bug Fixes:
- Fix type checking errors by marking the Ref generic type parameter as covariant.