### PR TITLE
Prepare 0.83.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.83.1
+
+### Bug fixes
+
+* Fix solitaire tutorial and drag examples to use `local_delta.x` and `local_delta.y` instead of removed `delta_x` and `delta_y` ([#6317](https://github.com/flet-dev/flet/issues/6317), [#6344](https://github.com/flet-dev/flet/pull/6344)) by @Krishnachaitanyakc.
+* Fix inherited dataclass field validation rules applying to overridden subclass fields and breaking `flet-datatable2` on `0.83.0` ([#6349](https://github.com/flet-dev/flet/issues/6349), [#6350](https://github.com/flet-dev/flet/pull/6350)) by @ndonkoHenri.
+
 ## 0.83.0
 
 ### New features

--- a/packages/flet/CHANGELOG.md
+++ b/packages/flet/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.83.1
+
+### Bug fixes
+
+* Fix solitaire tutorial and drag examples to use `local_delta.x` and `local_delta.y` instead of removed `delta_x` and `delta_y` ([#6317](https://github.com/flet-dev/flet/issues/6317), [#6344](https://github.com/flet-dev/flet/pull/6344)) by @Krishnachaitanyakc.
+* Fix inherited dataclass field validation rules applying to overridden subclass fields and breaking `flet-datatable2` on `0.83.0` ([#6349](https://github.com/flet-dev/flet/issues/6349), [#6350](https://github.com/flet-dev/flet/pull/6350)) by @ndonkoHenri.
+
 ## 0.83.0
 
 ### New features

--- a/packages/flet/pubspec.yaml
+++ b/packages/flet/pubspec.yaml
@@ -2,7 +2,7 @@ name: flet
 description: Write entire Flutter app in Python or add server-driven UI experience into existing Flutter app.
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/flet/tree/main/packages/flet
-version: 0.83.0
+version: 0.83.1
 
 # Supported platforms
 platforms:


### PR DESCRIPTION
## Summary
- bump `packages/flet` version from `0.83.0` to `0.83.1`
- add `0.83.1` entries to the root and package changelogs
- include the two fixes merged since `v0.83.0`

## Included changes
- Fix solitaire tutorial and drag examples to use `local_delta.x` and `local_delta.y` instead of removed `delta_x` and `delta_y` ([#6317](https://github.com/flet-dev/flet/issues/6317), [#6344](https://github.com/flet-dev/flet/pull/6344)) by @Krishnachaitanyakc
- Fix inherited dataclass field validation rules applying to overridden subclass fields and breaking `flet-datatable2` on `0.83.0` ([#6349](https://github.com/flet-dev/flet/issues/6349), [#6350](https://github.com/flet-dev/flet/pull/6350)) by @ndonkoHenri

## Verification
- ran `flutter pub get` in `packages/flet`
- verified there are no `Unreleased` sections in the scanned changelogs

## Summary by Sourcery

Prepare the 0.83.1 patch release for the flet package and root project changelog.

Bug Fixes:
- Document fixes to drag handling in solitaire tutorial and drag examples to use the new local delta properties.
- Document fixes to dataclass field validation so overridden subclass fields no longer break flet-datatable2 on 0.83.0.

Documentation:
- Add 0.83.1 bug-fix entries to the root and flet package changelogs.

Chores:
- Bump the flet package version from 0.83.0 to 0.83.1.