### PR TITLE
chore: bump serious_python to 0.9.12 in build template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * Add a declarative `ReorderableListView` app example showing add, remove, and reorder flows with stable item identity ([#6374](https://github.com/flet-dev/flet/pull/6374)) by @FeodorFitsner.
 * Remove deprecated module-level `margin`, `padding`, `border`, and `border_radius` helpers (`all()`, `symmetric()`, `only()`, `horizontal()`, `vertical()`) in favor of the corresponding `Margin`, `Padding`, `Border`, and `BorderRadius` classmethods ([#6425](https://github.com/flet-dev/flet/pull/6425)) by @ndonkoHenri.
 * Centralize Linux apt dependencies in `flet.utils.linux_deps` and update CI workflows and publish docs to consume them dynamically ([#6357](https://github.com/flet-dev/flet/issues/6357), [#6383](https://github.com/flet-dev/flet/pull/6383)) by @ndonkoHenri.
+* Bump `serious_python` to `0.9.12` in the `flet build` template ([#6461](https://github.com/flet-dev/flet/pull/6461)) by @FeodorFitsner.
 
 ## 0.84.0
 

--- a/sdk/python/templates/build/{{cookiecutter.out_dir}}/pubspec.yaml
+++ b/sdk/python/templates/build/{{cookiecutter.out_dir}}/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
 
   flet:
     path: ../../../../../packages/flet
-  serious_python: 0.9.11
+  serious_python: 0.9.12
 
   package_info_plus: ^9.0.0
   path_provider: ^2.1.4


### PR DESCRIPTION
## Summary

- Bump `serious_python` dependency from `0.9.11` to `0.9.12` in the `flet build` template `pubspec.yaml`.

## Test plan

- [ ] `flet build` produces an app pinned to `serious_python: 0.9.12`.

## Summary by Sourcery

Build:
- Bump serious_python dependency from 0.9.11 to 0.9.12 in the flet build pubspec.yaml template.