### PR TITLE
Optimize object_patch memory churn

### DIFF
--- a/sdk/python/packages/flet/tests/test_object_diff_memory_churn.py
+++ b/sdk/python/packages/flet/tests/test_object_diff_memory_churn.py
@@ -1,0 +1,64 @@
+import gc
+import tracemalloc
+
+import flet as ft
+from flet.controls.base_control import BaseControl
+from flet.controls.object_patch import ObjectPatch
+
+
+def _make_tree(iteration: int, size: int = 36) -> ft.Column:
+    controls: list[ft.Text] = []
+    offset = iteration % size
+    for i in range(size):
+        key = (i + offset) % size
+        value = f"Item {key}"
+        if i == (iteration % 7):
+            value = f"{value}*{iteration % 5}"
+        controls.append(ft.Text(value=value, key=key))
+    return ft.Column(controls=controls)
+
+
+def _object_patch_size(snapshot: tracemalloc.Snapshot) -> int:
+    total = 0
+    for stat in snapshot.statistics("filename"):
+        frame = stat.traceback[0]
+        if frame.filename.endswith("flet/controls/object_patch.py"):
+            total += stat.size
+    return total
+
+
+def test_object_diff_churn_memory_growth_is_bounded():
+    iterations = 480
+    sample_step = 80
+    warmup = 160
+
+    previous = _make_tree(0)
+    previous._frozen = True
+
+    tracemalloc.start(10)
+    samples: list[int] = []
+    try:
+        for i in range(1, iterations + 1):
+            current = _make_tree(i)
+            ObjectPatch.from_diff(previous, current, control_cls=BaseControl)
+            previous = current
+            previous._frozen = True
+
+            if i % sample_step == 0:
+                gc.collect()
+                samples.append(_object_patch_size(tracemalloc.take_snapshot()))
+    finally:
+        tracemalloc.stop()
+
+    steady_state = [
+        size for idx, size in enumerate(samples, start=1) if idx * sample_step >= warmup
+    ]
+    assert steady_state, samples
+
+    baseline = steady_state[0]
+    final = steady_state[-1]
+    max_steady = max(steady_state)
+
+    # In steady state this should stay near a plateau, not grow linearly with churn.
+    assert final - baseline < 500_000, (baseline, final, steady_state)
+    assert max_steady - baseline < 700_000, (baseline, max_steady, steady_state)


### PR DESCRIPTION
Reduce memory churn and redundant per-instance monkeypatching in object_patch.py. Add a shared _control_setattr and install it once on control classes (and set a __flet_control_cls__ marker) instead of assigning __setattr__ on every instance. Introduce typed index storage and a safer fallback format to avoid expensive hashing and TypeError paths. Add helper methods to update list/dict snapshots in-place (preserving references) rather than replacing them. Update uses throughout DiffBuilder to use these helpers. Add a new test (test_object_diff_memory_churn.py) that verifies steady-state memory growth remains bounded under repeated diffs.

## Summary by Sourcery

Reduce memory churn and stabilize memory usage in object patching and diff building by reusing control setattr logic, optimizing index storage, and updating collection snapshots in place.

Enhancements:
- Share a single _control_setattr implementation across control classes and mark configured classes to avoid per-instance monkeypatching.
- Optimize index storage in DiffBuilder with typed buckets and a safer fallback format to reduce hashing overhead and TypeError handling.
- Introduce helper methods to update list and dict snapshots in place to preserve references and avoid unnecessary allocations during diffs.

Tests:
- Add a memory churn regression test that ensures object_patch steady-state memory growth remains bounded under repeated diffs.