### PR TITLE
Register MIME types for .mjs and .wasm

### DIFF
--- a/sdk/python/packages/flet-web/src/flet_web/fastapi/flet_static_files.py
+++ b/sdk/python/packages/flet-web/src/flet_web/fastapi/flet_static_files.py
@@ -1,4 +1,5 @@
 import logging
+import mimetypes
 import os
 import shutil
 import tempfile
@@ -20,6 +21,11 @@ from flet_web import (
 from flet_web.fastapi.flet_app_manager import app_manager
 
 logger = logging.getLogger(flet_fastapi.__name__)
+
+# Ensure correct MIME types on platforms (e.g. Windows)
+# that do not register them by default.
+mimetypes.add_type("text/javascript", ".mjs")
+mimetypes.add_type("application/wasm", ".wasm")
 
 
 class FletStaticFiles(StaticFiles):


### PR DESCRIPTION
Fix #6057

Add mimetypes import and register text/javascript for .mjs and application/wasm for .wasm to ensure correct MIME types when serving static files (fixes platforms like Windows that don't register these by default). The calls are made at module import time near the logger initialization.

## Summary by Sourcery

Bug Fixes:
- Register explicit MIME types for .mjs (text/javascript) and .wasm (application/wasm) to fix incorrect or missing MIME types on platforms that do not provide them by default.