### PR TITLE
fix: Add full offline support for yarn start to enable local browsing of Flet documentation

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -16,7 +16,16 @@ $ yarn
 $ yarn start
 ```
 
-This command starts a local development server and open up a browser window. Most changes are reflected live without having to restart the server.
+This command runs CrocoDocs generation and starts a local development server.
+If CrocoDocs generation fails (for example while offline), `yarn start` reuses existing generated files from previous successful runs.
+
+If this is the very first run, keep an internet connection and run:
+
+```
+$ yarn crocodocs:generate
+```
+
+Most changes are reflected live without having to restart the server.
 
 ### Build
 

--- a/website/package.json
+++ b/website/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "crocodocs:generate": "cd .. && uv --directory ./tools/crocodocs run crocodocs generate",
-    "start": "yarn crocodocs:generate && docusaurus start",
+    "start": "node ./scripts/start.js",
     "build": "yarn crocodocs:generate && docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy"

--- a/website/scripts/sanitize-offline-artifacts.js
+++ b/website/scripts/sanitize-offline-artifacts.js
@@ -1,0 +1,72 @@
+const fs = require("fs");
+const path = require("path");
+
+/**
+ * Sanitize offline-generated MDX artifacts that may contain unescaped MDX/JSX.
+ * This runs as a post-processing step after CrocoDocs generates partials.
+ *
+ * When CrocoDocs fails (e.g., offline), the PyPI index partial may contain
+ * unescaped characters like <, >, [, ] which break MDX compilation.
+ *
+ * This script replaces invalid partials with safe fallback versions.
+ */
+
+const crocodocs_dir = path.resolve(__dirname, "..", ".crocodocs");
+
+function sanitize_pypi_index() {
+  const pypi_file = path.join(crocodocs_dir, "pypi-index.mdx");
+  if (!fs.existsSync(pypi_file)) {
+    return; // File doesn't exist; nothing to sanitize
+  }
+
+  const content = fs.readFileSync(pypi_file, "utf-8");
+
+  // Check for common unescaped MDX/JSX patterns in warning blocks
+  // (heuristic: if we see <, >, [, ] outside code blocks in a warning, it's likely broken)
+  const lines = content.split("\n");
+  let in_warning = false;
+  let has_unescaped = false;
+
+  for (const line of lines) {
+    if (line.includes(":::warning")) {
+      in_warning = true;
+    } else if (line.includes(":::")) {
+      in_warning = false;
+    }
+
+    if (in_warning) {
+      // Simple heuristic: bare < > [ ] outside backticks are problematic in MDX
+      const outside_backticks = line.replace(/`[^`]+`/g, "");
+      if (/[<>\[\]]/.test(outside_backticks)) {
+        has_unescaped = true;
+        break;
+      }
+    }
+  }
+
+  if (has_unescaped) {
+    // Replace with safe fallback
+    const fallback = `:::info
+PyPI index unavailable (offline or network error).
+
+Run \`yarn crocodocs:generate\` from \`website/\` when online to fetch the latest packages.
+:::
+`;
+    fs.writeFileSync(pypi_file, fallback, "utf-8");
+    console.warn(
+      `  [warn] Sanitized ${pypi_file}: replaced invalid offline content`,
+    );
+  }
+}
+
+// Run sanitization
+try {
+  if (!fs.existsSync(crocodocs_dir)) {
+    // Artifacts directory doesn't exist yet; nothing to sanitize
+    process.exit(0);
+  }
+  sanitize_pypi_index();
+} catch (err) {
+  console.error("Error sanitizing offline artifacts:", err.message);
+  process.exit(1);
+}

--- a/website/scripts/start.js
+++ b/website/scripts/start.js
@@ -11,10 +11,17 @@ const requiredArtifacts = [
   path.join(websiteRoot, "sidebars.js"),
 ];
 
+const ALLOWED_COMMANDS = new Set(["uv", "node", "docusaurus"]);
+
 function run(command, args, options = {}) {
+  if (!ALLOWED_COMMANDS.has(command)) {
+    throw new Error(`Command not allowed: ${command}`);
+  }
   const result = spawnSync(command, args, {
     stdio: "inherit",
-    shell: true,
+    // shell: true is intentionally avoided to prevent command injection.
+    // On Windows, .cmd wrappers in node_modules/.bin require a shell.
+    shell: process.platform === "win32",
     ...options,
   });
   return typeof result.status === "number" ? result.status : 1;

--- a/website/scripts/start.js
+++ b/website/scripts/start.js
@@ -1,0 +1,63 @@
+const fs = require("fs");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const websiteRoot = path.resolve(__dirname, "..");
+const repoRoot = path.resolve(websiteRoot, "..");
+
+const requiredArtifacts = [
+  path.join(websiteRoot, ".crocodocs", "api-data.json"),
+  path.join(websiteRoot, ".crocodocs", "docs-manifest.json"),
+  path.join(websiteRoot, "sidebars.js"),
+];
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    stdio: "inherit",
+    shell: true,
+    ...options,
+  });
+  return typeof result.status === "number" ? result.status : 1;
+}
+
+function hasAllArtifacts() {
+  return requiredArtifacts.every((file) => fs.existsSync(file));
+}
+
+const generateExitCode = run(
+  "uv",
+  ["--directory", "./tools/crocodocs", "run", "crocodocs", "generate"],
+  { cwd: repoRoot },
+);
+
+if (generateExitCode !== 0) {
+  if (!hasAllArtifacts()) {
+    console.error(
+      "\nCrocoDocs generation failed and required generated artifacts are missing.",
+    );
+    console.error(
+      "Connect to the internet once and run 'yarn crocodocs:generate' from website/.\n",
+    );
+    process.exit(generateExitCode);
+  }
+
+  console.warn(
+    "\nCrocoDocs generation failed. Reusing existing generated artifacts for offline start.\n",
+  );
+}
+
+// Sanitize offline-generated artifacts (removes unescaped MDX/JSX in error messages)
+const sanitizeExitCode = run(
+  "node",
+  [path.join("scripts", "sanitize-offline-artifacts.js")],
+  {
+    cwd: websiteRoot,
+  },
+);
+if (sanitizeExitCode !== 0) {
+  console.error("Failed to sanitize offline artifacts");
+  process.exit(sanitizeExitCode);
+}
+
+const startExitCode = run("docusaurus", ["start"], { cwd: websiteRoot });
+process.exit(startExitCode);


### PR DESCRIPTION
## 📝 PR Description

This pull request introduces full offline support for running `yarn start`, allowing contributors and users to browse the Flet documentation locally without requiring an Internet connection.

Motivation
Not everyone has access to an unlimited or stable Internet connection, — myself included... By default, Docusaurus may attempt to fetch external resources during development, which can cause errors or prevent the local dev server from starting when offline. This makes contributing or consulting the documentation difficult in low‑connectivity environments.

What this change does
- Removes or bypasses unnecessary network requests during "yarn start".
- Ensures all required assets are served locally (as long as the site has been successfully built at least once beforehand).
- Then, allows the documentation site to be fully navigable offline.

Benefits
- yarn start works reliably even with no Internet connection.
- Contributors can work on documentation anywhere, regardless of connectivity.
- Users with limited or expensive bandwidth can still access the full docs locally.
- Improves accessibility and developer experience for the entire community.

## Test Code

```python
# Test code for the review of this PR
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation updated (done)

## Checklist

- [x] I signed the CLA.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass locally with my changes
- [x] I have made corresponding changes to the [documentation](https://github.com/flet-dev/website) (if applicable)

## Summary by Sourcery

Enable running the documentation site locally with full offline support while preserving existing generated artifacts when CrocoDocs cannot run.

New Features:
- Allow `yarn start` to reuse previously generated CrocoDocs artifacts so the docs site can start while offline.
- Introduce a sanitization step for CrocoDocs-generated MDX artifacts to replace invalid offline content with a safe fallback message.

Enhancements:
- Route `yarn start` through a custom Node script that coordinates CrocoDocs generation, artifact validation, sanitization, and Docusaurus startup.
- Clarify README instructions for running the docs site locally, including initial online setup and offline behavior of `yarn start`.