### PR TITLE
Updated Extending Flet doc

### DIFF
--- a/sdk/python/examples/controls/markdown/basic.py
+++ b/sdk/python/examples/controls/markdown/basic.py
@@ -64,7 +64,7 @@ Style text as _italic_, __bold__, ~~strikethrough~~, or `inline code`.
 
 Formatted Dart code looks really pretty too:
 
-```
+~~~dart
 void main() {
   runApp(MaterialApp(
     home: Scaffold(
@@ -72,7 +72,7 @@ void main() {
     ),
   ));
 }
-```
+~~~
 """
 
 

--- a/sdk/python/examples/controls/markdown/code_syntax_highlight.py
+++ b/sdk/python/examples/controls/markdown/code_syntax_highlight.py
@@ -19,9 +19,9 @@ On the server side Flet provides an easy to learn programming model that enables
 
 Flet requires Python 3.7 or above. To start with Flet, you need to install flet module first:
 
-```
+~~~bash
 pip install flet
-```
+~~~
 
 ### Create Python program
 
@@ -29,7 +29,7 @@ Create a new Python program using Flet which will be driving the content of `Fle
 
 Let's do a simple `counter.py` app similar to a Flutter new project template:
 
-```python
+~~~python
 import flet
 from flet import IconButton, Page, Row, TextField, icons
 
@@ -59,13 +59,13 @@ def main(page: Page):
     )
 
 flet.app(main, port=8550)
-```
+~~~
 
 Run the app:
 
-```
+~~~bash
 python counter.py
-```
+~~~
 
 You should see the app running in a native OS window.
 
@@ -81,13 +81,13 @@ Create a new or open existing Flutter project.
 
 Install Flutter `flet` package:
 
-```
+~~~bash
 flutter pub add flet
-```
+~~~
 
 For a new project replace `main.dart` with the following:
 
-```dart
+~~~dart
 import 'package:flet/flet.dart';
 import 'package:flutter/material.dart';
 
@@ -107,13 +107,13 @@ class MyApp extends StatelessWidget {
     );
   }
 }
-```
+~~~
 
 In the app above `FletApp` widget is hosted inside `MaterialApp` widget.
 
 If Flet app must be able to handle page route change events (web browser URL changes, mobile app deep linking) it must be the top most widget as it contains its own `MaterialApp` widget handling route changes:
 
-```dart
+~~~dart
 import 'package:flet/flet.dart';
 import 'package:flutter/material.dart';
 
@@ -121,7 +121,7 @@ void main() async {
   await setupDesktop();
   runApp(const FletApp(pageUrl: "http://localhost:8550"));
 }
-```
+~~~
 
 Run the program and see Flet app running inside a Flutter app.
 

--- a/sdk/python/packages/flet/docs/controls/markdown.md
+++ b/sdk/python/packages/flet/docs/controls/markdown.md
@@ -26,7 +26,7 @@ example_media: ../examples/controls/markdown/media
 --8<-- "{{ examples }}/code_syntax_highlight.py"
 ```
 
-{{ image(example_images + "/code_syntax_highlight.png", alt="code-syntax-highlight", width="80%") }}
+{{ image(example_media + "/code_syntax_highlight.png", alt="code-syntax-highlight", width="80%") }}
 
 
 ### Custom text theme


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

<!-- If this PR fixes an open issue, please link to the issue here. Ex: Fixes #4562 -->

## Test Code

```python
# Test code for the review of this PR
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I signed the CLA.
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass locally with my changes
- [ ] I have made corresponding changes to the [documentation](https://github.com/flet-dev/website) (if applicable)

## Screenshots 

<!-- Add screenshots here if applicable. -->

## Additional details

<!-- Any additional details to be known about this PR. -->

## Summary by Sourcery

Update Flet extension documentation to reflect the current extension architecture, control types, and usage patterns, along with minor API doc additions.

Enhancements:
- Improve inline documentation for Theme.font_family and Theme.use_material3 to better describe their purpose.

Documentation:
- Revise the user extensions guide with updated steps, code samples, control type explanations, asset paths, and recommendations for LayoutControl, DialogControl, and Service-based extensions.
- Clarify how Python-side default values relate to Dart-side runtime defaults in custom controls and update helper method usage in examples.
- Update dependency version requirements and mkdocs documentation instructions in the extension guide.