### PR TITLE
Update screenshot sizes for Control docs

### DIFF
--- a/website/docs/controls/animatedswitcher.md
+++ b/website/docs/controls/animatedswitcher.md
@@ -17,7 +17,7 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/scale_effect/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/scale_effect.gif'} alt="scale-effect" width="55%" />
+<Image src={frontMatter.example_images + '/scale_effect.gif'} alt="scale-effect" width="25%" />
 
 ### Animate Image switch
 

--- a/website/docs/controls/autofillgroup.md
+++ b/website/docs/controls/autofillgroup.md
@@ -17,6 +17,6 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/basic/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/basic.gif'} alt="basic" width="55%" />
+<Image src={frontMatter.example_images + '/basic.gif'} alt="basic" width="40%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/banner.md
+++ b/website/docs/controls/banner.md
@@ -18,6 +18,6 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/basic/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/basic.gif'} alt="basic" width="55%" />
+<Image src={frontMatter.example_media + '/basic.gif'} alt="basic" width="50%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/bottomsheet.md
+++ b/website/docs/controls/bottomsheet.md
@@ -7,7 +7,7 @@ title: "BottomSheet"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic BottomSheet" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic BottomSheet" imageWidth="30%"/>
 
 ## Examples
 

--- a/website/docs/controls/button.md
+++ b/website/docs/controls/button.md
@@ -7,7 +7,7 @@ title: "Button"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Enabled and disabled buttons" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Enabled and disabled buttons" imageWidth="25%"/>
 
 ## Examples
 
@@ -17,46 +17,46 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/basic/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/basic.png'} alt="Basic button" width="50%" />
+<Image src={frontMatter.example_images + '/basic.png'} alt="Basic button" width="25%" />
 
 ### Icons
 
 <CodeExample path={frontMatter.examples + '/icons/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/icons.png'} alt="Basic button" width="50%" />
+<Image src={frontMatter.example_images + '/icons.png'} alt="Basic button" width="35%" />
 
 ### Handling clicks
 
 <CodeExample path={frontMatter.examples + '/handling_clicks/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/handling_clicks.png'} alt="Handling clicks" width="50%" />
+<Image src={frontMatter.example_images + '/handling_clicks.png'} alt="Handling clicks" width="35%" />
 
 ### Custom content
 
 <CodeExample path={frontMatter.examples + '/custom_content/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/custom_content.png'} alt="Buttons with custom content" width="50%" />
+<Image src={frontMatter.example_images + '/custom_content.png'} alt="Buttons with custom content" width="35%" />
 
 ### Shapes
 
 <CodeExample path={frontMatter.examples + '/button_shapes/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/button_shapes.png'} alt="Buttons with different shapes" width="50%" />
+<Image src={frontMatter.example_images + '/button_shapes.png'} alt="Buttons with different shapes" width="35%" />
 
 ### Styling
 
 <CodeExample path={frontMatter.examples + '/styling/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/styled_initial.png'} alt="Styled button - default state" width="50%" caption="Default state" />
+<Image src={frontMatter.example_images + '/styled_initial.png'} alt="Styled button - default state" width="25%" caption="Default state" />
 
-<Image src={frontMatter.example_images + '/styled_hovered.png'} alt="Styled button - hovered state" width="50%" caption="Hovered state" />
+<Image src={frontMatter.example_images + '/styled_hovered.png'} alt="Styled button - hovered state" width="25%" caption="Hovered state" />
 
 ### Animate on hover
 
 <CodeExample path={frontMatter.examples + '/animate_on_hover/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/animate_on_hover_initial.png'} alt="Unhovered button" width="50%" caption="Normal button" />
+<Image src={frontMatter.example_images + '/animate_on_hover_initial.png'} alt="Unhovered button" width="40%" caption="Normal button" />
 
-<Image src={frontMatter.example_images + '/animate_on_hover_hovered.png'} alt="Hovered button" width="50%" caption="Hovered button" />
+<Image src={frontMatter.example_images + '/animate_on_hover_hovered.png'} alt="Hovered button" width="40%" caption="Hovered button" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/canvas/index.md
+++ b/website/docs/controls/canvas/index.md
@@ -10,7 +10,7 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 # Canvas
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic Canvas" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic Canvas" imageWidth="25%"/>
 
 ## Examples
 
@@ -20,25 +20,25 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/smiling_face/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/smiling_face.png'} alt="smiling-face" width="55%" />
+<Image src={frontMatter.example_media + '/smiling_face.png'} alt="smiling-face" width="25%" />
 
 ### Flet logo
 
 <CodeExample path={frontMatter.examples + '/flet_logo/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/flet_logo.png'} alt="flet-logo" width="55%" />
+<Image src={frontMatter.example_media + '/flet_logo.png'} alt="flet-logo" width="35%" />
 
 ### Triangles
 
 <CodeExample path={frontMatter.examples + '/triangles/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/triangles.png'} alt="triangles" width="55%" />
+<Image src={frontMatter.example_media + '/triangles.png'} alt="triangles" width="25%" />
 
 ### Bezier curves
 
 <CodeExample path={frontMatter.examples + '/bezier_curves/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/bezier_curves.png'} alt="bezier-curves" width="55%" />
+<Image src={frontMatter.example_media + '/bezier_curves.png'} alt="bezier-curves" width="25%" />
 
 ### Text
 

--- a/website/docs/controls/charts/barchart.md
+++ b/website/docs/controls/charts/barchart.md
@@ -8,7 +8,7 @@ title: "BarChart"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.diagram} imageCaption="Basic bar chart" imageWidth="55%" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.diagram} imageCaption="Basic bar chart" imageWidth="80%" />
 
 ## Examples
 
@@ -16,12 +16,12 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/example_1/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/example_1.png'} width="55%" />
+<Image src={frontMatter.example_images + '/example_1.png'} width="65%" />
 
 ### Example 2
 
 <CodeExample path={frontMatter.examples + '/example_2/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/example_2.png'} width="55%" />
+<Image src={frontMatter.example_images + '/example_2.png'} width="65%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/charts/candlestickchart.md
+++ b/website/docs/controls/charts/candlestickchart.md
@@ -7,7 +7,7 @@ title: "CandlestickChart"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic candlestick chart" imageWidth="55%" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic candlestick chart" imageWidth="65%" />
 
 ## Examples
 
@@ -15,6 +15,6 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/example_1/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/example_1.png'} width="55%" />
+<Image src={frontMatter.example_images + '/example_1.png'} width="65%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/charts/linechart.md
+++ b/website/docs/controls/charts/linechart.md
@@ -8,7 +8,7 @@ title: "LineChart"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.diagram} imageCaption="Basic line chart" imageWidth="55%" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.diagram} imageCaption="Basic line chart" imageWidth="80%" />
 
 ## Examples
 
@@ -16,12 +16,12 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/example_1/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/example_1.png'} width="55%" />
+<Image src={frontMatter.example_images + '/example_1.png'} width="65%" />
 
 ### Example 2
 
 <CodeExample path={frontMatter.examples + '/example_2/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/example_2.png'} width="55%" />
+<Image src={frontMatter.example_images + '/example_2.png'} width="65%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/charts/matplotlibchart.md
+++ b/website/docs/controls/charts/matplotlibchart.md
@@ -18,6 +18,6 @@ Based on an official [Matplotlib example](https://matplotlib.org/stable/gallery/
 
 <CodeExample path={frontMatter.examples + '/bar_chart/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/bar_chart.png'} width="55%" />
+<Image src={frontMatter.example_images + '/bar_chart.png'} width="65%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/charts/matplotlibchartwithtoolbar.md
+++ b/website/docs/controls/charts/matplotlibchartwithtoolbar.md
@@ -8,7 +8,7 @@ title: "MatplotlibChartWithToolbar"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/toolbar.png'} imageWidth="55%" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/toolbar.png'} imageWidth="65%" />
 
 ## Examples
 
@@ -18,19 +18,19 @@ Based on an official [Matplotlib example](https://matplotlib.org/stable/gallery/
 
 <CodeExample path={frontMatter.examples + '/toolbar/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/toolbar.png'} width="55%" />
+<Image src={frontMatter.example_images + '/toolbar.png'} width="65%" />
 
 ### 3D chart
 
 <CodeExample path={frontMatter.examples + '/three_d/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/three_d.png'} width="55%" />
+<Image src={frontMatter.example_images + '/three_d.png'} width="65%" />
 
 ### Handle events
 
 <CodeExample path={frontMatter.examples + '/handle_events/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/handle_events.png'} width="55%" />
+<Image src={frontMatter.example_images + '/handle_events.png'} width="65%" />
 
 ### Animated chart
 

--- a/website/docs/controls/charts/piechart.md
+++ b/website/docs/controls/charts/piechart.md
@@ -8,7 +8,7 @@ title: "PieChart"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.diagram} imageWidth="65%" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.diagram} imageWidth="50%" />
 
 ## Examples
 
@@ -16,18 +16,18 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/example_1/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/example_1.png'} width="55%" />
+<Image src={frontMatter.example_images + '/example_1.png'} width="65%" />
 
 ### Example 2
 
 <CodeExample path={frontMatter.examples + '/example_2/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/example_2.png'} width="55%" />
+<Image src={frontMatter.example_images + '/example_2.png'} width="65%" />
 
 ### Example 3
 
 <CodeExample path={frontMatter.examples + '/example_3/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/example_3.png'} width="55%" />
+<Image src={frontMatter.example_images + '/example_3.png'} width="65%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/charts/plotlychart.md
+++ b/website/docs/controls/charts/plotlychart.md
@@ -17,7 +17,7 @@ Based on an official [Plotly example](https://plotly.com/python/line-charts).
 
 <CodeExample path={frontMatter.examples + '/example_1/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/example_1.png'} width="55%" />
+<Image src={frontMatter.example_images + '/example_1.png'} width="65%" />
 
 ### Example 2
 
@@ -25,7 +25,7 @@ Based on an official [Plotly example](https://plotly.com/python/bar-charts).
 
 <CodeExample path={frontMatter.examples + '/example_2/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/example_2.png'} width="55%" />
+<Image src={frontMatter.example_images + '/example_2.png'} width="65%" />
 
 ### Example 3
 
@@ -33,7 +33,7 @@ Based on an official [Plotly example](https://plotly.com/python/pie-charts).
 
 <CodeExample path={frontMatter.examples + '/example_3/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/example_3.png'} width="55%" />
+<Image src={frontMatter.example_images + '/example_3.png'} width="65%" />
 
 ### Example 4
 
@@ -41,6 +41,6 @@ Based on an official [Plotly example](https://plotly.com/python/box-plots).
 
 <CodeExample path={frontMatter.examples + '/example_4/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/example_4.png'} width="55%" />
+<Image src={frontMatter.example_images + '/example_4.png'} width="65%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/charts/scatterchart.md
+++ b/website/docs/controls/charts/scatterchart.md
@@ -15,6 +15,6 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/example_1/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/example_1.png'} width="55%" />
+<Image src={frontMatter.example_images + '/example_1.png'} width="65%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/checkbox.md
+++ b/website/docs/controls/checkbox.md
@@ -7,7 +7,7 @@ title: "Checkbox"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic checkboxes" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic checkboxes" imageWidth="12%"/>
 
 ## Examples
 
@@ -23,12 +23,12 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/handling_events/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/handling_events.png'} alt="handling-events" width="50%" caption="After three clicks" />
+<Image src={frontMatter.example_images + '/handling_events.png'} alt="handling-events" width="35%" caption="After three clicks" />
 
 ### Styled checkboxes
 
 <CodeExample path={frontMatter.examples + '/styled/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/styled_checkboxes.png'} alt="Styled checkboxes" width="50%" />
+<Image src={frontMatter.example_images + '/styled_checkboxes.png'} alt="Styled checkboxes" width="35%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/chip.md
+++ b/website/docs/controls/chip.md
@@ -8,7 +8,7 @@ title: "Chip"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic Chip" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic Chip" imageWidth="20%"/>
 
 ## Examples
 
@@ -25,7 +25,7 @@ An alternative to assist chips are buttons, which should appear persistently and
 
 <CodeExample path={frontMatter.examples + '/assist_chips/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/assist_chips.png'} alt="assist-chips" width="55%" />
+<Image src={frontMatter.example_media + '/assist_chips.png'} alt="assist-chips" width="40%" />
 
 ### Filter chips
 
@@ -36,6 +36,6 @@ They can be a good alternative to switches or checkboxes.
 
 <CodeExample path={frontMatter.examples + '/filter_chips/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/filter_chips.png'} alt="filter-chips" width="55%" />
+<Image src={frontMatter.example_media + '/filter_chips.png'} alt="filter-chips" width="70%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/circleavatar.md
+++ b/website/docs/controls/circleavatar.md
@@ -8,7 +8,7 @@ title: "CircleAvatar"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic CircleAvatar" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic CircleAvatar" imageWidth="5%"/>
 
 ## Examples
 
@@ -18,6 +18,6 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/user_avatars/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/user_avatars.png'} alt="user-avatars" width="55%" />
+<Image src={frontMatter.example_media + '/user_avatars.png'} alt="user-avatars" width="7%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/codeeditor/index.md
+++ b/website/docs/controls/codeeditor/index.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 import Tabs from '@theme/Tabs';
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic CodeEditor" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic CodeEditor" imageWidth="60%"/>
 
 ## Usage
 
@@ -35,18 +35,18 @@ pip install flet-code-editor  # (1)!
 ### Basic example
 <CodeExample path={frontMatter.examples + '/example_1/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/example_1.png'} alt="code-editor-example-1" width="55%" />
+<Image src={frontMatter.example_images + '/example_1.png'} alt="code-editor-example-1" width="60%" />
 
 ### Selection handling
 
 <CodeExample path={frontMatter.examples + '/example_2/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/example_2.png'} alt="code-editor-example-2" width="55%" />
+<Image src={frontMatter.example_images + '/example_2.png'} alt="code-editor-example-2" width="65%" />
 
 ### Folding and initial selection
 
 <CodeExample path={frontMatter.examples + '/example_3/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/example_3.png'} alt="code-editor-example-3" width="55%" />
+<Image src={frontMatter.example_images + '/example_3.png'} alt="code-editor-example-3" width="65%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/colorpickers/blockpicker.md
+++ b/website/docs/controls/colorpickers/blockpicker.md
@@ -9,7 +9,7 @@ import {ClassMembers, ClassSummary, CodeExample} from '@site/src/components/croc
 
 # BlockPicker
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/block_picker.png'} imageCaption="Basic BlockPicker" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/block_picker.png'} imageCaption="Basic BlockPicker" imageWidth="35%"/>
 
 ## Example
 

--- a/website/docs/controls/colorpickers/colorpicker.md
+++ b/website/docs/controls/colorpickers/colorpicker.md
@@ -9,7 +9,7 @@ import {ClassMembers, ClassSummary, CodeExample} from '@site/src/components/croc
 
 # ColorPicker
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic ColorPicker" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic ColorPicker" imageWidth="55%"/>
 
 ## Example
 

--- a/website/docs/controls/colorpickers/hueringpicker.md
+++ b/website/docs/controls/colorpickers/hueringpicker.md
@@ -9,7 +9,7 @@ import {ClassMembers, ClassSummary, CodeExample} from '@site/src/components/croc
 
 # HueRingPicker
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/hue_ring_picker.png'} imageCaption="Basic HueRingPicker" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/hue_ring_picker.png'} imageCaption="Basic HueRingPicker" imageWidth="55%"/>
 
 ## Example
 

--- a/website/docs/controls/colorpickers/materialpicker.md
+++ b/website/docs/controls/colorpickers/materialpicker.md
@@ -9,7 +9,7 @@ import {ClassMembers, ClassSummary, CodeExample} from '@site/src/components/croc
 
 # MaterialPicker
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/material_picker.png'} imageCaption="Basic MaterialPicker" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/material_picker.png'} imageCaption="Basic MaterialPicker" imageWidth="55%"/>
 
 ## Example
 

--- a/website/docs/controls/colorpickers/multiplechoiceblockpicker.md
+++ b/website/docs/controls/colorpickers/multiplechoiceblockpicker.md
@@ -9,7 +9,7 @@ import {ClassMembers, ClassSummary, CodeExample} from '@site/src/components/croc
 
 # MultipleChoiceBlockPicker
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/multiple_choice_block_picker.png'} imageCaption="Basic MultipleChoiceBlockPicker" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/multiple_choice_block_picker.png'} imageCaption="Basic MultipleChoiceBlockPicker" imageWidth="35%"/>
 
 ## Example
 

--- a/website/docs/controls/colorpickers/slidepicker.md
+++ b/website/docs/controls/colorpickers/slidepicker.md
@@ -9,7 +9,7 @@ import {ClassMembers, ClassSummary, CodeExample} from '@site/src/components/croc
 
 # SlidePicker
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/slide_picker.png'} imageCaption="Basic SlidePicker" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/slide_picker.png'} imageCaption="Basic SlidePicker" imageWidth="35%"/>
 
 ## Example
 

--- a/website/docs/controls/column.md
+++ b/website/docs/controls/column.md
@@ -8,7 +8,7 @@ title: "Column"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic Column with Text controls" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic Column with Text controls" imageWidth="25%"/>
 
 ## Examples
 
@@ -36,7 +36,7 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/horizontal_alignment/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/horizontal_alignment.png'} alt="horizontal-alignment" width="55%" />
+<Image src={frontMatter.example_media + '/horizontal_alignment.png'} alt="horizontal-alignment" width="40%" />
 
 ### Infinite scrolling
 

--- a/website/docs/controls/container.md
+++ b/website/docs/controls/container.md
@@ -18,25 +18,25 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/clickable/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/clickable.gif'} width="55%" />
+<Image src={frontMatter.example_media + '/clickable.gif'} width="65%" />
 
 ### Handling clicks
 
 <CodeExample path={frontMatter.examples + '/handling_clicks/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/handling_clicks.gif'} width="55%" />
+<Image src={frontMatter.example_media + '/handling_clicks.gif'} width="40%" />
 
 ### Handling hovers
 
 <CodeExample path={frontMatter.examples + '/handling_hovers/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/handling_hovers.gif'} width="55%" />
+<Image src={frontMatter.example_media + '/handling_hovers.gif'} width="15%" />
 
 ### Animate 1
 
 <CodeExample path={frontMatter.examples + '/animate_1/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/animate_1.gif'} width="55%" />
+<Image src={frontMatter.example_media + '/animate_1.gif'} width="25%" />
 
 ### Animate 2
 
@@ -50,24 +50,24 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/nested_themes_1/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/nested_themes_1.png'} width="55%" />
+<Image src={frontMatter.example_images + '/nested_themes_1.png'} width="40%" />
 
 ### Nested themes 2
 
 <CodeExample path={frontMatter.examples + '/nested_themes_2/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/nested_themes_2.png'} width="55%" />
+<Image src={frontMatter.example_images + '/nested_themes_2.png'} width="60%" />
 
 ### Nested themes 3
 
 <CodeExample path={frontMatter.examples + '/nested_themes_3/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/nested_themes_3.gif'} width="55%" />
+<Image src={frontMatter.example_media + '/nested_themes_3.gif'} width="40%" />
 
 ### Size aware
 
 <CodeExample path={frontMatter.examples + '/size_aware/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/size_aware.png'} width="55%" />
+<Image src={frontMatter.example_images + '/size_aware.png'} width="40%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/contextmenu.md
+++ b/website/docs/controls/contextmenu.md
@@ -7,7 +7,7 @@ title: "ContextMenu"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic ContextMenu" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic ContextMenu" imageWidth="30%"/>
 
 ## Examples
 
@@ -19,7 +19,7 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/programmatic_open/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/programmatic_open.png'} width="55%" />
+<Image src={frontMatter.example_images + '/programmatic_open.png'} width="30%" />
 
 ## Programmatic open with custom trigger
 

--- a/website/docs/controls/cupertinoactivityindicator.md
+++ b/website/docs/controls/cupertinoactivityindicator.md
@@ -8,7 +8,7 @@ title: "CupertinoActivityIndicator"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic CupertinoActivityIndicator" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic CupertinoActivityIndicator" imageWidth="8%"/>
 
 ## Examples
 
@@ -18,6 +18,6 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/basic/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/basic.png'} alt="basic" width="55%" />
+<Image src={frontMatter.example_media + '/basic.png'} alt="basic" width="25%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/cupertinoalertdialog.md
+++ b/website/docs/controls/cupertinoalertdialog.md
@@ -17,7 +17,7 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/file_deletion_confirmation/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/file_deletion_confirmation.png'} alt="file-deletion-confirmation" width="55%" />
+<Image src={frontMatter.example_images + '/file_deletion_confirmation.png'} alt="file-deletion-confirmation" width="40%" />
 
 ### Cupertino, material and adaptive alert dialogs
 

--- a/website/docs/controls/cupertinobutton.md
+++ b/website/docs/controls/cupertinobutton.md
@@ -8,7 +8,7 @@ title: "CupertinoButton"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic CupertinoButton" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic CupertinoButton" imageWidth="10%"/>
 
 ## Examples
 

--- a/website/docs/controls/cupertinocheckbox.md
+++ b/website/docs/controls/cupertinocheckbox.md
@@ -8,7 +8,7 @@ title: "CupertinoCheckbox"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic CupertinoCheckboxes" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic CupertinoCheckboxes" imageWidth="10%"/>
 
 ## Examples
 
@@ -18,7 +18,7 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/cupertino_material_and_adaptive/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/cupertino_material_and_adaptive.png'} alt="cupertino-material-and-adaptive" width="55%" />
+<Image src={frontMatter.example_media + '/cupertino_material_and_adaptive.png'} alt="cupertino-material-and-adaptive" width="80%" />
 
 ### Styled checkboxes
 

--- a/website/docs/controls/cupertinofilledbutton.md
+++ b/website/docs/controls/cupertinofilledbutton.md
@@ -8,7 +8,7 @@ title: "CupertinoFilledButton"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic CupertinoFilledButton" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic CupertinoFilledButton" imageWidth="10%"/>
 
 ## Examples
 
@@ -18,6 +18,6 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/basic/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/basic.png'} alt="basic" width="55%" />
+<Image src={frontMatter.example_media + '/basic.png'} alt="basic" width="25%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/cupertinolisttile.md
+++ b/website/docs/controls/cupertinolisttile.md
@@ -18,6 +18,6 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/notched/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/notched.png'} alt="notched" width="55%" />
+<Image src={frontMatter.example_media + '/notched.png'} alt="notched" width="60%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/cupertinopicker.md
+++ b/website/docs/controls/cupertinopicker.md
@@ -17,6 +17,6 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/fruit_selection/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/fruit_selection.gif'} alt="fruit-selection" width="55%" />
+<Image src={frontMatter.example_images + '/fruit_selection.gif'} alt="fruit-selection" width="35%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/cupertinoradio.md
+++ b/website/docs/controls/cupertinoradio.md
@@ -8,7 +8,7 @@ title: "CupertinoRadio"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic CupertinoRadios" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic CupertinoRadios" imageWidth="10%"/>
 
 ## Examples
 
@@ -18,6 +18,6 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/cupertino_material_and_adaptive/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/cupertino_material_and_adaptive.png'} alt="cupertino-material-and-adaptive" width="55%" />
+<Image src={frontMatter.example_media + '/cupertino_material_and_adaptive.png'} alt="cupertino-material-and-adaptive" width="40%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/cupertinosegmentedbutton.md
+++ b/website/docs/controls/cupertinosegmentedbutton.md
@@ -8,7 +8,7 @@ title: "CupertinoSegmentedButton"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic CupertinoSegmentedButton" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic CupertinoSegmentedButton" imageWidth="20%"/>
 
 ## Examples
 
@@ -18,7 +18,7 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/basic/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/basic.gif'} alt="basic" width="55%" />
+<Image src={frontMatter.example_media + '/basic.gif'} alt="basic" width="40%" />
 
 ### Adjusting segments padding
 

--- a/website/docs/controls/cupertinoslider.md
+++ b/website/docs/controls/cupertinoslider.md
@@ -8,7 +8,7 @@ title: "CupertinoSlider"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic CupertinoSlider" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic CupertinoSlider" imageWidth="20%"/>
 
 ## Examples
 
@@ -18,6 +18,6 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/handling_events/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/handling_events.gif'} alt="handling-events" width="55%" />
+<Image src={frontMatter.example_media + '/handling_events.gif'} alt="handling-events" width="40%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/cupertinoslidingsegmentedbutton.md
+++ b/website/docs/controls/cupertinoslidingsegmentedbutton.md
@@ -8,7 +8,7 @@ title: "CupertinoSlidingSegmentedButton"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic CupertinoSlidingSegmentedButton" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic CupertinoSlidingSegmentedButton" imageWidth="25%"/>
 
 ## Examples
 
@@ -18,6 +18,6 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/basic/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/basic.gif'} alt="basic" width="55%" />
+<Image src={frontMatter.example_media + '/basic.gif'} alt="basic" width="30%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/cupertinoswitch.md
+++ b/website/docs/controls/cupertinoswitch.md
@@ -8,7 +8,7 @@ title: "CupertinoSwitch"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic CupertinoSwitch" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic CupertinoSwitch" imageWidth="8%"/>
 
 ## Examples
 
@@ -18,6 +18,6 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/cupertino_material_and_adaptive/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/cupertino_material_and_adaptive.gif'} alt="cupertino-material-and-adaptive" width="55%" />
+<Image src={frontMatter.example_media + '/cupertino_material_and_adaptive.gif'} alt="cupertino-material-and-adaptive" width="70%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/cupertinotextfield.md
+++ b/website/docs/controls/cupertinotextfield.md
@@ -8,7 +8,7 @@ title: "CupertinoTextField"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic CupertinoTextField" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic CupertinoTextField" imageWidth="40%"/>
 
 ## Examples
 
@@ -18,7 +18,7 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/cupertino_material_and_adaptive/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/cupertino_material_and_adaptive.png'} alt="cupertino-material-and-adaptive" width="55%" />
+<Image src={frontMatter.example_media + '/cupertino_material_and_adaptive.png'} alt="cupertino-material-and-adaptive" width="70%" />
 
 ### Handling selection changes
 

--- a/website/docs/controls/cupertinotimerpicker.md
+++ b/website/docs/controls/cupertinotimerpicker.md
@@ -8,7 +8,7 @@ title: "CupertinoTimerPicker"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Simple Cupertino timer picker" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Simple Cupertino timer picker" imageWidth="70%"/>
 
 ## Examples
 
@@ -18,6 +18,6 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/basic/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/basic.gif'} alt="basic" width="55%" />
+<Image src={frontMatter.example_media + '/basic.gif'} alt="basic" width="35%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/cupertinotintedbutton.md
+++ b/website/docs/controls/cupertinotintedbutton.md
@@ -6,6 +6,6 @@ title: "CupertinoTintedButton"
 
 import {ClassMembers, ClassSummary} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic CupertinoTintedButton" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic CupertinoTintedButton" imageWidth="10%"/>
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/datatable/index.md
+++ b/website/docs/controls/datatable/index.md
@@ -9,7 +9,7 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 # DataTable
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic DataTable" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic DataTable" imageWidth="25%"/>
 
 ## Examples
 
@@ -19,7 +19,7 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/basic/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/basic.png'} width="55%" />
+<Image src={frontMatter.example_images + '/basic.png'} width="40%" />
 
 ### Horizontal margin and column spacing
 

--- a/website/docs/controls/datatable2/index.md
+++ b/website/docs/controls/datatable2/index.md
@@ -49,7 +49,7 @@ pip install flet-datatable2  # (1)!
 
 <CodeExample path={frontMatter.examples + '/example_2/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/example_2.gif'} width="55%" />
+<Image src={frontMatter.example_media + '/example_2.gif'} width="65%" />
 
 ## Description
 

--- a/website/docs/controls/dismissible.md
+++ b/website/docs/controls/dismissible.md
@@ -17,7 +17,7 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/dismissible_list_tiles/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/dismissible_list_tiles.gif'} alt="dismissible-list-tiles" width="55%" />
+<Image src={frontMatter.example_images + '/dismissible_list_tiles.gif'} alt="dismissible-list-tiles" width="30%" />
 
 ### Remove Dismissible `on_dismiss` inside component
 

--- a/website/docs/controls/divider.md
+++ b/website/docs/controls/divider.md
@@ -8,7 +8,7 @@ title: "Divider"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic Divider" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic Divider" imageWidth="30%"/>
 
 ## Examples
 
@@ -18,6 +18,6 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/basic/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/basic.png'} alt="basic" width="55%" />
+<Image src={frontMatter.example_media + '/basic.png'} alt="basic" width="40%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/draggable.md
+++ b/website/docs/controls/draggable.md
@@ -23,6 +23,6 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/drag_and_drop_containers_declarative/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/drag_and_drop_containers.gif'} alt="drag-and-drop-containers" width="55%" />
+<Image src={frontMatter.example_images + '/drag_and_drop_containers.gif'} alt="drag-and-drop-containers" width="40%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/dropdown/index.md
+++ b/website/docs/controls/dropdown/index.md
@@ -10,7 +10,7 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 # Dropdown
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic Dropdown" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic Dropdown" imageWidth="25%"/>
 
 ## Examples
 
@@ -20,13 +20,13 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/color_selection_with_filtering/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/color_selection_with_filtering.gif'} alt="color-selection-with-filtering" width="55%" />
+<Image src={frontMatter.example_media + '/color_selection_with_filtering.gif'} alt="color-selection-with-filtering" width="25%" />
 
 ### Icon selection
 
 <CodeExample path={frontMatter.examples + '/icon_selection/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/icon_selection.png'} alt="icon-selection" width="55%" />
+<Image src={frontMatter.example_media + '/icon_selection.png'} alt="icon-selection" width="25%" />
 
 ### Styled dropdowns
 

--- a/website/docs/controls/dropdownm2.md
+++ b/website/docs/controls/dropdownm2.md
@@ -8,7 +8,7 @@ title: "DropdownM2"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic DropdownM2" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic DropdownM2" imageWidth="25%"/>
 
 ## Examples
 
@@ -18,24 +18,24 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/basic/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/basic.gif'} alt="basic" width="55%" />
+<Image src={frontMatter.example_media + '/basic.gif'} alt="basic" width="40%" />
 
 ### Dropdown with label and hint
 
 <CodeExample path={frontMatter.examples + '/label_and_hint/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/label_and_hint.gif'} alt="label-and-hint" width="55%" />
+<Image src={frontMatter.example_media + '/label_and_hint.gif'} alt="label-and-hint" width="35%" />
 
 ### Handling events
 
 <CodeExample path={frontMatter.examples + '/handling_events/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/handling_events.gif'} alt="handling-events" width="55%" />
+<Image src={frontMatter.example_media + '/handling_events.gif'} alt="handling-events" width="40%" />
 
 ### Add and delete options
 
 <CodeExample path={frontMatter.examples + '/add_and_delete_options/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/add_and_delete_options.gif'} alt="add-and-delete-options" width="55%" />
+<Image src={frontMatter.example_media + '/add_and_delete_options.gif'} alt="add-and-delete-options" width="50%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/expansionpanel.md
+++ b/website/docs/controls/expansionpanel.md
@@ -6,6 +6,6 @@ title: "ExpansionPanel"
 
 import {ClassMembers, ClassSummary} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic ExpansionPanel" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic ExpansionPanel" imageWidth="45%"/>
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/expansionpanellist.md
+++ b/website/docs/controls/expansionpanellist.md
@@ -8,7 +8,7 @@ title: "ExpansionPanelList"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic ExpansionPanelList" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic ExpansionPanelList" imageWidth="45%"/>
 
 ## Examples
 
@@ -18,7 +18,7 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/basic/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/basic.gif'} width="55%" />
+<Image src={frontMatter.example_media + '/basic.gif'} width="40%" />
 
 ### Scrolling
 

--- a/website/docs/controls/expansiontile.md
+++ b/website/docs/controls/expansiontile.md
@@ -17,7 +17,7 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/basic/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/basic.png'} width="55%" />
+<Image src={frontMatter.example_images + '/basic.png'} width="30%" />
 
 ## Programmatic expansion/collapse
 

--- a/website/docs/controls/filledbutton.md
+++ b/website/docs/controls/filledbutton.md
@@ -8,7 +8,7 @@ title: "FilledButton"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic FilledButton" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic FilledButton" imageWidth="13%"/>
 
 ## Examples
 
@@ -18,6 +18,6 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/basic/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/basic.png'} alt="basic" width="55%" />
+<Image src={frontMatter.example_media + '/basic.png'} alt="basic" width="25%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/fillediconbutton.md
+++ b/website/docs/controls/fillediconbutton.md
@@ -6,6 +6,6 @@ title: "FilledIconButton"
 
 import {ClassMembers, ClassSummary} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic FilledIconButton" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic FilledIconButton" imageWidth="5%"/>
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/filledtonalbutton.md
+++ b/website/docs/controls/filledtonalbutton.md
@@ -8,7 +8,7 @@ title: "FilledTonalButton"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic FilledTonalButton" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic FilledTonalButton" imageWidth="13%"/>
 
 ## Examples
 
@@ -18,6 +18,6 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/basic/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/basic.png'} alt="basic" width="55%" />
+<Image src={frontMatter.example_media + '/basic.png'} alt="basic" width="25%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/filledtonaliconbutton.md
+++ b/website/docs/controls/filledtonaliconbutton.md
@@ -6,6 +6,6 @@ title: "FilledTonalIconButton"
 
 import {ClassMembers, ClassSummary} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic FilledTonalIconButton" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic FilledTonalIconButton" imageWidth="5%"/>
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/floatingactionbutton.md
+++ b/website/docs/controls/floatingactionbutton.md
@@ -8,7 +8,7 @@ title: "FloatingActionButton"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic FloatingActionButton" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic FloatingActionButton" imageWidth="7%"/>
 
 ## Examples
 
@@ -18,6 +18,6 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/handling_clicks/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/handling_clicks.gif'} alt="handling-clicks" width="55%" />
+<Image src={frontMatter.example_media + '/handling_clicks.gif'} alt="handling-clicks" width="60%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/gesturedetector.md
+++ b/website/docs/controls/gesturedetector.md
@@ -28,7 +28,7 @@ inside another control (yellow container) giving the same results.
 
 <CodeExample path={frontMatter.examples + '/draggable_containers/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/draggable_containers.gif'} alt="draggable-containers" width="55%" />
+<Image src={frontMatter.example_images + '/draggable_containers.gif'} alt="draggable-containers" width="40%" />
 
 ### Window drag area
 

--- a/website/docs/controls/gridview.md
+++ b/website/docs/controls/gridview.md
@@ -8,7 +8,7 @@ title: "GridView"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic GridView" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic GridView" imageWidth="20%"/>
 
 ## Examples
 

--- a/website/docs/controls/hero.md
+++ b/website/docs/controls/hero.md
@@ -15,7 +15,7 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/basic/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/basic.gif'} width="55%" />
+<Image src={frontMatter.example_images + '/basic.gif'} width="40%" />
 
 ### Gallery
 

--- a/website/docs/controls/icon.md
+++ b/website/docs/controls/icon.md
@@ -8,7 +8,7 @@ title: "Icon"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic Icon" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic Icon" imageWidth="5%"/>
 
 ## Examples
 
@@ -21,6 +21,6 @@ visit our [icons browser](https://examples.flet.dev/icons_browser/)
 
 <CodeExample path={frontMatter.examples + '/basic/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/basic.png'} alt="basic" width="55%" />
+<Image src={frontMatter.example_media + '/basic.png'} alt="basic" width="25%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/iconbutton.md
+++ b/website/docs/controls/iconbutton.md
@@ -8,7 +8,7 @@ title: "IconButton"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic IconButton" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic IconButton" imageWidth="6%"/>
 
 ## Examples
 
@@ -18,7 +18,7 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/handling_clicks/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/handling_clicks.gif'} alt="handling-clicks" width="55%" />
+<Image src={frontMatter.example_media + '/handling_clicks.gif'} alt="handling-clicks" width="45%" />
 
 ### Selected icon
 

--- a/website/docs/controls/image.md
+++ b/website/docs/controls/image.md
@@ -8,7 +8,7 @@ title: "Image"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic Image" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic Image" imageWidth="10%" />
 
 ## Examples
 
@@ -18,7 +18,7 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/gallery/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/gallery.gif'} width="55%" />
+<Image src={frontMatter.example_media + '/gallery.gif'} width="45%" />
 
 ### Fade-in images with a placeholder
 

--- a/website/docs/controls/listview.md
+++ b/website/docs/controls/listview.md
@@ -8,7 +8,7 @@ title: "ListView"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic list view" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic list view" imageWidth="10%"/>
 
 ## Examples
 
@@ -18,6 +18,6 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/autoscroll_and_dynamic_items/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/autoscroll_and_dynamic_items.gif'} alt="autoscroll-and-dynamic-items" width="55%" />
+<Image src={frontMatter.example_media + '/autoscroll_and_dynamic_items.gif'} alt="autoscroll-and-dynamic-items" width="40%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/markdown.md
+++ b/website/docs/controls/markdown.md
@@ -8,7 +8,7 @@ title: "Markdown"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic Markdown" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic Markdown" imageWidth="30%"/>
 
 ## Examples
 
@@ -24,7 +24,7 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/code_syntax_highlight/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/code_syntax_highlight.png'} alt="code-syntax-highlight" width="55%" />
+<Image src={frontMatter.example_media + '/code_syntax_highlight.png'} alt="code-syntax-highlight" width="65%" />
 
 ### Custom text theme
 

--- a/website/docs/controls/menubar.md
+++ b/website/docs/controls/menubar.md
@@ -7,7 +7,7 @@ title: "MenuBar"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic menu bar" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic menu bar" imageWidth="18%"/>
 
 ## Examples
 
@@ -17,6 +17,6 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/nested_submenus/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/nested_submenus.gif'} width="55%" />
+<Image src={frontMatter.example_images + '/nested_submenus.gif'} width="45%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/menuitembutton.md
+++ b/website/docs/controls/menuitembutton.md
@@ -7,7 +7,7 @@ title: "MenuItemButton"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Menu item buttons outside of menubar" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Menu item buttons outside of menubar" imageWidth="25%"/>
 
 ## Examples
 
@@ -17,6 +17,6 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/basic/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/basic.gif'} alt="basic" width="55%" />
+<Image src={frontMatter.example_images + '/basic.gif'} alt="basic" width="45%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/navigationbar/index.md
+++ b/website/docs/controls/navigationbar/index.md
@@ -9,7 +9,7 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 # NavigationBar
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Simple navigation bar" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Simple navigation bar" imageWidth="35%"/>
 
 ## Examples
 
@@ -19,6 +19,6 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/basic/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/basic.png'} alt="basic" width="55%" />
+<Image src={frontMatter.example_images + '/basic.png'} alt="basic" width="40%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/navigationdrawer/index.md
+++ b/website/docs/controls/navigationdrawer/index.md
@@ -19,12 +19,12 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/position_start/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/position_start.gif'} alt="position-start" width="55%" />
+<Image src={frontMatter.example_images + '/position_start.gif'} alt="position-start" width="40%" />
 
 ### End-aligned drawer
 
 <CodeExample path={frontMatter.examples + '/position_end/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/position_end.gif'} alt="position-end" width="55%" />
+<Image src={frontMatter.example_images + '/position_end.gif'} alt="position-end" width="40%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/navigationrail/index.md
+++ b/website/docs/controls/navigationrail/index.md
@@ -9,7 +9,7 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 # NavigationRail
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Navigation rail extended" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Navigation rail extended" imageWidth="12%"/>
 
 ## Examples
 
@@ -19,6 +19,6 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/basic/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/basic.png'} alt="basic" width="55%" />
+<Image src={frontMatter.example_images + '/basic.png'} alt="basic" width="45%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/outlinedbutton.md
+++ b/website/docs/controls/outlinedbutton.md
@@ -8,7 +8,7 @@ title: "OutlinedButton"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Simple Outlined Button" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Simple Outlined Button" imageWidth="25%"/>
 
 ## Examples
 
@@ -18,24 +18,24 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/basic/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/basic.png'} alt="basic" width="55%" />
+<Image src={frontMatter.example_images + '/basic.png'} alt="basic" width="25%" />
 
 ### Handling clicks
 
 <CodeExample path={frontMatter.examples + '/handling_clicks/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/handling_clicks.gif'} alt="handling-clicks" width="55%" />
+<Image src={frontMatter.example_images + '/handling_clicks.gif'} alt="handling-clicks" width="40%" />
 
 ### Icons
 
 <CodeExample path={frontMatter.examples + '/icons/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/icons.png'} alt="icons" width="55%" />
+<Image src={frontMatter.example_images + '/icons.png'} alt="icons" width="35%" />
 
 ### Custom content
 
 <CodeExample path={frontMatter.examples + '/custom_content/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/custom_content.png'} alt="custom-content" width="55%" />
+<Image src={frontMatter.example_images + '/custom_content.png'} alt="custom-content" width="35%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/placeholder.md
+++ b/website/docs/controls/placeholder.md
@@ -17,6 +17,6 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/basic/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/basic.png'} alt="basic" width="55%" />
+<Image src={frontMatter.example_images + '/basic.png'} alt="basic" width="30%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/popupmenubutton.md
+++ b/website/docs/controls/popupmenubutton.md
@@ -9,7 +9,7 @@ title: "PopupMenuButton"
 
 import {ClassAll, ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Opened popup menu under button" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Opened popup menu under button" imageWidth="11%"/>
 
 ## Examples
 
@@ -19,7 +19,7 @@ import {ClassAll, ClassMembers, ClassSummary, CodeExample, Image} from '@site/sr
 
 <CodeExample path={frontMatter.examples + '/basic/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/basic.gif'} alt="basic" width="55%" />
+<Image src={frontMatter.example_media + '/basic.gif'} alt="basic" width="35%" />
 
 <ClassMembers name={frontMatter.class_name} />
 

--- a/website/docs/controls/progressbar.md
+++ b/website/docs/controls/progressbar.md
@@ -18,6 +18,6 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/determinate_and_indeterminate/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/determinate_and_indeterminate.gif'} alt="determinate-and-indeterminate" width="55%" />
+<Image src={frontMatter.example_media + '/determinate_and_indeterminate.gif'} alt="determinate-and-indeterminate" width="40%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/progressring.md
+++ b/website/docs/controls/progressring.md
@@ -8,7 +8,7 @@ title: "ProgressRing"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Fixed progress ring" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Fixed progress ring" imageWidth="10%"/>
 
 ## Examples
 
@@ -18,12 +18,12 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/determinate_and_indeterminate/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/determinate_and_indeterminate.gif'} alt="determinate-and-indeterminate" width="55%" />
+<Image src={frontMatter.example_media + '/determinate_and_indeterminate.gif'} alt="determinate-and-indeterminate" width="40%" />
 
 ### Gauge with progress
 
 <CodeExample path={frontMatter.examples + '/gauge_with_progress/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/gauge_with_progress.png'} alt="determinate-and-indeterminate" width="55%" />
+<Image src={frontMatter.example_images + '/gauge_with_progress.png'} alt="determinate-and-indeterminate" width="13%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/radio.md
+++ b/website/docs/controls/radio.md
@@ -7,7 +7,7 @@ title: "Radio"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Simple radio buttons" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Simple radio buttons" imageWidth="80%"/>
 
 ## Examples
 
@@ -17,13 +17,13 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/basic/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/basic.png'} alt="basic" width="55%" />
+<Image src={frontMatter.example_images + '/basic.png'} alt="basic" width="25%" />
 
 ### Handling selection changes
 
 <CodeExample path={frontMatter.examples + '/handling_selection_changes/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/handling_selection_changes.png'} alt="handling-selection-changes" width="55%" />
+<Image src={frontMatter.example_images + '/handling_selection_changes.png'} alt="handling-selection-changes" width="25%" />
 
 ### Styled radio buttons
 

--- a/website/docs/controls/reorderablelistview.md
+++ b/website/docs/controls/reorderablelistview.md
@@ -7,7 +7,7 @@ title: "ReorderableListView"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Reorderable list view" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Reorderable list view" imageWidth="70%"/>
 
 ## Examples
 
@@ -17,7 +17,7 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/horizontal_and_vertical/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/horizontal_and_vertical.png'} alt="horizontal-and-vertical" width="55%" />
+<Image src={frontMatter.example_images + '/horizontal_and_vertical.png'} alt="horizontal-and-vertical" width="65%" />
 
 ### Custom drag handle
 

--- a/website/docs/controls/responsiverow.md
+++ b/website/docs/controls/responsiverow.md
@@ -7,7 +7,7 @@ title: "ResponsiveRow"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Responsive row" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Responsive row" imageWidth="80%"/>
 
 ## Examples
 
@@ -17,12 +17,12 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/basic/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/basic.gif'} width="55%" />
+<Image src={frontMatter.example_images + '/basic.gif'} width="80%" />
 
 ### Custom breakpoints
 
 <CodeExample path={frontMatter.examples + '/custom_breakpoint/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/custom_breakpoint.gif'} width="55%" />
+<Image src={frontMatter.example_images + '/custom_breakpoint.gif'} width="70%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/row.md
+++ b/website/docs/controls/row.md
@@ -7,7 +7,7 @@ title: "Row"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic row of controls" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic row of controls" imageWidth="60%"/>
 
 ## Examples
 
@@ -17,24 +17,24 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/spacing/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/row_spacing_adjustment.gif'} alt="spacing" width="55%" />
+<Image src={frontMatter.example_images + '/row_spacing_adjustment.gif'} alt="spacing" width="70%" />
 
 ### Wrapping children
 
 <CodeExample path={frontMatter.examples + '/wrap/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/wrap_adjustment.gif'} alt="wrap" width="55%" />
+<Image src={frontMatter.example_images + '/wrap_adjustment.gif'} alt="wrap" width="70%" />
 
 ### Setting horizontal alignment
 
 <CodeExample path={frontMatter.examples + '/alignment/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/alignment.png'} alt="alignment" width="40%" />
+<Image src={frontMatter.example_images + '/alignment.png'} alt="alignment" width="28%" />
 
 ### Setting vertical alignment
 
 <CodeExample path={frontMatter.examples + '/vertical_alignment/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/vertical_alignment.png'} alt="vertical-alignment" width="40%" />
+<Image src={frontMatter.example_images + '/vertical_alignment.png'} alt="vertical-alignment" width="23%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/searchbar.md
+++ b/website/docs/controls/searchbar.md
@@ -7,7 +7,7 @@ title: "SearchBar"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic search bar" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic search bar" imageWidth="70%"/>
 
 ## Examples
 
@@ -17,6 +17,6 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/basic/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/basic.png'} alt="basic" width="55%" />
+<Image src={frontMatter.example_images + '/basic.png'} alt="basic" width="45%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/selectionarea.md
+++ b/website/docs/controls/selectionarea.md
@@ -8,7 +8,7 @@ title: "SelectionArea"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Selectable and unselectable text" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Selectable and unselectable text" imageWidth="15%"/>
 
 ## Examples
 
@@ -16,6 +16,6 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/basic/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/basic.gif'} alt="basic" width="55%" />
+<Image src={frontMatter.example_media + '/basic.gif'} alt="basic" width="30%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/shimmer.md
+++ b/website/docs/controls/shimmer.md
@@ -7,7 +7,7 @@ title: "Shimmer"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.gif'} imageCaption="Basic shimmer" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.gif'} imageCaption="Basic shimmer" imageWidth="30%"/>
 
 ## Examples
 
@@ -15,18 +15,18 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/basic/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/image_for_docs.gif'} alt="custom-label" width="50%" />
+<Image src={frontMatter.example_images + '/image_for_docs.gif'} alt="custom-label" width="30%" />
 
 ### Skeleton list placeholders
 
 <CodeExample path={frontMatter.examples + '/basic_placeholder/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/basic_placeholder.png'} alt="custom-label" width="50%" />
+<Image src={frontMatter.example_images + '/basic_placeholder.png'} alt="custom-label" width="30%" />
 
 ### Custom gradients and directions
 
 <CodeExample path={frontMatter.examples + '/custom_gradient/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/custom_gradient.png'} alt="custom-label" width="50%" />
+<Image src={frontMatter.example_images + '/custom_gradient.png'} alt="custom-label" width="30%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/slider.md
+++ b/website/docs/controls/slider.md
@@ -7,7 +7,7 @@ title: "Slider"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic slider" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic slider" imageWidth="70%"/>
 
 ## Examples
 
@@ -17,18 +17,18 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/basic/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/basic.png'} alt="basic" width="55%" />
+<Image src={frontMatter.example_images + '/basic.png'} alt="basic" width="20%" />
 
 ### Setting a custom label
 
 <CodeExample path={frontMatter.examples + '/custom_label/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/custom_label.png'} alt="custom-label" width="55%" />
+<Image src={frontMatter.example_images + '/custom_label.png'} alt="custom-label" width="30%" />
 
 ### Handling events
 
 <CodeExample path={frontMatter.examples + '/handling_events/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/handling_events.png'} alt="handling-events" width="55%" />
+<Image src={frontMatter.example_images + '/handling_events.png'} alt="handling-events" width="25%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/snackbar.md
+++ b/website/docs/controls/snackbar.md
@@ -8,7 +8,7 @@ title: "SnackBar"
 
 import {ClassAll, ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Opened snack bar" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Opened snack bar" imageWidth="30%"/>
 
 ## Examples
 
@@ -18,13 +18,13 @@ import {ClassAll, ClassMembers, ClassSummary, CodeExample, Image} from '@site/sr
 
 <CodeExample path={frontMatter.examples + '/basic/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/basic.png'} alt="basic" width="55%" />
+<Image src={frontMatter.example_images + '/basic.png'} alt="basic" width="30%" />
 
 ### Counter
 
 <CodeExample path={frontMatter.examples + '/counter/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/snack_bar_flow.gif'} alt="Snack bar with counter" width="50%" caption="Snack bar with counter" />
+<Image src={frontMatter.example_images + '/snack_bar_flow.gif'} alt="Snack bar with counter" width="30%" caption="Snack bar with counter" />
 
 ### Action
 

--- a/website/docs/controls/stack.md
+++ b/website/docs/controls/stack.md
@@ -17,12 +17,12 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/online_avatar/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/online_avatar.png'} alt="online-avatar" width="55%" />
+<Image src={frontMatter.example_images + '/online_avatar.png'} alt="online-avatar" width="8%" />
 
 ### Absolute positioning
 
 <CodeExample path={frontMatter.examples + '/absolute_positioning/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/absolute_positioning.png'} alt="absolute-positioning" width="55%" />
+<Image src={frontMatter.example_images + '/absolute_positioning.png'} alt="absolute-positioning" width="20%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/submenubutton.md
+++ b/website/docs/controls/submenubutton.md
@@ -7,7 +7,7 @@ title: "SubmenuButton"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Activated submenu button" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Activated submenu button" imageWidth="25%"/>
 
 ## Examples
 

--- a/website/docs/controls/switch.md
+++ b/website/docs/controls/switch.md
@@ -8,7 +8,7 @@ title: "Switch"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic switch and disabled switch" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic switch and disabled switch" imageWidth="20%"/>
 
 ## Examples
 
@@ -18,12 +18,12 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/basic/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/basic.png'} alt="basic" width="55%" />
+<Image src={frontMatter.example_images + '/basic.png'} alt="basic" width="40%" />
 
 ### Handling change events
 
 <CodeExample path={frontMatter.examples + '/handling_events/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/handling_events.gif'} alt="handling-events" width="55%" />
+<Image src={frontMatter.example_media + '/handling_events.gif'} alt="handling-events" width="40%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/text.md
+++ b/website/docs/controls/text.md
@@ -8,7 +8,7 @@ title: "Text"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic Text control" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic Text control" imageWidth="30%"/>
 
 ## Examples
 
@@ -18,19 +18,19 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/custom_styles/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/custom_styles.gif'} width="55%" />
+<Image src={frontMatter.example_media + '/custom_styles.gif'} width="40%" />
 
 ### Pre-defined theme text styles
 
 <CodeExample path={frontMatter.examples + '/text_theme_styles/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/text_theme_styles.png'} width="55%" />
+<Image src={frontMatter.example_media + '/text_theme_styles.png'} width="40%" />
 
 ### Font with variable weight
 
 <CodeExample path={frontMatter.examples + '/variable_font_weight/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/variable_font_weight.gif'} width="55%" />
+<Image src={frontMatter.example_media + '/variable_font_weight.gif'} width="40%" />
 
 ### Basic rich text example
 

--- a/website/docs/controls/textbutton.md
+++ b/website/docs/controls/textbutton.md
@@ -7,7 +7,7 @@ title: "TextButton"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Simple text button" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Simple text button" imageWidth="20%"/>
 
 ## Examples
 
@@ -17,24 +17,24 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/basic/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/basic.png'} alt="basic" width="55%" />
+<Image src={frontMatter.example_images + '/basic.png'} alt="basic" width="20%" />
 
 ### Icons
 
 <CodeExample path={frontMatter.examples + '/icons/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/icons.png'} alt="icons" width="55%" />
+<Image src={frontMatter.example_images + '/icons.png'} alt="icons" width="30%" />
 
 ### Handling clicks
 
 <CodeExample path={frontMatter.examples + '/handling_clicks/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/handling_clicks.png'} alt="handling-clicks" width="55%" />
+<Image src={frontMatter.example_images + '/handling_clicks.png'} alt="handling-clicks" width="30%" />
 
 ### Custom content
 
 <CodeExample path={frontMatter.examples + '/custom_content/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/custom_content.png'} alt="custom-content" width="55%" />
+<Image src={frontMatter.example_images + '/custom_content.png'} alt="custom-content" width="30%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/textfield.md
+++ b/website/docs/controls/textfield.md
@@ -8,7 +8,7 @@ title: "TextField"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic TextField" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic TextField" imageWidth="30%"/>
 
 ## Examples
 
@@ -18,7 +18,7 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/basic/main.py'} language="python" />
 
-<Image src={frontMatter.example_media + '/basic.gif'} alt="basic" width="55%" />
+<Image src={frontMatter.example_media + '/basic.gif'} alt="basic" width="45%" />
 
 ### Handling change events
 

--- a/website/docs/controls/timepicker.md
+++ b/website/docs/controls/timepicker.md
@@ -7,7 +7,7 @@ title: "TimePicker"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Time picker" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Time picker" imageWidth="60%"/>
 
 ## Examples
 

--- a/website/docs/controls/verticaldivider.md
+++ b/website/docs/controls/verticaldivider.md
@@ -7,7 +7,7 @@ title: "VerticalDivider"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Vertical divider" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Vertical divider" imageWidth="30%"/>
 
 ## Examples
 
@@ -17,6 +17,6 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/basic/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/basic.png'} alt="basic" width="55%" />
+<Image src={frontMatter.example_images + '/basic.png'} alt="basic" width="45%" />
 
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/controls/windowdragarea.md
+++ b/website/docs/controls/windowdragarea.md
@@ -7,7 +7,7 @@ title: "WindowDragArea"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Simple Window Drag Area" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Simple Window Drag Area" imageWidth="70%"/>
 
 ## Examples
 

--- a/website/docs/tutorials/todo.md
+++ b/website/docs/tutorials/todo.md
@@ -8,7 +8,7 @@ import {CodeExample, Image} from '@site/src/components/crocodocs';
 In this tutorial we will show you, step-by-step, how to create a To-Do app in Python
 using Flet framework and then publish it as a desktop, mobile or web app.
 The app is a single-file console program of just
-[163 lines (formatted!) of Python code](https://github.com/flet-dev/flet/blob/main/sdk/python/examples/apps/todo/basic/main.py),
+[167 lines (formatted!) of Python code](https://github.com/flet-dev/flet/blob/main/sdk/python/examples/apps/todo/basic/main.py),
 yet it is a multi-platform application with rich, responsive UI:
 
 <Image src="examples/tutorials/todo/media/complete-demo-web.gif" width="55%" />

--- a/website/docs/types/badge.md
+++ b/website/docs/types/badge.md
@@ -7,7 +7,7 @@ title: "Badge"
 
 import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/components/crocodocs';
 
-<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic Badge" />
+<ClassSummary name={frontMatter.class_name} image={frontMatter.example_images + '/image_for_docs.png'} imageCaption="Basic Badge" imageWidth="10%"/>
 
 ## Examples
 
@@ -17,6 +17,6 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 
 <CodeExample path={frontMatter.examples + '/basic/main.py'} language="python" />
 
-<Image src={frontMatter.example_images + '/basic.png'} width="55%" />
+<Image src={frontMatter.example_images + '/basic.png'} width="40%" />
 
 <ClassMembers name={frontMatter.class_name} />


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

<!-- If this PR fixes an open issue, please link to the issue here. Ex: Fixes #4562 -->

## Test Code

```python
# Test code for the review of this PR
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I signed the CLA.
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass locally with my changes
- [ ] I have made corresponding changes to the [documentation](https://github.com/flet-dev/website) (if applicable)

## Screenshots 

<!-- Add screenshots here if applicable. -->

## Additional details

<!-- Any additional details to be known about this PR. -->

## Summary by Sourcery

Standardize visual presentation of control documentation by adjusting example and summary image widths and updating the To-Do tutorial’s referenced code line count.

Documentation:
- Resize screenshots and animated media across multiple control documentation pages for more consistent layout and readability.
- Update the To-Do tutorial to reflect the current line count of the referenced example application code.