### PR TITLE
fix: Enable TextButton style and full-width Dropdown

### DIFF
--- a/packages/flet/lib/src/controls/button.dart
+++ b/packages/flet/lib/src/controls/button.dart
@@ -98,7 +98,7 @@ class _ButtonControlState extends State<ButtonControl> with FletStoreMixin {
     var theme = Theme.of(context);
 
     var style = parseButtonStyle(
-      widget.control.internals?["style"],
+      widget.control.internals?["style"] ?? widget.control.get("style"),
       theme,
       defaultForegroundColor:
           widget.control.getColor("color", context, theme.colorScheme.primary)!,

--- a/sdk/python/packages/flet/src/flet/controls/material/text_button.py
+++ b/sdk/python/packages/flet/src/flet/controls/material/text_button.py
@@ -101,10 +101,5 @@ class TextButton(LayoutControl, AdaptiveControl):
     Called when this button has lost focus.
     """
 
-    def before_update(self):
-        super().before_update()
-        if self.style is not None:
-            self._internals["style"] = self.style.copy()
-
     async def focus(self):
         await self._invoke_method("focus")


### PR DESCRIPTION
## Description

Made TextButton style actually work and allowed Dropdown to expand fully

issues:
* #6047
* #6044


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I signed the CLA.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing tests pass locally with my changes
- [x] I have made corresponding changes to the [documentation](https://github.com/flet-dev/website) (if applicable)

## Screenshots 

<img width="967" height="674" alt="image" src="https://github.com/user-attachments/assets/ab108217-14bb-48f8-9983-a3502af61a2e" />
<img width="448" height="433" alt="image" src="https://github.com/user-attachments/assets/bfa7affa-cf7e-4e9e-8a3e-32a1840a8948" />


## Additional details

<!-- Any additional details to be known about this PR. -->

## Summary by Sourcery

Fix button styling and dropdown layout behavior to honor configured styles and horizontal expansion.

Bug Fixes:
- Make button controls correctly apply the configured style from control properties.
- Allow dropdown controls to fully expand horizontally when the expand property is set.