### PR TITLE
Prepare 0.82.1 release

### DIFF
--- a/.codex/skills/prepare-flet-release/SKILL.md
+++ b/.codex/skills/prepare-flet-release/SKILL.md
@@ -13,22 +13,24 @@ description: Use when asked to prepare new Flet release by bumping versions and 
 * Take latest Flet release version from the repo and
   increment third (patch) digit to get the next version if it's a minor release
   or second (minor) digit if it's a major release.
+* Pull the latest `main` and create a new branch named `prepare-release-{new_version}` from `main`.
 * Set new version in packages/flet/pubspec.yaml.
 * Run pub get in /client dir to refresh pubspec.lock with new version.
 * Add a new entry into packages/flet/CHANGELOG.md from a git log since the last release. Go through all commits and collect all mentioned issues and pull requests. There could be several issues done in a single PR (commit) - group them by creating a single descriptive change/fix/feature item and put all issues and PR links in `[#<issue_number>](<issue_url>)` format in braces next to it. Do not add chore/trivial/duplicate items.
   Every changelog item must include both related issue link(s) and PR link(s) when available (issue first, PR second). If no issue exists, include PR link(s) only.
   Also include issue-only items when a change was done via direct commit without PR (for example, an issue referenced in commit context but no PR exists).
-  Every changelog item must include author attribution in GitHub style: `by @<github_login>`.
+  Every changelog item must include author attribution as a GitHub profile link: `by [@<github_login>](https://github.com/<github_login>)`.
   Place attribution at the end of each item after links, for example:
-  `* Added feature X ([#123](...), [#456](...)) by @contributor.`
+  `* Added feature X ([#123](...), [#456](...)) by [@contributor](https://github.com/contributor).`
   Use PR author login for PR-based items. For issue-only direct-commit items, use the commit author GitHub login if available.
   If one item groups multiple PRs by different authors, attribute all relevant authors:
-  `by @user1, @user2`.
+  `by [@user1](https://github.com/user1), [@user2](https://github.com/user2)`.
+  Ensure that all infered PRs and issues in the changelog have `{version}` milestone attached on GitHub.
   As it's a Flutter package prefer items having changes on Flutter side.
 * Add a new entry into /CHANGELOG.md. Do not add chore/trivial/duplicate items, add "worth while" items with related issue or PR.
   Every changelog item must include both related issue link(s) and PR link(s) when available (issue first, PR second). If no issue exists, include PR link(s) only.
   Also include issue-only items when a change was done via direct commit without PR (for example, an issue referenced in commit context but no PR exists).
-  Every changelog item must include author attribution in GitHub style: `by @<github_login>`.
+  Every changelog item must include author attribution as a GitHub profile link: `by [@<github_login>](https://github.com/<github_login>)`.
   Use PR author login for PR-based items. For issue-only direct-commit items, use the commit author GitHub login if available.
 * Scan all changelogs for `Unreleased` sections, not only the root ones:
   * `/CHANGELOG.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.82.1
+
+### Bug fixes
+
+* Lazy-load optional auth dependencies to avoid import-time failures in web/Pyodide startup ([#6258](https://github.com/flet-dev/flet/issues/6258), [#6280](https://github.com/flet-dev/flet/pull/6280)) by [@ndonkoHenri](https://github.com/ndonkoHenri).
+* Pin `binaryornot` below `0.5` to fix build-template UTF-8 decode errors ([#6276](https://github.com/flet-dev/flet/issues/6276), [#6279](https://github.com/flet-dev/flet/pull/6279)) by [@ndonkoHenri](https://github.com/ndonkoHenri).
+
 ## 0.82.0
 
 ### New features

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -359,7 +359,7 @@ packages:
       path: "../packages/flet"
       relative: true
     source: path
-    version: "0.82.0"
+    version: "0.82.1"
   flet_ads:
     dependency: "direct main"
     description:

--- a/packages/flet/CHANGELOG.md
+++ b/packages/flet/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.82.1
+
+### Bug fixes
+
+* Lazy-load optional auth dependencies to avoid import-time failures in web/Pyodide startup ([#6258](https://github.com/flet-dev/flet/issues/6258), [#6280](https://github.com/flet-dev/flet/pull/6280)) by [@ndonkoHenri](https://github.com/ndonkoHenri).
+* Pin `binaryornot` below `0.5` to fix build-template UTF-8 decode errors ([#6276](https://github.com/flet-dev/flet/issues/6276), [#6279](https://github.com/flet-dev/flet/pull/6279)) by [@ndonkoHenri](https://github.com/ndonkoHenri).
+
 ## 0.82.0
 
 ### Improvements

--- a/packages/flet/pubspec.yaml
+++ b/packages/flet/pubspec.yaml
@@ -2,7 +2,7 @@ name: flet
 description: Write entire Flutter app in Python or add server-driven UI experience into existing Flutter app.
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/flet/tree/main/packages/flet
-version: 0.82.0
+version: 0.82.1
 
 # Supported platforms
 platforms:

--- a/sdk/python/packages/flet-ads/CHANGELOG.md
+++ b/sdk/python/packages/flet-ads/CHANGELOG.md
@@ -5,9 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.82.1
 
-### Changed
+### Improvements
 
 - Refactored `BaseAd` class to be based on `flet.BaseControl`.
 - Refactored `InterstitialAd` to a service-based control (`flet.Service`).


### PR DESCRIPTION
## Summary

Prepare `0.82.1` release artifacts:

- bump `packages/flet` version to `0.82.1`
- refresh `client/pubspec.lock`
- add `0.82.1` entries to root and package changelogs
- convert `flet-ads` changelog `Unreleased` section to `0.82.1`
- switch changelog author attributions to linked GitHub profiles
- update release skill guidance to require linked author attribution format

## Notes

- release notes are based on changes since `v0.82.0`
- branch `0.82.1` existence was verified for both template repos during prep

## Summary by Sourcery

Prepare the 0.82.1 patch release including version bumps, changelog updates, and release process guidance tweaks.

Bug Fixes:
- Document and ship fixes for lazy-loading optional auth dependencies to prevent web/Pyodide import-time failures.
- Document and ship a dependency pin for `binaryornot` < 0.5 to resolve build-template UTF-8 decode errors.

Enhancements:
- Finalize the `flet-ads` package 0.82.1 changelog entry, promoting previous unreleased improvements to a tagged release.
- Refine the release preparation skill to require linked GitHub profile attributions, ensure milestones are applied, and include branch creation from main in the workflow.

Build:
- Bump the `packages/flet` package version to 0.82.1 and refresh the client `pubspec.lock` to align with the new release.