### PR TITLE
Add View.shader and move decoration Container behind the main content

### DIFF
--- a/packages/flet/lib/src/controls/view.dart
+++ b/packages/flet/lib/src/controls/view.dart
@@ -286,7 +286,6 @@ class _ViewControlState extends State<ViewControl> {
       var bgContainer = Container(
         decoration: backgroundDecoration,
         foregroundDecoration: foregroundDecoration,
-        child: result,
       );
       result = Stack(
         fit: StackFit.expand,

--- a/packages/flet/lib/src/controls/view.dart
+++ b/packages/flet/lib/src/controls/view.dart
@@ -15,6 +15,8 @@ import '../utils/box.dart';
 import '../utils/buttons.dart';
 import '../utils/colors.dart';
 import '../utils/edge_insets.dart';
+import '../utils/gradient.dart';
+import '../utils/images.dart';
 import '../utils/numbers.dart';
 import '../utils/theme.dart';
 import '../widgets/loading_page.dart';
@@ -268,14 +270,27 @@ class _ViewControlState extends State<ViewControl> {
               )
             : scaffold);
 
+    var shaderGradient = control.getGradient("shader", Theme.of(context));
+    if (shaderGradient != null) {
+      result = ShaderMask(
+        shaderCallback: (bounds) => shaderGradient.createShader(bounds),
+        blendMode: control.getBlendMode("blend_mode", BlendMode.modulate)!,
+        child: result,
+      );
+    }
+
     var backgroundDecoration = control.getBoxDecoration("decoration", context);
     var foregroundDecoration =
         control.getBoxDecoration("foreground_decoration", context);
     if (backgroundDecoration != null || foregroundDecoration != null) {
-      result = Container(
+      var bgContainer = Container(
         decoration: backgroundDecoration,
         foregroundDecoration: foregroundDecoration,
         child: result,
+      );
+      result = Stack(
+        fit: StackFit.expand,
+        children: [bgContainer, result],
       );
     }
 

--- a/packages/flet/lib/src/controls/view.dart
+++ b/packages/flet/lib/src/controls/view.dart
@@ -270,15 +270,6 @@ class _ViewControlState extends State<ViewControl> {
               )
             : scaffold);
 
-    var shaderGradient = control.getGradient("shader", Theme.of(context));
-    if (shaderGradient != null) {
-      result = ShaderMask(
-        shaderCallback: (bounds) => shaderGradient.createShader(bounds),
-        blendMode: control.getBlendMode("blend_mode", BlendMode.modulate)!,
-        child: result,
-      );
-    }
-
     var backgroundDecoration = control.getBoxDecoration("decoration", context);
     var foregroundDecoration =
         control.getBoxDecoration("foreground_decoration", context);
@@ -290,6 +281,15 @@ class _ViewControlState extends State<ViewControl> {
       result = Stack(
         fit: StackFit.expand,
         children: [bgContainer, result],
+      );
+    }
+
+    var shaderGradient = control.getGradient("shader", Theme.of(context));
+    if (shaderGradient != null) {
+      result = ShaderMask(
+        shaderCallback: (bounds) => shaderGradient.createShader(bounds),
+        blendMode: control.getBlendMode("blend_mode", BlendMode.modulate)!,
+        child: result,
       );
     }
 

--- a/sdk/python/packages/flet/src/flet/controls/core/view.py
+++ b/sdk/python/packages/flet/src/flet/controls/core/view.py
@@ -7,6 +7,7 @@ from flet.controls.control import Control
 from flet.controls.control_event import ControlEventHandler
 from flet.controls.cupertino.cupertino_app_bar import CupertinoAppBar
 from flet.controls.cupertino.cupertino_navigation_bar import CupertinoNavigationBar
+from flet.controls.gradients import Gradient
 from flet.controls.layout_control import LayoutControl
 from flet.controls.material.app_bar import AppBar
 from flet.controls.material.bottom_app_bar import BottomAppBar
@@ -18,6 +19,7 @@ from flet.controls.scrollable_control import ScrollableControl
 from flet.controls.services.service import Service
 from flet.controls.transform import OffsetValue
 from flet.controls.types import (
+    BlendMode,
     ColorValue,
     CrossAxisAlignment,
     FloatingActionButtonLocation,
@@ -154,6 +156,16 @@ class View(ScrollableControl, LayoutControl):
     foreground_decoration: Optional[BoxDecoration] = None
     """
     The foreground decoration.
+    """
+
+    shader: Optional[Gradient] = None
+    """
+    Use gradient as a shader.
+    """
+
+    blend_mode: BlendMode = BlendMode.MODULATE
+    """
+    The blend mode to use when applying the shader
     """
 
     fullscreen_dialog: bool = False


### PR DESCRIPTION
## Description

The `View` rendering order has been updated so the `decoration container` is moved to the background and is now rendered fully behind the main content, including `foreground_decoration`. This fixes issues where decorations could overlap or interfere with content rendering. In addition, a new `shader` property (with configurable `blend_mode`) is introduced to preserve the previous behavior where `foreground_decoration` was visually applied on top of all other content.

Fixes https://github.com/flet-dev/flet/issues/6094

## Test Code

```python
# Test code for the review of this PR
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] I signed the CLA.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes
- [x] I have made corresponding changes to the [documentation](https://github.com/flet-dev/website) (if applicable)

## Summary by Sourcery

Update view rendering to place background decorations behind main content and introduce configurable shader-based foreground effects.

New Features:
- Add a shader gradient and blend mode properties to views to apply customizable shader effects over the content.

Enhancements:
- Change view decoration composition so the decoration container is rendered behind the main content while retaining an overlay effect via shaders.