### PR TITLE
fix(linux): link libpthread alongside mimalloc.o

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -523,7 +523,7 @@ jobs:
             echo "::endgroup::"
 
             echo "::group::($PACKAGE_NAME) Flutter build"
-            flutter build linux --verbose --build-name="$PKG_VER" --build-number="$BUILD_NUM"
+            flutter build linux --build-name="$PKG_VER" --build-number="$BUILD_NUM"
 
             # Remove any previous build output, so mv below works as expected
             rm -rf "build/linux/${BUILD_ARCH}/release/flet"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -523,7 +523,7 @@ jobs:
             echo "::endgroup::"
 
             echo "::group::($PACKAGE_NAME) Flutter build"
-            flutter build linux --build-name="$PKG_VER" --build-number="$BUILD_NUM"
+            flutter build linux --verbose --build-name="$PKG_VER" --build-number="$BUILD_NUM"
 
             # Remove any previous build output, so mv below works as expected
             rm -rf "build/linux/${BUILD_ARCH}/release/flet"

--- a/client/linux/CMakeLists.txt
+++ b/client/linux/CMakeLists.txt
@@ -93,9 +93,17 @@ include(flutter/generated_plugins.cmake)
 
 # Link mimalloc when media_kit_libs_linux exposes it. This must happen after
 # generated plugins are included so MIMALLOC_LIB is initialized.
+message(NOTICE "DIAG: MIMALLOC_LIB=[${MIMALLOC_LIB}]")
 if(MIMALLOC_LIB)
+  if(EXISTS "${MIMALLOC_LIB}")
+    message(NOTICE "DIAG: MIMALLOC_LIB exists on disk")
+  else()
+    message(NOTICE "DIAG: MIMALLOC_LIB does NOT exist on disk")
+  endif()
   target_link_libraries(${BINARY_NAME} PRIVATE ${MIMALLOC_LIB})
 endif()
+# DIAG: surface the real ld error that Flutter's build UI normally hides.
+target_link_options(${BINARY_NAME} PRIVATE "LINKER:--verbose")
 
 
 # === Installation ===

--- a/client/linux/CMakeLists.txt
+++ b/client/linux/CMakeLists.txt
@@ -93,17 +93,12 @@ include(flutter/generated_plugins.cmake)
 
 # Link mimalloc when media_kit_libs_linux exposes it. This must happen after
 # generated plugins are included so MIMALLOC_LIB is initialized.
-message(NOTICE "DIAG: MIMALLOC_LIB=[${MIMALLOC_LIB}]")
+# mimalloc.o references pthread_*, so pair it with Threads::Threads — modern
+# ld --as-needed won't pull libpthread in transitively through other DSOs.
 if(MIMALLOC_LIB)
-  if(EXISTS "${MIMALLOC_LIB}")
-    message(NOTICE "DIAG: MIMALLOC_LIB exists on disk")
-  else()
-    message(NOTICE "DIAG: MIMALLOC_LIB does NOT exist on disk")
-  endif()
-  target_link_libraries(${BINARY_NAME} PRIVATE ${MIMALLOC_LIB})
+  find_package(Threads REQUIRED)
+  target_link_libraries(${BINARY_NAME} PRIVATE ${MIMALLOC_LIB} Threads::Threads)
 endif()
-# DIAG: surface the real ld error that Flutter's build UI normally hides.
-target_link_options(${BINARY_NAME} PRIVATE "LINKER:--verbose")
 
 
 # === Installation ===

--- a/sdk/python/templates/build/{{cookiecutter.out_dir}}/linux/CMakeLists.txt
+++ b/sdk/python/templates/build/{{cookiecutter.out_dir}}/linux/CMakeLists.txt
@@ -94,8 +94,11 @@ include(flutter/generated_plugins.cmake)
 
 # Link mimalloc when media_kit_libs_linux exposes it. This must happen after
 # generated plugins are included so MIMALLOC_LIB is initialized.
+# mimalloc.o references pthread_*, so pair it with Threads::Threads — modern
+# ld --as-needed won't pull libpthread in transitively through other DSOs.
 if(MIMALLOC_LIB)
-  target_link_libraries(${BINARY_NAME} PRIVATE ${MIMALLOC_LIB})
+  find_package(Threads REQUIRED)
+  target_link_libraries(${BINARY_NAME} PRIVATE ${MIMALLOC_LIB} Threads::Threads)
 endif()
 
 


### PR DESCRIPTION
## Summary

- The Linux client has been failing to link on every distro in the CI matrix since mimalloc was actually wired up in #6416. `mimalloc.o` uses `pthread_setspecific`; with `ld --as-needed` (default on Ubuntu 20.04+), libpthread won't be pulled in transitively and the final link aborts with `undefined reference to symbol 'pthread_setspecific@@GLIBC_2.2.5'` / `libpthread.so.0: error adding symbols: DSO missing from command line`.
- Pair the mimalloc link with `Threads::Threads` in both [client/linux/CMakeLists.txt](../blob/diag/mimalloc-ld/client/linux/CMakeLists.txt) and the `flet build linux` template so libpthread is explicitly on the link line.
- Ubuntu 20.04 was the only distro that surfaced in logs because fail-fast cancelled the rest of the matrix — all Linux distros would hit the same failure.

## Investigation

Flutter's build UI swallows `ld` stderr, leaving only a bare `clang: error: linker command failed with exit code 1` in CI. I pushed a temporary diagnostic commit (reverted in this branch) that added `flutter build linux --verbose`, `LINKER:--verbose`, and `message(NOTICE ...)` dumps for `MIMALLOC_LIB`. The diagnostic run (https://github.com/flet-dev/flet/actions/runs/24813135717) confirmed the undefined-symbol failure.

## Test plan

- [ ] CI passes on Ubuntu 20.04 AMD64.
- [ ] CI passes on all other Linux matrix entries (Debian 10/12, Ubuntu 22.04/24.04, both AMD64 + ARM64).

## Summary by Sourcery

Ensure Linux client binaries explicitly link pthread when mimalloc is enabled to fix linker failures on modern distributions.

Build:
- Update Linux client CMake configuration to link Threads::Threads alongside mimalloc when MIMALLOC_LIB is present.
- Update Python SDK Linux build template to mirror the explicit pthread linkage for mimalloc-enabled builds.