### PR TITLE
fix: reduce Linux video memory retention with mimalloc linking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Bug fixes
 
-* Reduce Linux memory retention when repeatedly removing `flet_video.Video` controls by linking `media_kit` video apps against mimalloc in run and build flows ([#6164](https://github.com/flet-dev/flet/issues/6164)) by @ndonkoHenri.
+* Reduce Linux memory retention when repeatedly removing `flet_video.Video` controls by linking `media_kit` video apps against mimalloc in run and build flows ([#6164](https://github.com/flet-dev/flet/issues/6164), [#6416](https://github.com/flet-dev/flet/pull/6416)) by @ndonkoHenri.
 * Fix `flet build` and `flet publish` dependency parsing for `project.dependencies` and Poetry constraints with `<`/`<=`, and add coverage for normalized requirement handling ([#6332](https://github.com/flet-dev/flet/issues/6332), [#6340](https://github.com/flet-dev/flet/pull/6340)) by @td3447.
 * Fix `CodeEditor` background not filling the entire area when `expand=True` ([#6407](https://github.com/flet-dev/flet/pull/6407)) by @FeodorFitsner.
 * Handle unbounded width in `ResponsiveRow` with an explicit error, treat child controls with `col=0` as hidden, and clarify `Container` expansion behavior when `alignment` is set ([#1951](https://github.com/flet-dev/flet/issues/1951), [#3805](https://github.com/flet-dev/flet/issues/3805), [#5209](https://github.com/flet-dev/flet/issues/5209), [#6354](https://github.com/flet-dev/flet/pull/6354)) by @ndonkoHenri.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Bug fixes
 
+* Reduce Linux memory retention when repeatedly removing `flet_video.Video` controls by linking `media_kit` video apps against mimalloc in run and build flows ([#6164](https://github.com/flet-dev/flet/issues/6164)) by @ndonkoHenri.
 * Fix `flet build` and `flet publish` dependency parsing for `project.dependencies` and Poetry constraints with `<`/`<=`, and add coverage for normalized requirement handling ([#6332](https://github.com/flet-dev/flet/issues/6332), [#6340](https://github.com/flet-dev/flet/pull/6340)) by @td3447.
 * Fix `CodeEditor` background not filling the entire area when `expand=True` ([#6407](https://github.com/flet-dev/flet/pull/6407)) by @FeodorFitsner.
 * Handle unbounded width in `ResponsiveRow` with an explicit error, treat child controls with `col=0` as hidden, and clarify `Container` expansion behavior when `alignment` is set ([#1951](https://github.com/flet-dev/flet/issues/1951), [#3805](https://github.com/flet-dev/flet/issues/3805), [#5209](https://github.com/flet-dev/flet/issues/5209), [#6354](https://github.com/flet-dev/flet/pull/6354)) by @ndonkoHenri.

--- a/client/linux/CMakeLists.txt
+++ b/client/linux/CMakeLists.txt
@@ -91,6 +91,12 @@ set_target_properties(${BINARY_NAME}
 # them to the application.
 include(flutter/generated_plugins.cmake)
 
+# Link mimalloc when media_kit_libs_linux exposes it. This must happen after
+# generated plugins are included so MIMALLOC_LIB is initialized.
+if(MIMALLOC_LIB)
+  target_link_libraries(${BINARY_NAME} PRIVATE ${MIMALLOC_LIB})
+endif()
+
 
 # === Installation ===
 # By default, "installing" just makes a relocatable bundle in the build

--- a/sdk/python/packages/flet-video/CHANGELOG.md
+++ b/sdk/python/packages/flet-video/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 0.85.0
+
+### Fixed
+
+- Reduce Linux memory retention when repeatedly removing `Video` controls by linking `media_kit` video apps against mimalloc in Flet run and build flows ([#6164](https://github.com/flet-dev/flet/issues/6164)).
+
 ## 0.80.0
 
 ### Added

--- a/sdk/python/packages/flet-video/CHANGELOG.md
+++ b/sdk/python/packages/flet-video/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Reduce Linux memory retention when repeatedly removing `Video` controls by linking `media_kit` video apps against mimalloc in Flet run and build flows ([#6164](https://github.com/flet-dev/flet/issues/6164)).
+- Reduce Linux memory retention when repeatedly removing `Video` controls by linking `media_kit` video apps against mimalloc in Flet run and build flows ([#6164](https://github.com/flet-dev/flet/issues/6164), [#6416](https://github.com/flet-dev/flet/pull/6416)).
 
 ## 0.80.0
 

--- a/sdk/python/templates/build/{{cookiecutter.out_dir}}/linux/CMakeLists.txt
+++ b/sdk/python/templates/build/{{cookiecutter.out_dir}}/linux/CMakeLists.txt
@@ -73,7 +73,6 @@ apply_standard_settings(${BINARY_NAME})
 # Add dependency libraries. Add any application-specific dependencies here.
 target_link_libraries(${BINARY_NAME} PRIVATE flutter)
 target_link_libraries(${BINARY_NAME} PRIVATE PkgConfig::GTK)
-target_link_libraries(${BINARY_NAME} PRIVATE ${MIMALLOC_LIB})
 
 # Run the Flutter tool portions of the build. This must not be removed.
 add_dependencies(${BINARY_NAME} flutter_assemble)
@@ -92,6 +91,12 @@ set_target_properties(${BINARY_NAME}
 # Generated plugin build rules, which manage building the plugins and adding
 # them to the application.
 include(flutter/generated_plugins.cmake)
+
+# Link mimalloc when media_kit_libs_linux exposes it. This must happen after
+# generated plugins are included so MIMALLOC_LIB is initialized.
+if(MIMALLOC_LIB)
+  target_link_libraries(${BINARY_NAME} PRIVATE ${MIMALLOC_LIB})
+endif()
 
 
 # === Installation ===


### PR DESCRIPTION
This addresses repeated `flet_video.Video` teardown on Linux retaining media_kit/libmpv memory. The generated build template already attempted to link mimalloc, but did so before `flutter/generated_plugins.cmake` initialized `MIMALLOC_LIB`, making the link ineffective.

Fix #6164

## Summary by Sourcery

Ensure Linux Flutter video binaries correctly link mimalloc after plugin initialization to reduce memory retention when tearing down video controls.

Bug Fixes:
- Reduce memory retention on Linux when repeatedly removing video controls by conditionally linking mimalloc after generated plugins initialize its library variable.

Build:
- Adjust Linux CMake configuration for Flutter binaries to link mimalloc only when available and after plugin-generated CMake is included.

Documentation:
- Document the Linux video memory retention fix and mimalloc linking behavior in the main changelog and the flet-video package changelog.