### PR TITLE
fix: resolve absolute-path `src` against `assets_dir` on web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * Fix environment variable priority in `flet build` template: inherit from `Platform.environment` and use `putIfAbsent` for FLET_* variables so pre-set system env vars are not overwritten ([#6394](https://github.com/flet-dev/flet/pull/6394)) by @Bahtya.
 * Fix 3- and 4-digit hex color shorthand (e.g. `#c00`, `#fc00`) rendering as invisible by expanding them to their full 6/8-digit forms ([#6419](https://github.com/flet-dev/flet/issues/6419), [#6421](https://github.com/flet-dev/flet/pull/6421)) by @ndonkoHenri.
 * Fix `LineChart` (and other charts) silently dropping custom `ChartAxisLabel` entries whose `value` matched a tick only after floating-point rounding (e.g. `0.1`, `0.2`, `0.3`) by switching label lookup to a tolerance-based comparison scaled to the axis interval ([#6445](https://github.com/flet-dev/flet/issues/6445), [#6459](https://github.com/flet-dev/flet/pull/6459)) by @KangZhaoKui.
+* Fix absolute-path `src` (e.g. `Image(src="/images/foo.svg")`) breaking on web when the app is mounted at a non-root URL, pass `data:`/`blob:` URIs through the asset resolver unchanged, preserve origin-relative semantics when `assets_dir` is unset, and add a `window.flet.assetsDir` JS-interop bridge so embedding hosts can supply `assets_dir` to the top-level `FletApp` ([#6470](https://github.com/flet-dev/flet/pull/6470)) by @FeodorFitsner.
 
 ### Documentation
 

--- a/client/lib/main.dart
+++ b/client/lib/main.dart
@@ -90,6 +90,7 @@ void main([List<String>? args]) async {
     if (routeUrlStrategy == "path") {
       usePathUrlStrategy();
     }
+    assetsDir = getAssetsDir();
   } else {
     if (args!.isNotEmpty) {
       pageUrl = args[0];

--- a/packages/flet/CHANGELOG.md
+++ b/packages/flet/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Handle unbounded width in `ResponsiveRow` with an explicit error and treat child controls with `col=0` as hidden at the current breakpoint ([#1951](https://github.com/flet-dev/flet/issues/1951), [#3805](https://github.com/flet-dev/flet/issues/3805), [#6354](https://github.com/flet-dev/flet/pull/6354)) by @ndonkoHenri.
 * Fix `page.window.destroy()` taking several seconds to close Windows desktop apps when `prevent_close` is enabled ([#5459](https://github.com/flet-dev/flet/issues/5459), [#6428](https://github.com/flet-dev/flet/pull/6428)) by @ndonkoHenri.
 * Fix `flet pack` desktop packaging so Windows and Linux bundles include the expected client archive, and Windows taskbar pins point to the packed app instead of the cached `flet.exe` ([#5151](https://github.com/flet-dev/flet/issues/5151), [#6403](https://github.com/flet-dev/flet/pull/6403)) by @ndonkoHenri.
+* Resolve absolute-path `src` (e.g. `Image(src="/images/foo.svg")`) against `assets_dir` on web so embedded apps mounted at non-root URLs load assets correctly, pass `data:`/`blob:` URIs through unchanged, preserve origin-relative semantics when `assets_dir` is unset, and add a `window.flet.assetsDir` JS-interop bridge so embedding hosts can supply `assets_dir` to the top-level `FletApp` ([#6470](https://github.com/flet-dev/flet/pull/6470)) by @FeodorFitsner.
 
 ### Other changes
 

--- a/packages/flet/lib/src/utils/images_web.dart
+++ b/packages/flet/lib/src/utils/images_web.dart
@@ -15,15 +15,18 @@ SvgPicture getSvgPictureFromFile(
 }
 
 AssetSource getAssetSrc(String src, Uri pageUri, String assetsDir) {
-  if (src.startsWith("http://") || src.startsWith("https://")) {
+  if (src.startsWith("http://") ||
+      src.startsWith("https://") ||
+      src.startsWith("data:") ||
+      src.startsWith("blob:")) {
     return AssetSource(path: src, isFile: false);
   }
-  final cleaned = src.startsWith("/") ? src.substring(1) : src;
   if (assetsDir.isNotEmpty) {
+    final cleaned = src.startsWith("/") ? src.substring(1) : src;
     final base = assetsDir.endsWith("/") ? assetsDir : "$assetsDir/";
     return AssetSource(path: "$base$cleaned", isFile: false);
   }
-  return AssetSource(path: cleaned, isFile: false);
+  return AssetSource(path: src, isFile: false);
 }
 
 ImageProvider getFileImageProvider(String path) {

--- a/packages/flet/lib/src/utils/platform_utils_non_web.dart
+++ b/packages/flet/lib/src/utils/platform_utils_non_web.dart
@@ -16,6 +16,10 @@ String getFletRouteUrlStrategy() {
   return "";
 }
 
+String getAssetsDir() {
+  return "";
+}
+
 bool isPyodideMode() {
   return false;
 }

--- a/packages/flet/lib/src/utils/platform_utils_web.dart
+++ b/packages/flet/lib/src/utils/platform_utils_web.dart
@@ -20,6 +20,10 @@ String getFletRouteUrlStrategy() {
   return fletJS?.routeUrlStrategy ?? "";
 }
 
+String getAssetsDir() {
+  return fletJS?.assetsDir ?? "";
+}
+
 bool isPyodideMode() {
   return fletJS?.pyodide == true;
 }
@@ -54,6 +58,7 @@ extension FletJSExtension on FletJS {
   external String get pyodideUrl;
   external String get webRenderer;
   external String? get appPackageUrl;
+  external String? get assetsDir;
 }
 
 @JS('flet')

--- a/sdk/python/templates/build/{{cookiecutter.out_dir}}/lib/main.dart
+++ b/sdk/python/templates/build/{{cookiecutter.out_dir}}/lib/main.dart
@@ -146,6 +146,7 @@ Future prepareApp() async {
     if (routeUrlStrategy == "path") {
       usePathUrlStrategy();
     }
+    assetsDir = getAssetsDir();
   } else if (_args.isNotEmpty && isDesktopPlatform()) {
     // developer mode
     debugPrint("Flet app is running in Developer mode");


### PR DESCRIPTION
## Summary

- Complete the web-side asset resolver so `data:`/`blob:` URIs pass through and so absolute-path src stays origin-relative when `assets_dir` is unset.
- Add a JS-interop bridge (`window.flet.assetsDir`) so embedding hosts can supply `assets_dir` to the top-level `FletApp`, then wire it through both `client/lib/main.dart` and the build-template `main.dart`.

## Problem

Embedded Flet apps mounted at non-root URLs (e.g. Flet Studio's `/gallery/run/<path>/`) broke on absolute-path image src like `ft.Image(src="/images/card_back.png")` — the browser resolved `/` against the document origin instead of the configured `assets_dir`, fetching HTML and tripping `flutter_svg` with `Bad state: Invalid SVG data`. The Solitaire declarative example (`sdk/python/examples/tutorials/solitaire_declarative/solitaire-final/main.py`) is a clean repro: every card breaks under any embedding host that mounts the app at a sub-path.

The bulk of the fix landed in #6406 ("feat(FletApp): assets_dir prop for embedded apps"). This PR closes the remaining gaps.

## Changes

### `getAssetSrc()` in `packages/flet/lib/src/utils/images_web.dart`

| `src` value         | `assets_dir` set? | Resolved to                     |
|---------------------|-------------------|---------------------------------|
| `http(s)://...`     | (any)             | `src` as-is                     |
| `data:` / `blob:`   | (any)             | `src` as-is *(new)*             |
| `/images/foo.svg`   | yes               | `<assets_dir>/images/foo.svg`   |
| `/images/foo.svg`   | no                | `src` as-is (origin-rel) *(new)* |
| `images/foo.svg`    | yes               | `<assets_dir>/images/foo.svg`   |
| `images/foo.svg`    | no                | `src` as-is (page-rel)          |

Two deltas vs. previous behaviour:
- `data:` / `blob:` join the early-return list — they used to fall through and either get `assets_dir` prepended or have their first char stripped.
- The leading-`/` strip moved *inside* the `assetsDir.isNotEmpty` branch — when `assets_dir` is unset, `/foo.png` is returned untouched so the browser resolves it origin-relative. Previously stripped unconditionally, breaking standalone `flet run --web` whenever the page sat on a sub-route.

### JS-interop bridge for `assetsDir`

The top-level `FletApp` in `client/lib/main.dart` previously hardcoded `assetsDir = ""` on web — there was no path for an embedding host to supply it. Added:
- `external String? get assetsDir` on `FletJSExtension` and a `getAssetsDir()` helper in `platform_utils_web.dart`.
- Stub `getAssetsDir()` returning `""` in `platform_utils_non_web.dart`.
- `client/lib/main.dart` and the build-template `sdk/python/templates/build/{{cookiecutter.out_dir}}/lib/main.dart` set `assetsDir = getAssetsDir()` inside their `if (kIsWeb)` branch.

Embedding hosts can now do:

```html
<script>
  window.flet = window.flet || {};
  window.flet.assetsDir = "/some/path/";
</script>
```

before the Flutter bundle boots, and the resolver will use it.

### Out of scope

- Native (`images_io.dart`) is intentionally untouched — `src="/foo.svg"` on desktop/mobile may legitimately mean an absolute filesystem path.
- No Python or example changes.

## Test plan

- [ ] Build the web bundle and serve the Solitaire example under a non-root path (`python -m http.server` from a parent directory, access via `http://localhost:8000/sub/dir/`). Cards should load.
- [ ] Existing examples that use bare `src="logo.png"` continue to work.
- [ ] Examples using full URLs (`src="https://..."`) continue to work.
- [ ] Standalone `flet run --web`: when `assets_dir` is unset, `src="/foo.png"` still resolves to origin root (regression guard for sub-route navigation).
- [ ] Embedding host can override via `window.flet.assetsDir = "/path/"` and have it picked up by the top-level `FletApp`.

## Summary by Sourcery

Update web asset resolution to correctly handle special URI schemes and allow embedding hosts to provide an assets directory via JS interop.

New Features:
- Add JS interop support for supplying assetsDir from embedding hosts to the web FletApp.

Bug Fixes:
- Fix web image asset resolution so data: and blob: URIs are passed through unchanged.
- Ensure absolute-path src values remain origin-relative when assetsDir is unset, avoiding incorrect stripping of leading slashes.

Enhancements:
- Route web asset resolution through a new getAssetsDir() helper, with a no-op implementation on non-web platforms.