### PR TITLE
fix(flet-charts): match axis labels with float tolerance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Fix `flet pack` desktop packaging so Windows and Linux bundles include the expected client archive, and Windows taskbar pins point to the packed app instead of the cached `flet.exe` ([#5151](https://github.com/flet-dev/flet/issues/5151), [#6403](https://github.com/flet-dev/flet/pull/6403)) by @ndonkoHenri.
 * Fix environment variable priority in `flet build` template: inherit from `Platform.environment` and use `putIfAbsent` for FLET_* variables so pre-set system env vars are not overwritten ([#6394](https://github.com/flet-dev/flet/pull/6394)) by @Bahtya.
 * Fix 3- and 4-digit hex color shorthand (e.g. `#c00`, `#fc00`) rendering as invisible by expanding them to their full 6/8-digit forms ([#6419](https://github.com/flet-dev/flet/issues/6419), [#6421](https://github.com/flet-dev/flet/pull/6421)) by @ndonkoHenri.
+* Fix `LineChart` (and other charts) silently dropping custom `ChartAxisLabel` entries whose `value` matched a tick only after floating-point rounding (e.g. `0.1`, `0.2`, `0.3`) by switching label lookup to a tolerance-based comparison scaled to the axis interval ([#6445](https://github.com/flet-dev/flet/issues/6445), [#6459](https://github.com/flet-dev/flet/pull/6459)) by @KangZhaoKui.
 
 ### Other changes
 

--- a/sdk/python/packages/flet-charts/src/flutter/flet_charts/lib/src/utils/charts.dart
+++ b/sdk/python/packages/flet-charts/src/flutter/flet_charts/lib/src/utils/charts.dart
@@ -156,8 +156,11 @@ AxisTitles parseAxisTitles(Control? control) {
         getTitlesWidget: labels.isEmpty
             ? defaultGetTitle
             : (double value, TitleMeta meta) {
-                var label = labels
-                    .firstWhereOrNull((l) => l.getDouble("value") == value);
+                final epsilon = meta.appliedInterval * 1e-3;
+                final label = labels.firstWhereOrNull((l) {
+                  final v = l.getDouble("value");
+                  return v != null && (v - value).abs() < epsilon;
+                });
                 return label?.buildTextOrWidget("label") ??
                     const SizedBox.shrink();
               },


### PR DESCRIPTION
Fixes #6445. Supersedes #6452 — thanks @KangZhaoKui for the original report and fix.

## Description

`ChartAxisLabel` entries silently disappeared from the axis because labels were matched against tick values with `==`, which fails for doubles like `0.1`, `0.2`, `0.3` due to IEEE 754 representation.

This change uses a tolerance-based comparison scaled by `meta.appliedInterval`, so it adapts to the chart's value range instead of relying on a hardcoded epsilon.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

- [ ] Run the repro from #6445 and confirm all 11 left-axis labels render (0%–100%).
- [ ] Verify charts with very small ranges (e.g. 0.0001 step) still match correctly.
- [ ] Verify charts with large ranges (e.g. 0–1000) still match correctly.

## Summary by Sourcery

Bug Fixes:
- Fix axis labels not rendering when their double values failed exact equality comparison with tick values due to floating-point precision.