### PR TITLE
Very minor correction in calculator tutorial

### DIFF
--- a/website/docs/tutorials/calculator.md
+++ b/website/docs/tutorials/calculator.md
@@ -110,9 +110,9 @@ result = ft.Text(value="0", color=ft.Colors.WHITE, size=20)
 
 For the buttons, if we look again at the UI we are aiming to achieve, there are 3 types of buttons:
 
-1. **Digit Buttons**. They have dark grey background color and white text, size is the same for all.
+1. **Digit Buttons**. They have dark grey background color and white text, size is the same for all except `0` button which is twice as large.
 
-2. **Action Buttons**.  They have orange background color and white text, size is the same for all except `0` button which is twice as large.
+2. **Action Buttons**.  They have orange background color and white text, size is the same for all.
 
 3. **Extra action buttons**. They have light grey background color and dark text, size is the same for all.
 


### PR DESCRIPTION
As a digit button, '0' has a specific role in the section on digit buttons.

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

<!-- If this PR fixes an open issue, please link to the issue here. Ex: Fixes #4562 -->

## Test Code

```python
# Test code for the review of this PR
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I signed the CLA.
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass locally with my changes
- [ ] I have made corresponding changes to the [documentation](https://github.com/flet-dev/website) (if applicable)

## Screenshots 

<!-- Add screenshots here if applicable. -->

## Additional details

<!-- Any additional details to be known about this PR. -->

## Summary by Sourcery

Documentation:
- Correct the calculator UI tutorial to state that the `0` digit button is the only button that is twice as large, and that all action buttons share the same size.