### PR TITLE
ci: add flet-build base image (manual workflow)

### DIFF
--- a/.github/workflows/flet-build-image.yml
+++ b/.github/workflows/flet-build-image.yml
@@ -1,0 +1,147 @@
+name: Build flet-build base image
+
+on:
+  workflow_dispatch:
+    inputs:
+      flutter_version:
+        description: "Flutter version (e.g. 3.41.7). Leave blank to read from .fvmrc."
+        required: false
+      push_latest:
+        description: "Also push :latest"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE: ghcr.io/${{ github.repository_owner }}/flet-build
+
+jobs:
+  resolve_version:
+    name: Resolve Flutter version
+    runs-on: ubuntu-latest
+    outputs:
+      flutter_version: ${{ steps.v.outputs.value }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Resolve version
+        id: v
+        run: |
+          if [ -n "${{ inputs.flutter_version }}" ]; then
+            v="${{ inputs.flutter_version }}"
+          else
+            v="$(jq -r .flutter .fvmrc)"
+          fi
+          echo "value=${v}" >> "$GITHUB_OUTPUT"
+          echo "Flutter version: ${v}"
+
+  build:
+    name: Build (${{ matrix.platform }})
+    needs: resolve_version
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    env:
+      FLUTTER_VERSION: ${{ needs.resolve_version.outputs.flutter_version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Compute platform pair
+        id: pair
+        run: |
+          p="${{ matrix.platform }}"
+          echo "value=${p//\//-}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/flet-build
+          file: docker/flet-build/Dockerfile
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            FLUTTER_VERSION=${{ env.FLUTTER_VERSION }}
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=flet-build-${{ steps.pair.outputs.value }}
+          cache-to: type=gha,mode=max,scope=flet-build-${{ steps.pair.outputs.value }}
+          provenance: false
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: flet-build-digests-${{ steps.pair.outputs.value }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge & push manifest
+    needs:
+      - resolve_version
+      - build
+    runs-on: ubuntu-latest
+    env:
+      FLUTTER_VERSION: ${{ needs.resolve_version.outputs.flutter_version }}
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: flet-build-digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute tag flags
+        id: tags
+        run: |
+          MM="${FLUTTER_VERSION%.*}"
+          flags="-t ${IMAGE}:${FLUTTER_VERSION} -t ${IMAGE}:${MM}"
+          if [ "${{ inputs.push_latest }}" = "true" ]; then
+            flags="${flags} -t ${IMAGE}:latest"
+          fi
+          echo "flags=${flags}" >> "$GITHUB_OUTPUT"
+
+      - name: Create & push manifest
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create ${{ steps.tags.outputs.flags }} \
+            $(printf "${IMAGE}@sha256:%s " *)
+
+      - name: Inspect image
+        run: docker buildx imagetools inspect "${IMAGE}:${FLUTTER_VERSION}"

--- a/docker/flet-build/Dockerfile
+++ b/docker/flet-build/Dockerfile
@@ -1,0 +1,52 @@
+# syntax=docker/dockerfile:1.7
+#
+# Base image for building Flet web apps.
+#
+# Bakes Python + uv + Flutter SDK on PATH. No Flet CLI, no app warmup —
+# downstream Dockerfiles install the Flet version they need via uv and run
+# `flet build web` themselves, picking up the pre-installed Flutter
+# automatically (Flet validates Flutter major.minor only and falls back to
+# `shutil.which("flutter")` for discovery).
+#
+# Built and published manually from .github/workflows/flet-build-image.yml
+# for both linux/amd64 and linux/arm64. Image: ghcr.io/flet-dev/flet-build.
+
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+
+ARG TARGETARCH
+ARG FLUTTER_VERSION
+
+ENV FLUTTER_VERSION=${FLUTTER_VERSION} \
+    FLUTTER_HOME=/opt/flutter \
+    PATH="/opt/flutter/bin:${PATH}"
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      ca-certificates curl git unzip xz-utils zip \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN git config --global --add safe.directory '*'
+
+# linux/amd64: download prebuilt stable tarball.
+# linux/arm64: clone Flutter repo at the version tag - the stable channel
+# doesn't ship linux-arm64 binaries (same trick the existing Linux client CI
+# uses via subosito/flutter-action's master channel,
+# https://github.com/subosito/flutter-action/issues/345).
+RUN set -eux; \
+    mkdir -p /opt; \
+    case "$TARGETARCH" in \
+      amd64) \
+        curl -fL "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_${FLUTTER_VERSION}-stable.tar.xz" \
+          | tar -xJ -C /opt ;; \
+      arm64) \
+        git clone --depth 1 --branch "${FLUTTER_VERSION}" \
+          https://github.com/flutter/flutter.git /opt/flutter ;; \
+      *) echo "Unsupported TARGETARCH=$TARGETARCH"; exit 1 ;; \
+    esac
+
+RUN flutter --version \
+ && flutter config --no-analytics \
+ && flutter precache --web \
+      --no-android --no-ios --no-linux --no-windows --no-macos --no-fuchsia
+
+WORKDIR /app


### PR DESCRIPTION
## Summary
- Adds a slim Docker base image — Python + uv + Flutter SDK on PATH — published to `ghcr.io/flet-dev/flet-build`. No Flet CLI baked in, no app warmup. Downstream installs Flet via `uv sync` / `uv tool install` and runs `flet build web` themselves; Flet picks up Flutter from PATH automatically.
- Manual `workflow_dispatch` only. Image rebuild cadence is decoupled from Flet releases: Flet only validates Flutter major.minor ([flutter_base.py:211](https://github.com/flet-dev/flet/blob/main/sdk/python/packages/flet-cli/src/flet_cli/commands/flutter_base.py#L211)) and discovers it via `shutil.which` ([flutter_base.py:387](https://github.com/flet-dev/flet/blob/main/sdk/python/packages/flet-cli/src/flet_cli/commands/flutter_base.py#L387)), so a `:3.41` image satisfies any Flet release wanting Flutter 3.41.x.
- Multi-arch: `linux/amd64` (prebuilt stable tarball) + `linux/arm64` (git-clone at version tag, since the stable channel ships no linux-arm64 binaries — same trick the existing Linux client CI uses via subosito/flutter-action's master channel). Built per-arch on native runners (`ubuntu-latest` / `ubuntu-24.04-arm`), assembled into a multi-arch manifest.
- Tag scheme: `:X.Y.Z`, `:X.Y`, `:latest` (`:latest` togglable via input).

## Test plan
- [ ] Merge this PR, then `gh workflow run flet-build-image.yml --ref main -f flutter_version=3.41.7 -f push_latest=true`
- [ ] Verify both jobs (`build (linux/amd64)`, `build (linux/arm64)`) succeed and `merge` pushes the manifest
- [ ] `docker buildx imagetools inspect ghcr.io/flet-dev/flet-build:3.41` shows both arches
- [ ] One-time: flip the new GHCR package visibility to public
- [ ] `docker run --rm ghcr.io/flet-dev/flet-build:3.41 bash -c 'flutter --version && uv --version && python --version'` returns expected versions
- [ ] Smoke: in a minimal Flet app dir, `docker run --rm -v "$PWD":/app -w /app ghcr.io/flet-dev/flet-build:3.41 bash -c 'uv sync && uv run flet build web -v'` reaches `flutter build web` without re-installing Flutter

## Summary by Sourcery

Introduce a manually triggered CI workflow to build and publish a multi-architecture Docker base image providing Python, uv, and Flutter for Flet web builds.

Enhancements:
- Create a Dockerfile for a slim flet-build base image that installs Python 3.12, uv, and a Flutter SDK matching a specified version for both amd64 and arm64 architectures.

Build:
- Add a workflow_dispatch GitHub Actions workflow to build per-architecture images, assemble them into a multi-arch manifest, and publish to GHCR with semantic version and optional latest tags.

CI:
- Configure matrix-based GitHub Actions jobs to build and cache linux/amd64 and linux/arm64 images on appropriate runners and merge their digests into a single multi-arch image manifest.

Deployment:
- Define and publish a new flet-build Docker base image to ghcr.io for downstream Flet web build pipelines.