### PR TITLE
fix: Pin binaryornot below `v0.5` to prevent build-template UTF-8 decode errors

### DIFF
--- a/sdk/python/packages/flet-cli/pyproject.toml
+++ b/sdk/python/packages/flet-cli/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "qrcode >=7.4.2",
     "tomli >= 1.1.0 ; python_version < '3.11'",
     "cookiecutter >=2.6.0",
+    "binaryornot <0.5",
     "chardet <6"
 ]
 


### PR DESCRIPTION
Fix #6276