### PR TITLE
hotfix: `Null check operator used on a null value` in `WebView`

### DIFF
--- a/sdk/python/packages/flet-webview/src/flutter/flet_webview/lib/src/utils/webview.dart
+++ b/sdk/python/packages/flet-webview/src/flutter/flet_webview/lib/src/utils/webview.dart
@@ -8,5 +8,5 @@ LoadRequestMethod? parseLoadRequestMethod(String? value,
 
 JavaScriptMode? parseJavaScriptMode(String? value,
     [JavaScriptMode? defaultValue]) {
-  return parseEnum(JavaScriptMode.values, value);
+  return parseEnum(JavaScriptMode.values, value, defaultValue);
 }


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix potential null check operator errors in WebView by forwarding default enum values in parsing helpers.