### PR TITLE
Disable Rive in desktop client light

### DIFF
--- a/.github/scripts/common.sh
+++ b/.github/scripts/common.sh
@@ -9,8 +9,8 @@ function patch_python_package_versions() (
     for pkg in flet flet-cli flet-desktop flet-desktop-light flet-web; do
       version_py="packages/$pkg/src/${pkg//-/_}/version.py"
       if [[ -f "$version_py" ]]; then
-        sed -i -e "s/version = \"\"/version = \"$PYPI_VER\"/g" "$version_py"
         sed -i -e "s/flet_version = \"\"/flet_version = \"$PYPI_VER\"/g" "$version_py"
+        sed -i -e "s/version = \"\"/version = \"$PYPI_VER\"/g" "$version_py"
       else
         echo "Skipping version patch: $version_py not found"
       fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,12 +283,12 @@ jobs:
       matrix:
         include:
           - arch: arm64
-            runner: ubuntu-22.04-arm
+            runner: ubuntu-24.04-arm
             build_arch: arm64
             platform_arch: aarch64
             title: ARM64
           - arch: amd64
-            runner: ubuntu-22.04
+            runner: ubuntu-24.04
             build_arch: x64
             platform_arch: x86_64
             title: AMD64
@@ -323,10 +323,6 @@ jobs:
         run: |
           sudo sed -i.bak '/apt.postgresql.org/s/^/# /' /etc/apt/sources.list
           sudo apt update --allow-releaseinfo-change
-          sudo apt install -y software-properties-common
-          sudo add-apt-repository -y universe
-          sudo apt update
-          sudo apt install -y libunwind-dev
           sudo apt install -y clang libgtk-3-dev libasound2-dev
           sudo apt install -y \
             libmpv-dev mpv \

--- a/client/lib/main.dart
+++ b/client/lib/main.dart
@@ -13,10 +13,10 @@ import 'package:flet_lottie/flet_lottie.dart' as flet_lottie;
 import 'package:flet_map/flet_map.dart' as flet_map;
 import 'package:flet_permission_handler/flet_permission_handler.dart'
     as flet_permission_handler;
+// --FAT_CLIENT_START--
 // --RIVE_IMPORT_START--
 import 'package:flet_rive/flet_rive.dart' as flet_rive;
 // --RIVE_IMPORT_END--
-// --FAT_CLIENT_START--
 import 'package:flet_video/flet_video.dart' as flet_video;
 // --FAT_CLIENT_END--
 import 'package:flet_webview/flet_webview.dart' as flet_webview;
@@ -44,19 +44,18 @@ void main([List<String>? args]) async {
     flet_lottie.Extension(),
     flet_map.Extension(),
     flet_ads.Extension(),
-    // --RIVE_EXTENSION_START--
-    flet_rive.Extension(),
-    // --RIVE_EXTENSION_END--
     flet_webview.Extension(),
     flet_flashlight.Extension(),
     flet_datatable2.Extension(),
     flet_charts.Extension(),
+    // --FAT_CLIENT_START--
+    // --RIVE_EXTENSION_START--
+    flet_rive.Extension(),
+    // --RIVE_EXTENSION_END--
+    flet_audio.Extension(),
+    flet_video.Extension(),
+    // --FAT_CLIENT_END--
   ];
-
-  // --FAT_CLIENT_START--
-  extensions.add(flet_audio.Extension());
-  extensions.add(flet_video.Extension());
-  // --FAT_CLIENT_END--
 
   // initialize extensions
   for (var extension in extensions) {

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -41,6 +41,12 @@ dependencies:
 
   flet_video:
     path: ../sdk/python/packages/flet-video/src/flutter/flet_video
+
+  # --RIVE_CLIENT_START--
+  flet_rive:
+    path: ../sdk/python/packages/flet-rive/src/flutter/flet_rive
+  # --RIVE_CLIENT_END--
+
 # --FAT_CLIENT_END--
 
   flet_audio_recorder:
@@ -63,11 +69,6 @@ dependencies:
 
   flet_permission_handler:
     path: ../sdk/python/packages/flet-permission-handler/src/flutter/flet_permission_handler
-
-  # --RIVE_CLIENT_START--
-  flet_rive:
-    path: ../sdk/python/packages/flet-rive/src/flutter/flet_rive
-  # --RIVE_CLIENT_END--
 
   flet_webview:
     path: ../sdk/python/packages/flet-webview/src/flutter/flet_webview


### PR DESCRIPTION
## Summary by Sourcery

Gate the Rive extension and dependency behind the fat desktop client configuration and improve Python package version patching.

Bug Fixes:
- Restrict the Rive Flutter extension and dependency so they are only included in the fat desktop client build, effectively disabling Rive for the light desktop client.

Enhancements:
- Update the Python packaging version patch script to also populate generic `version` fields alongside `flet_version`.

Build:
- Adjust Dart imports and extension registration to align Rive and media extensions with the fat client build guards.
- Move the `flet_rive` dependency into the fat client section of the Flutter `pubspec.yaml` so it is only pulled in for fat desktop builds.