### PR TITLE
fix: replace deprecated delta_x/delta_y with local_delta.x/y in examples and docs

### DIFF
--- a/sdk/python/examples/controls/gesture_detector/mouse_cursors.py
+++ b/sdk/python/examples/controls/gesture_detector/mouse_cursors.py
@@ -5,8 +5,8 @@ import flet as ft
 
 def main(page: ft.Page):
     def on_pan_update(event: ft.DragUpdateEvent[ft.GestureDetector]):
-        container.top = max(0.0, container.top + event.delta_y)
-        container.left = max(0.0, container.left + event.delta_x)
+        container.top = max(0.0, container.top + event.local_delta.y)
+        container.left = max(0.0, container.left + event.local_delta.x)
         container.update()
 
     gesture_detector = ft.GestureDetector(

--- a/sdk/python/examples/tutorials/solitaire/solitaire-classes/card.py
+++ b/sdk/python/examples/tutorials/solitaire/solitaire-classes/card.py
@@ -45,8 +45,8 @@ class Card(ft.GestureDetector):
         self.update()
 
     def drag(self, e: ft.DragUpdateEvent):
-        self.top = max(0, self.top + e.delta_y)
-        self.left = max(0, self.left + e.delta_x)
+        self.top = max(0, self.top + e.local_delta.y)
+        self.left = max(0, self.left + e.local_delta.x)
         self.update()
 
     def drop(self, e: ft.DragEndEvent):

--- a/sdk/python/examples/tutorials/solitaire/solitaire-drag-and-drop/step1.py
+++ b/sdk/python/examples/tutorials/solitaire/solitaire-drag-and-drop/step1.py
@@ -6,8 +6,8 @@ import flet as ft
 
 def main(page: ft.Page):
     def drag(e: ft.DragUpdateEvent):
-        e.control.top = max(0, e.control.top + e.delta_y)
-        e.control.left = max(0, e.control.left + e.delta_x)
+        e.control.top = max(0, e.control.top + e.local_delta.y)
+        e.control.left = max(0, e.control.left + e.local_delta.x)
         e.control.update()
 
     card = ft.GestureDetector(

--- a/sdk/python/examples/tutorials/solitaire/solitaire-drag-and-drop/step2.py
+++ b/sdk/python/examples/tutorials/solitaire/solitaire-drag-and-drop/step2.py
@@ -28,8 +28,8 @@ def main(page: ft.Page):
         solitaire.start_left = e.control.left
 
     def drag(e: ft.DragUpdateEvent):
-        e.control.top = max(0, e.control.top + e.delta_y)
-        e.control.left = max(0, e.control.left + e.delta_x)
+        e.control.top = max(0, e.control.top + e.local_delta.y)
+        e.control.left = max(0, e.control.left + e.local_delta.x)
         e.control.update()
 
     def drop(e: ft.DragEndEvent):

--- a/sdk/python/examples/tutorials/solitaire/solitaire-drag-and-drop/step3.py
+++ b/sdk/python/examples/tutorials/solitaire/solitaire-drag-and-drop/step3.py
@@ -33,8 +33,8 @@ def main(page: ft.Page):
         solitaire.start_left = e.control.left
 
     def drag(e: ft.DragUpdateEvent):
-        e.control.top = max(0, e.control.top + e.delta_y)
-        e.control.left = max(0, e.control.left + e.delta_x)
+        e.control.top = max(0, e.control.top + e.local_delta.y)
+        e.control.left = max(0, e.control.left + e.local_delta.x)
         e.control.update()
 
     def drop(e: ft.DragEndEvent):

--- a/sdk/python/examples/tutorials/solitaire/solitaire-drag-and-drop/step4.py
+++ b/sdk/python/examples/tutorials/solitaire/solitaire-drag-and-drop/step4.py
@@ -35,8 +35,8 @@ def main(page: ft.Page):
         solitaire.start_left = e.control.left
 
     def drag(e: ft.DragUpdateEvent):
-        e.control.top = max(0, e.control.top + e.delta_y)
-        e.control.left = max(0, e.control.left + e.delta_x)
+        e.control.top = max(0, e.control.top + e.local_delta.y)
+        e.control.left = max(0, e.control.left + e.local_delta.x)
         e.control.update()
 
     def drop(e: ft.DragEndEvent):

--- a/sdk/python/examples/tutorials/solitaire/solitaire-fanned-piles/card.py
+++ b/sdk/python/examples/tutorials/solitaire/solitaire-fanned-piles/card.py
@@ -74,10 +74,10 @@ class Card(ft.GestureDetector):
     def drag(self, e: ft.DragUpdateEvent):
         for card in self.draggable_pile:
             card.top = (
-                max(0, self.top + e.delta_y)
+                max(0, self.top + e.local_delta.y)
                 + self.draggable_pile.index(card) * CARD_OFFSET
             )
-            card.left = max(0, self.left + e.delta_x)
+            card.left = max(0, self.left + e.local_delta.x)
             self.solitaire.update()
 
     def drop(self, e: ft.DragEndEvent):

--- a/sdk/python/examples/tutorials/solitaire/solitaire-final-part1/card.py
+++ b/sdk/python/examples/tutorials/solitaire/solitaire-final-part1/card.py
@@ -107,10 +107,10 @@ class Card(ft.GestureDetector):
         if self.face_up:
             for card in self.draggable_pile:
                 card.top = (
-                    max(0, self.top + e.delta_y)
+                    max(0, self.top + e.local_delta.y)
                     + self.draggable_pile.index(card) * CARD_OFFSET
                 )
-                card.left = max(0, self.left + e.delta_x)
+                card.left = max(0, self.left + e.local_delta.x)
                 self.solitaire.update()
 
     def drop(self, e: ft.DragEndEvent):

--- a/sdk/python/examples/tutorials/solitaire/solitaire-final/card.py
+++ b/sdk/python/examples/tutorials/solitaire/solitaire-final/card.py
@@ -59,10 +59,10 @@ class Card(ft.GestureDetector):
         if self.can_be_moved():
             i = 0
             for card in self.get_cards_to_move():
-                card.top = max(0, self.top + e.delta_y)
+                card.top = max(0, self.top + e.local_delta.y)
                 if card.slot.type == "tableau":
                     card.top += i * self.solitaire.card_offset
-                card.left = max(0, self.left + e.delta_x)
+                card.left = max(0, self.left + e.local_delta.x)
                 i += 1
             self.solitaire.update()
 

--- a/sdk/python/examples/tutorials/solitaire/solitaire-game-rules/card.py
+++ b/sdk/python/examples/tutorials/solitaire/solitaire-game-rules/card.py
@@ -104,10 +104,10 @@ class Card(ft.GestureDetector):
         if self.face_up:
             for card in self.draggable_pile:
                 card.top = (
-                    max(0, self.top + e.delta_y)
+                    max(0, self.top + e.local_delta.y)
                     + self.draggable_pile.index(card) * CARD_OFFSET
                 )
-                card.left = max(0, self.left + e.delta_x)
+                card.left = max(0, self.left + e.local_delta.x)
                 self.solitaire.update()
 
     def drop(self, e: ft.DragEndEvent):

--- a/sdk/python/examples/tutorials/solitaire/solitaire-game-setup/card.py
+++ b/sdk/python/examples/tutorials/solitaire/solitaire-game-setup/card.py
@@ -90,10 +90,10 @@ class Card(ft.GestureDetector):
     def drag(self, e: ft.DragUpdateEvent):
         for card in self.draggable_pile:
             card.top = (
-                max(0, self.top + e.delta_y)
+                max(0, self.top + e.local_delta.y)
                 + self.draggable_pile.index(card) * CARD_OFFSET
             )
-            card.left = max(0, self.left + e.delta_x)
+            card.left = max(0, self.left + e.local_delta.x)
             self.solitaire.update()
 
     def drop(self, e: ft.DragEndEvent):

--- a/sdk/python/packages/flet/docs/tutorials/solitaire.md
+++ b/sdk/python/packages/flet/docs/tutorials/solitaire.md
@@ -105,8 +105,8 @@ import flet as ft
 
 def main(page: ft.Page):
    def drag(e: ft.DragUpdateEvent):
-       e.control.top = max(0, e.control.top + e.delta_y)
-       e.control.left = max(0, e.control.left + e.delta_x)
+       e.control.top = max(0, e.control.top + e.local_delta.y)
+       e.control.left = max(0, e.control.left + e.local_delta.x)
        e.control.update()
 
    card = ft.GestureDetector(
@@ -424,8 +424,8 @@ class Card(ft.GestureDetector):
        self.update()
 
    def drag(self, e: ft.DragUpdateEvent):
-       self.top = max(0, self.top + e.delta_y)
-       self.left = max(0, self.left + e.delta_x)
+       self.top = max(0, self.top + e.local_delta.y)
+       self.left = max(0, self.left + e.local_delta.x)
        self.update()
 
    def drop(self, e: ft.DragEndEvent):
@@ -585,10 +585,10 @@ positions of all the cards being dragged:
     def drag(self, e: ft.DragUpdateEvent):
         for card in self.draggable_pile:
             card.top = (
-                max(0, self.top + e.delta_y)
+                max(0, self.top + e.local_delta.y)
                 + self.draggable_pile.index(card) * CARD_OFFSET
             )
-            card.left = max(0, self.left + e.delta_x)
+            card.left = max(0, self.left + e.local_delta.x)
             self.solitaire.update()
 ```
 
@@ -910,8 +910,8 @@ def start_drag(self, e: ft.DragStartEvent):
 def drag(self, e: ft.DragUpdateEvent):
     if self.face_up:
         for card in self.draggable_pile:
-            card.top = max(0, self.top + e.delta_y) + self.draggable_pile.index(card) * CARD_OFFSET
-            card.left = max(0, self.left + e.delta_x)
+            card.top = max(0, self.top + e.local_delta.y) + self.draggable_pile.index(card) * CARD_OFFSET
+            card.left = max(0, self.left + e.local_delta.x)
             card.solitaire.update()
 
 def drop(self, e: ft.DragEndEvent):


### PR DESCRIPTION
## Summary
- Replaces all usages of the removed `e.delta_x` and `e.delta_y` attributes on `DragUpdateEvent` with the correct `e.local_delta.x` and `e.local_delta.y` properties across all solitaire tutorial examples, the gesture detector mouse cursors example, and the solitaire tutorial documentation.
- `DragUpdateEvent` no longer exposes `delta_x`/`delta_y` — these were replaced by the `local_delta` `Offset` object (with `.x` and `.y` attributes), causing an `AttributeError` when running any of the affected examples.

Fixes #6317

## Files Changed (12 files)
**Example code (11 .py files):**
- `solitaire-drag-and-drop/step1.py`, `step2.py`, `step3.py`, `step4.py`
- `solitaire-classes/card.py`
- `solitaire-fanned-piles/card.py`
- `solitaire-game-setup/card.py`
- `solitaire-game-rules/card.py`
- `solitaire-final/card.py`
- `solitaire-final-part1/card.py`
- `gesture_detector/mouse_cursors.py`

**Documentation (1 .md file):**
- `docs/tutorials/solitaire.md`

## Test plan
- [ ] Run any of the solitaire drag-and-drop step examples (e.g., `step1.py`) and verify that dragging a card works without `AttributeError`
- [ ] Run the `mouse_cursors.py` gesture detector example and verify dragging works
- [ ] Verify the solitaire tutorial documentation code snippets match the updated API

## Summary by Sourcery

Update drag handling in solitaire tutorials and gesture detector example to use the current DragUpdateEvent local_delta API instead of removed delta_x/delta_y attributes.

Bug Fixes:
- Fix AttributeError in solitaire tutorial and gesture detector examples by replacing deprecated delta_x/delta_y with local_delta.x/local_delta.y in drag handlers.

Documentation:
- Align solitaire tutorial documentation snippets with the updated DragUpdateEvent local_delta-based API.