### PR TITLE
fix: TextField focus trapped when using D-pad or Arrow keys on Android TV/Desktop

### DIFF
--- a/packages/flet/lib/src/controls/textfield.dart
+++ b/packages/flet/lib/src/controls/textfield.dart
@@ -44,13 +44,13 @@ class _TextFieldControlState extends State<TextFieldControl> {
     if ((event is KeyDownEvent || event is KeyRepeatEvent) &&
         widget.control.getBool("ignore_up_down_keys", false)!) {
       if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
-        FocusScope.of(_focusNode.context!)
-            .focusInDirection(TraversalDirection.down);
+        FocusTraversalGroup.of(_focusNode.context!)
+            .inDirection(_focusNode, TraversalDirection.down);
         return KeyEventResult.handled;
       }
       if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
-        FocusScope.of(_focusNode.context!)
-            .focusInDirection(TraversalDirection.up);
+        FocusTraversalGroup.of(_focusNode.context!)
+            .inDirection(_focusNode, TraversalDirection.up);
         return KeyEventResult.handled;
       }
     }

--- a/packages/flet/lib/src/controls/textfield.dart
+++ b/packages/flet/lib/src/controls/textfield.dart
@@ -45,7 +45,7 @@ class _TextFieldControlState extends State<TextFieldControl> {
         widget.control.getBool("ignore_up_down_keys", false)! &&
         (event.logicalKey == LogicalKeyboardKey.arrowUp ||
             event.logicalKey == LogicalKeyboardKey.arrowDown)) {
-      return KeyEventResult.handled;
+      return KeyEventResult.ignored;
     }
 
     // submit on Enter if flag is set and shift is not pressed

--- a/packages/flet/lib/src/controls/textfield.dart
+++ b/packages/flet/lib/src/controls/textfield.dart
@@ -42,10 +42,17 @@ class _TextFieldControlState extends State<TextFieldControl> {
       {required bool submitOnEnter}) {
     // ignore up/down arrow keys if flag is set
     if ((event is KeyDownEvent || event is KeyRepeatEvent) &&
-        widget.control.getBool("ignore_up_down_keys", false)! &&
-        (event.logicalKey == LogicalKeyboardKey.arrowUp ||
-            event.logicalKey == LogicalKeyboardKey.arrowDown)) {
-      return KeyEventResult.ignored;
+        widget.control.getBool("ignore_up_down_keys", false)!) {
+      if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+        FocusScope.of(_focusNode.context!)
+            .focusInDirection(TraversalDirection.down);
+        return KeyEventResult.handled;
+      }
+      if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+        FocusScope.of(_focusNode.context!)
+            .focusInDirection(TraversalDirection.up);
+        return KeyEventResult.handled;
+      }
     }
 
     // submit on Enter if flag is set and shift is not pressed


### PR DESCRIPTION
## Description
Currently, when `ignore_up_down_keys` is set to `True`, the `TextField` marks arrow key events as handled but doesn't trigger any focus movement. This creates a **_"focus trap"_** where users (especially on Android TV with D-pads) cannot navigate away from the `TextField` using vertical arrows.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

<!-- If this PR fixes an open issue, please link to the issue here. Ex: Fixes #4562 -->

## Test Code

```python
# Test code for the review of this PR
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I signed the CLA.
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass locally with my changes
- [ ] I have made corresponding changes to the [documentation](https://github.com/flet-dev/website) (if applicable)

## Summary by Sourcery

Bug Fixes:
- Allow focus to move out of a text field when using up/down arrow keys or D-pad despite ignore_up_down_keys being enabled by delegating focus traversal instead of swallowing the events.