### PR TITLE
fix(charts): fix LineChart left_axis labels display incomplete #6445

### DIFF
--- a/sdk/python/packages/flet-charts/src/flutter/flet_charts/lib/src/utils/charts.dart
+++ b/sdk/python/packages/flet-charts/src/flutter/flet_charts/lib/src/utils/charts.dart
@@ -156,8 +156,10 @@ AxisTitles parseAxisTitles(Control? control) {
         getTitlesWidget: labels.isEmpty
             ? defaultGetTitle
             : (double value, TitleMeta meta) {
-                var label = labels
-                    .firstWhereOrNull((l) => l.getDouble("value") == value);
+                var label = labels.firstWhereOrNull(
+                  // (l) => l.getDouble("value") == value
+                  (l) => (l.getDouble("value")! - value).abs() < 0.001, //floating-point precision errors
+                  );
                 return label?.buildTextOrWidget("label") ??
                     const SizedBox.shrink();
               },


### PR DESCRIPTION
Fixes #6445

## Description
The bug was caused by floating-point precision errors in the axis label layout calculation.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


## Screenshots 

<img width="1441" height="817" alt="issue2" src="https://github.com/user-attachments/assets/231b2343-63b5-44f4-8e9e-72ac68a8552f" />

## Summary by Sourcery

Bug Fixes:
- Ensure axis label selection uses a tolerance-based comparison to avoid missing labels due to floating-point precision errors.