### PR TITLE
Lazy-import oauthlib/httpx and relax token type hint

### DIFF
--- a/sdk/python/packages/flet/src/flet/auth/authorization_service.py
+++ b/sdk/python/packages/flet/src/flet/auth/authorization_service.py
@@ -3,10 +3,6 @@ import secrets
 import time
 from typing import Optional
 
-import httpx
-from oauthlib.oauth2 import WebApplicationClient
-from oauthlib.oauth2.rfc6749.tokens import OAuth2Token
-
 from flet.auth.authorization import Authorization
 from flet.auth.oauth_provider import OAuthProvider
 from flet.auth.oauth_token import OAuthToken
@@ -95,6 +91,8 @@ class AuthorizationService(Authorization):
             A tuple of `(authorization_url, state)`.
         """
 
+        from oauthlib.oauth2 import WebApplicationClient
+
         self.state = secrets.token_urlsafe(16)
         client = WebApplicationClient(self.provider.client_id)
         authorization_url = client.prepare_request_uri(
@@ -118,6 +116,9 @@ class AuthorizationService(Authorization):
         Raises:
             httpx.HTTPStatusError: If token endpoint returns a non-success status.
         """
+
+        import httpx
+        from oauthlib.oauth2 import WebApplicationClient
 
         client = WebApplicationClient(self.provider.client_id)
         data = client.prepare_request_body(
@@ -165,7 +166,7 @@ class AuthorizationService(Authorization):
                     self.__token.access_token
                 )
 
-    def __convert_token(self, t: OAuth2Token):
+    def __convert_token(self, t):
         """
         Convert oauthlib token mapping to [`OAuthToken`][(p).oauth_token.].
 
@@ -204,6 +205,9 @@ class AuthorizationService(Authorization):
         ):
             return None
 
+        import httpx
+        from oauthlib.oauth2 import WebApplicationClient
+
         assert self.__token is not None
         client = WebApplicationClient(self.provider.client_id)
         data = client.prepare_refresh_body(
@@ -239,6 +243,8 @@ class AuthorizationService(Authorization):
         Raises:
             httpx.HTTPStatusError: If user endpoint request fails.
         """
+
+        import httpx
 
         assert self.__token is not None
         assert self.provider.user_endpoint is not None


### PR DESCRIPTION
Move imports of oauthlib.WebApplicationClient and httpx from module top-level into the functions that use them to enable lazy importing and avoid import-time dependency issues. Also remove the explicit OAuth2Token type annotation from __convert_token to avoid importing oauthlib types at module import. These changes reduce startup import overhead and make the module safer when oauthlib/httpx may not be available until runtime.

Fix #6258

## Summary by Sourcery

Make OAuth-related imports lazy and relax token typing to avoid import-time dependencies and reduce startup overhead.

Enhancements:
- Move oauthlib WebApplicationClient and httpx imports inside the authorization and token-handling methods to enable lazy loading.
- Remove the explicit OAuth2Token type annotation from the internal token conversion helper to prevent importing oauthlib types at module import time.