### PR TITLE
Fix `flet_rive` extension to work with Rive 0.14.2 update

### DIFF
--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -173,10 +173,10 @@ packages:
     dependency: transitive
     description:
       name: cross_file
-      sha256: "701dcfc06da0882883a2657c445103380e53e647060ad8d9dfb710c100996608"
+      sha256: "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.5+1"
+    version: "0.3.5+2"
   crypto:
     dependency: transitive
     description:
@@ -668,10 +668,10 @@ packages:
     dependency: transitive
     description:
       name: hooks
-      sha256: "5d309c86e7ce34cd8e37aa71cb30cb652d3829b900ab145e4d9da564b31d59f7"
+      sha256: "7a08a0d684cb3b8fb604b78455d5d352f502b68079f7b80b831c62220ab0a4f6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   http:
     dependency: transitive
     description:
@@ -1145,50 +1145,50 @@ packages:
     dependency: transitive
     description:
       name: record_android
-      sha256: "9aaf3f151e61399b09bd7c31eb5f78253d2962b3f57af019ac5a2d1a3afdcf71"
+      sha256: "3bb3c6abbcb5fc1e86719fc6f0acdee89dfe8078543b92caad11854c487e435a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.5"
+    version: "1.5.0"
   record_ios:
     dependency: transitive
     description:
       name: record_ios
-      sha256: "69fcd37c6185834e90254573599a9165db18a2cbfa266b6d1e46ffffeb06a28c"
+      sha256: "8df7c136131bd05efc19256af29b2ba6ccc000ccc2c80d4b6b6d7a8d21a3b5a9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.5"
+    version: "1.2.0"
   record_linux:
     dependency: transitive
     description:
       name: record_linux
-      sha256: "235b1f1fb84e810f8149cc0c2c731d7d697f8d1c333b32cb820c449bf7bb72d8"
+      sha256: c31a35cc158cd666fc6395f7f56fc054f31685571684be6b97670a27649ce5c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   record_macos:
     dependency: transitive
     description:
       name: record_macos
-      sha256: "842ea4b7e95f4dd237aacffc686d1b0ff4277e3e5357865f8d28cd28bc18ed95"
+      sha256: f04d1547ff61ae54b4154e9726f656a17ad993f1a90f8f44bc40de94bafa072f
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.2.0"
   record_platform_interface:
     dependency: transitive
     description:
       name: record_platform_interface
-      sha256: b0065fdf1ec28f5a634d676724d388a77e43ce7646fb049949f58c69f3fcb4ed
+      sha256: "8a81dbc4e14e1272a285bbfef6c9136d070a47d9b0d1f40aa6193516253ee2f6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   record_web:
     dependency: transitive
     description:
       name: record_web
-      sha256: "3feeffbc0913af3021da9810bb8702a068db6bc9da52dde1d19b6ee7cb9edb51"
+      sha256: "7e9846981c1f2d111d86f0ae3309071f5bba8b624d1c977316706f08fc31d16d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.3.0"
   record_windows:
     dependency: transitive
     description:
@@ -1201,18 +1201,18 @@ packages:
     dependency: transitive
     description:
       name: rive
-      sha256: d3901d82850e17395a149d05c8b446a16eca42b328bac6ca9bd9ed760016f20c
+      sha256: df0b211b042bcc900ebc97b171a825f3ab2d0e0d8708dd71bc51c3ba459d0621
       url: "https://pub.dev"
     source: hosted
-    version: "0.14.1"
+    version: "0.14.2"
   rive_native:
     dependency: transitive
     description:
       name: rive_native
-      sha256: "955e7820b7cd508f4885aa6f25d6240791c932756291c400326ab8b1f3c57c7d"
+      sha256: "64952cd010d0d745d4ac78978be6db44136e618ff7791d408d5a4736aab8a74e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.1"
+    version: "0.1.2"
   safe_local_storage:
     dependency: transitive
     description:

--- a/sdk/python/packages/flet-rive/src/flutter/flet_rive/lib/src/rive.dart
+++ b/sdk/python/packages/flet-rive/src/flutter/flet_rive/lib/src/rive.dart
@@ -227,7 +227,6 @@ base class _RiveMultiAnimationPainter extends rive.BasicArtboardPainter
   double speedMultiplier;
   final List<rive.Animation> _animations = [];
   final List<rive.StateMachine> _stateMachines = [];
-  final List<rive.CallbackHandler> _inputHandlers = [];
   bool _previousHit = false;
 
   @override
@@ -239,7 +238,7 @@ base class _RiveMultiAnimationPainter extends rive.BasicArtboardPainter
       final machine = artboard.defaultStateMachine();
       if (machine != null) {
         _stateMachines.add(machine);
-        _inputHandlers.add(machine.onInputChanged(_onInputChanged));
+        machine.addAdvanceRequestListener(_onAdvanceRequested);
       } else if (artboard.animationCount() > 0) {
         _animations.add(artboard.animationAt(0));
       }
@@ -255,7 +254,7 @@ base class _RiveMultiAnimationPainter extends rive.BasicArtboardPainter
         final machine = artboard.stateMachine(name);
         if (machine != null) {
           _stateMachines.add(machine);
-          _inputHandlers.add(machine.onInputChanged(_onInputChanged));
+          machine.addAdvanceRequestListener(_onAdvanceRequested);
         }
       }
     }
@@ -263,7 +262,7 @@ base class _RiveMultiAnimationPainter extends rive.BasicArtboardPainter
     notifyListeners();
   }
 
-  void _onInputChanged(int inputId) {
+  void _onAdvanceRequested() {
     notifyListeners();
   }
 
@@ -334,7 +333,7 @@ base class _RiveMultiAnimationPainter extends rive.BasicArtboardPainter
         return false;
       }
       final scaled = elapsedSeconds * speedMultiplier;
-      return artboard.advance(scaled) || artboard.updatePass();
+      return artboard.advance(scaled);
     }
 
     var advanced = false;
@@ -354,13 +353,10 @@ base class _RiveMultiAnimationPainter extends rive.BasicArtboardPainter
     }
     _animations.clear();
     for (final machine in _stateMachines) {
+      machine.removeAdvanceRequestListener(_onAdvanceRequested);
       machine.dispose();
     }
     _stateMachines.clear();
-    for (final handler in _inputHandlers) {
-      handler.dispose();
-    }
-    _inputHandlers.clear();
   }
 
   @override


### PR DESCRIPTION
Update pubspec.lock with newer transitive package versions and checksums (cross_file, hooks, record_* packages, rive, rive_native, etc.). Adapt Rive usage in rive.dart to the newer API: replace machine.onInputChanged handlers with addAdvanceRequestListener/_onAdvanceRequested, remove the _inputHandlers list and its disposal, remove artboard.updatePass() from the advance check, and ensure advance request listeners are removed on dispose. These changes align the code with updated Rive package behavior and dependency updates.

## Summary by Sourcery

Update Rive integration to be compatible with the Rive 0.14.2 API and clean up obsolete listeners and handlers.

Enhancements:
- Switch Rive state machine usage from input change handlers to advance request listeners to align with the updated Rive API.
- Simplify artboard advancing logic by relying solely on artboard.advance and removing the extra update pass.
- Ensure Rive state machines correctly unregister advance request listeners on dispose to prevent leaks and stale callbacks.

Build:
- Refresh pubspec.lock to newer transitive dependency versions and checksums for Rive and related packages.