### PR TITLE
fix: enforce disabled state across `Tabs`, `TabBar`, `Tab` and `TabBarView`

### DIFF
--- a/packages/flet/lib/src/controls/tabs.dart
+++ b/packages/flet/lib/src/controls/tabs.dart
@@ -175,6 +175,8 @@ class TabBarViewControl extends StatelessWidget {
             clipBehavior:
                 control.getClipBehavior("clip_behavior", Clip.hardEdge)!,
             viewportFraction: control.getDouble("viewport_fraction", 1.0)!,
+            physics:
+                control.disabled ? const NeverScrollableScrollPhysics() : null,
             children: control.buildWidgets("controls"),
           ));
     }
@@ -295,6 +297,8 @@ class _TabBarControlState extends State<TabBarControl> {
           .getTextStyle("unselected_label_text_style", Theme.of(context));
       var splashBorderRadius =
           widget.control.getBorderRadius("splash_border_radius");
+
+      final tabBarDisabled = widget.control.disabled;
       final tabControls = widget.control.children("tabs");
       final tabs = tabControls.map((tab) {
         // Ensure parent gets rebuilt when a tab becomes visible/invisible.
@@ -311,9 +315,10 @@ class _TabBarControlState extends State<TabBarControl> {
       }).toList();
 
       void onTap(int index) {
-        if (index >= 0 &&
-            index < tabControls.length &&
-            tabControls[index].disabled) {
+        if (tabBarDisabled ||
+            (index >= 0 &&
+                index < tabControls.length &&
+                tabControls[index].disabled)) {
           final fallbackIndex = tabController.previousIndex
               .clamp(0, tabController.length - 1)
               .toInt();
@@ -329,6 +334,13 @@ class _TabBarControlState extends State<TabBarControl> {
       }
 
       void onHover(bool hovering, int? index) {
+        if (tabBarDisabled ||
+            (index != null &&
+                index >= 0 &&
+                index < tabControls.length &&
+                tabControls[index].disabled)) {
+          return;
+        }
         widget.control
             .triggerEvent("hover", {"hovering": hovering, "index": index});
       }
@@ -398,7 +410,10 @@ class _TabBarControlState extends State<TabBarControl> {
             onHover: onHover);
       }
 
-      return BaseControl(control: widget.control, child: tabBar);
+      return BaseControl(
+        control: widget.control,
+        child: IgnorePointer(ignoring: tabBarDisabled, child: tabBar),
+      );
     } else {
       return const ErrorControl("TabBar must be used within a Tabs control");
     }

--- a/sdk/python/packages/flet/integration_tests/controls/material/test_tabs.py
+++ b/sdk/python/packages/flet/integration_tests/controls/material/test_tabs.py
@@ -146,7 +146,7 @@ async def test_disabled_tab(flet_app: ftt.FletTestApp):
     flet_app.page.update()
     await flet_app.tester.pump_and_settle()
 
-    # click (disabled) tab2
+    # click tab2 (disabled)
     await flet_app.tester.tap((await flet_app.tester.find_by_text("Tab 2")).first)
     await flet_app.tester.pump_and_settle()
     assert tabs.selected_index == 0
@@ -162,3 +162,112 @@ async def test_disabled_tab(flet_app: ftt.FletTestApp):
     await flet_app.tester.pump_and_settle()
     assert tabs.selected_index == 1
     assert clicked_indexes == [1, 1]
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_disabled_tabbar(flet_app: ftt.FletTestApp):
+    clicked_indexes = []
+    flet_app.page.padding = 0
+    flet_app.resize_page(300, 300)
+    flet_app.page.add(
+        tabs := ft.Tabs(
+            selected_index=0,
+            length=3,
+            expand=True,
+            content=ft.Column(
+                expand=True,
+                controls=[
+                    tab_bar := ft.TabBar(
+                        disabled=True,
+                        scrollable=False,
+                        on_click=lambda e: clicked_indexes.append(int(e.data)),
+                        tabs=[
+                            ft.Tab(label="Tab 1"),
+                            ft.Tab(label="Tab 2"),
+                            ft.Tab(label="Tab 3"),
+                        ],
+                    ),
+                    ft.TabBarView(
+                        expand=True,
+                        controls=[
+                            ft.Text("View 1"),
+                            ft.Text("View 2"),
+                            ft.Text("View 3"),
+                        ],
+                    ),
+                ],
+            ),
+        )
+    )
+    await flet_app.tester.pump_and_settle()
+
+    # click tab2 (disabled TabBar)
+    await flet_app.tester.tap((await flet_app.tester.find_by_text("Tab 2")).first)
+    await flet_app.tester.pump_and_settle()
+    assert tabs.selected_index == 0
+    assert clicked_indexes == []
+
+    # re-enable tabbar
+    tab_bar.disabled = False
+    flet_app.page.update()
+    await flet_app.tester.pump_and_settle()
+
+    await flet_app.tester.tap((await flet_app.tester.find_by_text("Tab 2")).first)
+    await flet_app.tester.pump_and_settle()
+    assert tabs.selected_index == 1
+    assert clicked_indexes == [1]
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_disabled_tabs(flet_app: ftt.FletTestApp):
+    clicked_indexes = []
+    flet_app.page.padding = 0
+    flet_app.resize_page(300, 300)
+    flet_app.page.add(
+        tabs := ft.Tabs(
+            disabled=True,
+            selected_index=0,
+            length=3,
+            expand=True,
+            content=ft.Column(
+                expand=True,
+                controls=[
+                    ft.TabBar(
+                        scrollable=False,
+                        on_click=lambda e: clicked_indexes.append(int(e.data)),
+                        tabs=[
+                            ft.Tab(label="Tab 1"),
+                            ft.Tab(label="Tab 2"),
+                            ft.Tab(label="Tab 3"),
+                        ],
+                    ),
+                    ft.TabBarView(
+                        expand=True,
+                        controls=[
+                            ft.Text("View 1"),
+                            ft.Text("View 2"),
+                            ft.Text("View 3"),
+                        ],
+                    ),
+                ],
+            ),
+        )
+    )
+    await flet_app.tester.pump_and_settle()
+
+    # click tab2 (disabled Tabs)
+    await flet_app.tester.tap((await flet_app.tester.find_by_text("Tab 2")).first)
+    await flet_app.tester.pump_and_settle()
+    assert tabs.selected_index == 0
+    assert clicked_indexes == []
+
+    # re-enable Tabs
+    tabs.disabled = False
+    flet_app.page.update()
+    await flet_app.tester.pump_and_settle()
+
+    # click tab2
+    await flet_app.tester.tap((await flet_app.tester.find_by_text("Tab 2")).first)
+    await flet_app.tester.pump_and_settle()
+    assert tabs.selected_index == 1
+    assert clicked_indexes == [1]


### PR DESCRIPTION
Fix #6220

## Summary by Sourcery

Enforce disabled state behavior across Tabs, TabBar, Tab, and TabBarView and add coverage for these scenarios.

Bug Fixes:
- Prevent disabled tabs and tab bars from changing selection or emitting click/hover events.
- Disable swiping between views when TabBarView is disabled by its parent Tabs control.

Tests:
- Add integration tests verifying disabled behavior for individual tabs, the entire TabBar, and the Tabs container.
- Adjust tabs integration test setup to create a fresh Flet app per test function for isolation.