### PR TITLE
Prevent external updates during composition/focus

### DIFF
--- a/sdk/python/packages/flet-code-editor/src/flutter/flet_code_editor/lib/src/code_editor.dart
+++ b/sdk/python/packages/flet-code-editor/src/flutter/flet_code_editor/lib/src/code_editor.dart
@@ -22,6 +22,8 @@ class _CodeEditorControlState extends State<CodeEditorControl> {
   TextSelection? _selection;
   String _value = "";
   String? _languageName;
+  String? _lastControlValue;
+  TextSelection? _lastControlSelection;
 
   @override
   void initState() {
@@ -31,6 +33,12 @@ class _CodeEditorControlState extends State<CodeEditorControl> {
     _controller = _createController();
     _value = _readValue();
     _selection = _controller.selection;
+    _lastControlValue = widget.control.getString("value");
+    _lastControlSelection = widget.control.getTextSelection(
+      "selection",
+      minOffset: 0,
+      maxOffset: _controller.text.length,
+    );
     _controller.addListener(_handleControllerChange);
     widget.control.addInvokeMethodListener(_invokeMethod);
   }
@@ -97,6 +105,20 @@ class _CodeEditorControlState extends State<CodeEditorControl> {
     _controller.fullText = value;
   }
 
+  bool get _isComposing {
+    final composing = _controller.value.composing;
+    return composing.isValid && !composing.isCollapsed;
+  }
+
+  bool _shouldApplyExternalState({
+    required bool incomingChanged,
+  }) {
+    if (!_focusNode.hasFocus) {
+      return true;
+    }
+    return incomingChanged && !_isComposing;
+  }
+
   void _handleControllerChange() {
     final value = _readValue();
     final selection = _controller.selection;
@@ -160,7 +182,11 @@ class _CodeEditorControlState extends State<CodeEditorControl> {
 
     final value = widget.control.getString("value");
     final controllerValue = _readValue();
-    if (value != null && value != controllerValue) {
+    final valueChangedInControl = value != _lastControlValue;
+    _lastControlValue = value;
+    if (value != null &&
+        value != controllerValue &&
+        _shouldApplyExternalState(incomingChanged: valueChangedInControl)) {
       _setValue(value);
       _value = value;
     }
@@ -170,7 +196,11 @@ class _CodeEditorControlState extends State<CodeEditorControl> {
       minOffset: 0,
       maxOffset: _controller.text.length,
     );
-    if (explicitSelection != null && explicitSelection != _controller.selection) {
+    final selectionChangedInControl = explicitSelection != _lastControlSelection;
+    _lastControlSelection = explicitSelection;
+    if (explicitSelection != null &&
+        explicitSelection != _controller.selection &&
+        _shouldApplyExternalState(incomingChanged: selectionChangedInControl)) {
       _controller.selection = explicitSelection;
     }
 


### PR DESCRIPTION
Track the last control-provided value and selection and avoid applying external value/selection updates while the editor has focus and the user is composing text. Added _lastControlValue and _lastControlSelection, an _isComposing getter, and _shouldApplyExternalState to gate updates. Value/selection handlers now only apply control changes when they actually changed in the control and applying them won't interfere with an in-progress composition or focused editing session.

Fix #6211

## Summary by Sourcery

Prevent external value and selection updates from interfering with in-progress text composition or focused editing in the code editor control.

Bug Fixes:
- Avoid overwriting the editor content with external value updates while the editor has focus and the user is composing text.
- Avoid applying external selection changes from the control when they would conflict with the current focused editing or composition state.

Enhancements:
- Track the last control-provided value and selection so external updates are only applied when they actually change.