### PR TITLE
Fix Android platform check to exclude web

### DIFF
--- a/packages/flet/lib/src/flet_backend.dart
+++ b/packages/flet/lib/src/flet_backend.dart
@@ -253,7 +253,7 @@ class FletBackend extends ChangeNotifier {
         await pageSizeUpdated.future;
         debugPrint("Registering web client with route: $newRoute");
         String platform = defaultTargetPlatform.name.toLowerCase();
-        if (platform == "android") {
+        if (platform == "android" && !kIsWeb) {
           try {
             DeviceInfoPlugin deviceInfo = DeviceInfoPlugin();
             AndroidDeviceInfo androidInfo = await deviceInfo.androidInfo;


### PR DESCRIPTION
Updated the platform check to ensure Android-specific code does not run on web by adding a '!kIsWeb' condition. This prevents potential issues when running on web platforms that report as Android.

## Summary by Sourcery

Bug Fixes:
- Prevent Android-only device info logic from running when the app is executing in a web environment.