### PR TITLE
Fix 0.85.0 integration tests

### DIFF
--- a/.github/workflows/macos-integration-tests.yml
+++ b/.github/workflows/macos-integration-tests.yml
@@ -38,12 +38,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        alert_test:
-        - test_image_for_docs
-        - test_basic
-        - test_use_dialog_dismiss_fires_after_animation
+        suite:
+        - apps
+        - examples/apps
+        - examples/core
+        - examples/cupertino
+        - examples/extensions
+        - examples/material
+        - controls/core
+        - controls/cupertino
+        - controls/material
+        - controls/services
+        - controls/theme
+        - extensions
 
-    name: "alert_dialog::${{ matrix.alert_test }} + test_button"
+    name: ${{ matrix.suite }} Integration Tests
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -61,15 +70,23 @@ jobs:
         run: |
           uv --version && uv run python --version && pod --version && flutter --version
 
-      - name: Run integration tests
+      - name: Run integration tests (${{ matrix.suite }})
         working-directory: sdk/python
         run: |
-          uv run pytest -s -o log_cli=true -o log_cli_level=INFO packages/flet/integration_tests/examples/material/test_alert_dialog.py::${{ matrix.alert_test }} packages/flet/integration_tests/examples/material/test_button.py::test_handling_clicks
+          uv run pytest -s -o log_cli=true -o log_cli_level=INFO packages/flet/integration_tests/${{ matrix.suite }}
+
+      - name: Prepare failure screenshots
+        if: failure()
+        run: |
+          SAFE_SUITE="${MATRIX_SUITE//\//-}"
+          echo "SAFE_SUITE=$SAFE_SUITE" >> $GITHUB_ENV
+        env:
+          MATRIX_SUITE: ${{ matrix.suite }}
 
       - name: Upload artifact
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: integration-test-failures-macos-${{ matrix.alert_test }}
-          path: sdk/python/packages/flet/integration_tests/examples/material/**/*_actual.png
+          name: integration-test-failures-macos-${{ env.SAFE_SUITE }}
+          path: sdk/python/packages/flet/integration_tests/${{ matrix.suite }}/**/*_actual.png
           if-no-files-found: ignore

--- a/.github/workflows/macos-integration-tests.yml
+++ b/.github/workflows/macos-integration-tests.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Run integration tests
         working-directory: sdk/python
         run: |
-          uv run pytest -s -o log_cli=true -o log_cli_level=INFO packages/flet/integration_tests/examples/material/test_text_button.py
+          uv run pytest -s -o log_cli=true -o log_cli_level=INFO packages/flet/integration_tests/examples/material/test_button.py
 
       - name: Upload artifact
         if: failure()

--- a/.github/workflows/macos-integration-tests.yml
+++ b/.github/workflows/macos-integration-tests.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Run integration tests
         working-directory: sdk/python
         run: |
-          uv run pytest -s -o log_cli=true -o log_cli_level=INFO packages/flet/integration_tests/examples/material/test_text_button.py::test_handling_clicks
+          uv run pytest -s -o log_cli=true -o log_cli_level=INFO packages/flet/integration_tests/examples/material/test_text_button.py
 
       - name: Upload artifact
         if: failure()

--- a/.github/workflows/macos-integration-tests.yml
+++ b/.github/workflows/macos-integration-tests.yml
@@ -35,7 +35,15 @@ env:
 jobs:
   test-macos:
     runs-on: macos-26
-    name: Integration Tests
+    strategy:
+      fail-fast: false
+      matrix:
+        alert_test:
+        - test_image_for_docs
+        - test_basic
+        - test_use_dialog_dismiss_fires_after_animation
+
+    name: "alert_dialog::${{ matrix.alert_test }} + test_button"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -56,12 +64,12 @@ jobs:
       - name: Run integration tests
         working-directory: sdk/python
         run: |
-          uv run pytest -s -o log_cli=true -o log_cli_level=INFO packages/flet/integration_tests/examples/material/test_alert_dialog.py packages/flet/integration_tests/examples/material/test_button.py
+          uv run pytest -s -o log_cli=true -o log_cli_level=INFO packages/flet/integration_tests/examples/material/test_alert_dialog.py::${{ matrix.alert_test }} packages/flet/integration_tests/examples/material/test_button.py::test_handling_clicks
 
       - name: Upload artifact
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: integration-test-failures-macos
+          name: integration-test-failures-macos-${{ matrix.alert_test }}
           path: sdk/python/packages/flet/integration_tests/examples/material/**/*_actual.png
           if-no-files-found: ignore

--- a/.github/workflows/macos-integration-tests.yml
+++ b/.github/workflows/macos-integration-tests.yml
@@ -35,24 +35,7 @@ env:
 jobs:
   test-macos:
     runs-on: macos-26
-    strategy:
-      fail-fast: false
-      matrix:
-        suite:
-        - apps
-        - examples/apps
-        - examples/core
-        - examples/cupertino
-        - examples/extensions
-        - examples/material
-        - controls/core
-        - controls/cupertino
-        - controls/material
-        - controls/services
-        - controls/theme
-        - extensions
-
-    name: ${{ matrix.suite }} Integration Tests
+    name: Integration Tests
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -70,23 +53,15 @@ jobs:
         run: |
           uv --version && uv run python --version && pod --version && flutter --version
 
-      - name: Run integration tests (${{ matrix.suite }})
+      - name: Run integration tests
         working-directory: sdk/python
         run: |
-          uv run pytest -s -o log_cli=true -o log_cli_level=INFO packages/flet/integration_tests/${{ matrix.suite }}
-
-      - name: Prepare failure screenshots
-        if: failure()
-        run: |
-          SAFE_SUITE="${MATRIX_SUITE//\//-}"
-          echo "SAFE_SUITE=$SAFE_SUITE" >> $GITHUB_ENV
-        env:
-          MATRIX_SUITE: ${{ matrix.suite }}
+          uv run pytest -s -o log_cli=true -o log_cli_level=INFO packages/flet/integration_tests/examples/material/test_text_button.py::test_handling_clicks
 
       - name: Upload artifact
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: integration-test-failures-macos-${{ env.SAFE_SUITE }}
-          path: sdk/python/packages/flet/integration_tests/${{ matrix.suite }}/**/*_actual.png
+          name: integration-test-failures-macos
+          path: sdk/python/packages/flet/integration_tests/examples/material/**/*_actual.png
           if-no-files-found: ignore

--- a/.github/workflows/macos-integration-tests.yml
+++ b/.github/workflows/macos-integration-tests.yml
@@ -35,7 +35,13 @@ env:
 jobs:
   test-macos:
     runs-on: macos-26
-    name: Integration Tests
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+        - examples/material
+
+    name: ${{ matrix.suite }} Integration Tests
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -53,15 +59,23 @@ jobs:
         run: |
           uv --version && uv run python --version && pod --version && flutter --version
 
-      - name: Run integration tests
+      - name: Run integration tests (${{ matrix.suite }})
         working-directory: sdk/python
         run: |
-          uv run pytest -s -o log_cli=true -o log_cli_level=INFO packages/flet/integration_tests/examples/material/test_button.py
+          uv run pytest -s -o log_cli=true -o log_cli_level=INFO packages/flet/integration_tests/${{ matrix.suite }}
+
+      - name: Prepare failure screenshots
+        if: failure()
+        run: |
+          SAFE_SUITE="${MATRIX_SUITE//\//-}"
+          echo "SAFE_SUITE=$SAFE_SUITE" >> $GITHUB_ENV
+        env:
+          MATRIX_SUITE: ${{ matrix.suite }}
 
       - name: Upload artifact
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: integration-test-failures-macos
-          path: sdk/python/packages/flet/integration_tests/examples/material/**/*_actual.png
+          name: integration-test-failures-macos-${{ env.SAFE_SUITE }}
+          path: sdk/python/packages/flet/integration_tests/${{ matrix.suite }}/**/*_actual.png
           if-no-files-found: ignore

--- a/.github/workflows/macos-integration-tests.yml
+++ b/.github/workflows/macos-integration-tests.yml
@@ -35,13 +35,7 @@ env:
 jobs:
   test-macos:
     runs-on: macos-26
-    strategy:
-      fail-fast: false
-      matrix:
-        suite:
-        - examples/material
-
-    name: ${{ matrix.suite }} Integration Tests
+    name: Integration Tests
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -59,23 +53,15 @@ jobs:
         run: |
           uv --version && uv run python --version && pod --version && flutter --version
 
-      - name: Run integration tests (${{ matrix.suite }})
+      - name: Run integration tests
         working-directory: sdk/python
         run: |
-          uv run pytest -s -o log_cli=true -o log_cli_level=INFO packages/flet/integration_tests/${{ matrix.suite }}
-
-      - name: Prepare failure screenshots
-        if: failure()
-        run: |
-          SAFE_SUITE="${MATRIX_SUITE//\//-}"
-          echo "SAFE_SUITE=$SAFE_SUITE" >> $GITHUB_ENV
-        env:
-          MATRIX_SUITE: ${{ matrix.suite }}
+          uv run pytest -s -o log_cli=true -o log_cli_level=INFO packages/flet/integration_tests/examples/material/test_alert_dialog.py packages/flet/integration_tests/examples/material/test_button.py
 
       - name: Upload artifact
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: integration-test-failures-macos-${{ env.SAFE_SUITE }}
-          path: sdk/python/packages/flet/integration_tests/${{ matrix.suite }}/**/*_actual.png
+          name: integration-test-failures-macos
+          path: sdk/python/packages/flet/integration_tests/examples/material/**/*_actual.png
           if-no-files-found: ignore

--- a/sdk/python/packages/flet/integration_tests/conftest.py
+++ b/sdk/python/packages/flet/integration_tests/conftest.py
@@ -46,4 +46,5 @@ async def flet_app_function(request):
         yield flet_app
     finally:
         _context_page.reset(token)  # restore previous context to avoid leakage
+        context.disable_components_mode()
         await flet_app.teardown()

--- a/sdk/python/packages/flet/src/flet/controls/context.py
+++ b/sdk/python/packages/flet/src/flet/controls/context.py
@@ -101,6 +101,12 @@ class Context:
         """
         self.__components_mode = True
 
+    def disable_components_mode(self):
+        """
+        Disables components mode in the current context.
+        """
+        self.__components_mode = False
+
     def is_components_mode(self) -> bool:
         """
         Returns whether the current context is in components mode.


### PR DESCRIPTION
## Summary by Sourcery

Ensure test context cleans up components mode after integration tests to prevent state leakage between runs.

Bug Fixes:
- Reset components mode in the test context fixture after each integration test run to avoid leaking state into subsequent tests.

Enhancements:
- Add an API to explicitly disable components mode in the control context.