### PR TITLE
feat: add `Page.theme_animation_style` for customizing theme transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Make `NavigationDrawerDestination.label` accept custom controls and add `NavigationDrawerTheme.icon_theme` ([#6379](https://github.com/flet-dev/flet/issues/6379), [#6395](https://github.com/flet-dev/flet/pull/6395)) by @ndonkoHenri.
 * Add `local_position` and `global_position` to `DragTargetEvent`, deprecating `x`, `y`, and `offset` ([#6387](https://github.com/flet-dev/flet/issues/6387), [#6401](https://github.com/flet-dev/flet/pull/6401)) by @ndonkoHenri.
 * Added PCM16 streaming to `AudioRecorder`, including `on_stream` chunks and direct upload support via `AudioRecorderUploadSettings` ([#5858](https://github.com/flet-dev/flet/issues/5858), [#6423](https://github.com/flet-dev/flet/pull/6423)) by @ndonkoHenri.
+* Add `Page.theme_animation_style` for customizing the duration and curve of the theme cross-fade between `theme` and `dark_theme` (or disabling it with `AnimationStyle.no_animation()`), exposing Flutter's `MaterialApp.themeAnimationStyle` ([#6476](https://github.com/flet-dev/flet/pull/6476)) by @FeodorFitsner.
 
 ### Improvements
 

--- a/packages/flet/lib/src/controls/page.dart
+++ b/packages/flet/lib/src/controls/page.dart
@@ -24,6 +24,7 @@ import '../routing/route_state.dart';
 import '../routing/router_delegate.dart';
 import '../services/service_binding.dart';
 import '../services/service_registry.dart';
+import '../utils/animations.dart';
 import '../utils/device_info.dart';
 import '../utils/locale.dart';
 import '../utils/numbers.dart';
@@ -533,6 +534,9 @@ class _PageControlState extends State<PageControl> with WidgetsBindingObserver {
     var themeMode = control.getThemeMode("theme_mode") ??
         PageContext.of(context)?.themeMode;
 
+    var themeAnimationStyle =
+        control.getAnimationStyle("theme_animation_style");
+
     var localeConfiguration =
         control.getLocaleConfiguration("locale_configuration");
 
@@ -621,6 +625,7 @@ class _PageControlState extends State<PageControl> with WidgetsBindingObserver {
                 theme: lightTheme,
                 darkTheme: darkTheme,
                 themeMode: themeMode,
+                themeAnimationStyle: themeAnimationStyle,
                 supportedLocales: localeConfiguration.supportedLocales,
                 locale: localeConfiguration.locale,
                 localizationsDelegates: localizationsDelegates,
@@ -636,6 +641,7 @@ class _PageControlState extends State<PageControl> with WidgetsBindingObserver {
                 theme: lightTheme,
                 darkTheme: darkTheme,
                 themeMode: themeMode,
+                themeAnimationStyle: themeAnimationStyle,
                 localizationsDelegates: localizationsDelegates,
                 supportedLocales: localeConfiguration.supportedLocales,
                 locale: localeConfiguration.locale,

--- a/sdk/python/examples/controls/core/types/theme_animation_style/showcase/main.py
+++ b/sdk/python/examples/controls/core/types/theme_animation_style/showcase/main.py
@@ -1,0 +1,64 @@
+import flet as ft
+
+
+def main(page: ft.Page):
+    page.theme_mode = ft.ThemeMode.LIGHT
+    page.horizontal_alignment = ft.CrossAxisAlignment.CENTER
+    page.vertical_alignment = ft.MainAxisAlignment.CENTER
+
+    custom_style = ft.AnimationStyle(
+        duration=ft.Duration(seconds=2),
+        curve=ft.AnimationCurve.EASE_IN_OUT_CUBIC,
+    )
+
+    def apply_style(value: str):
+        if value == "default":
+            page.theme_animation_style = None
+        elif value == "custom":
+            page.theme_animation_style = custom_style
+        else:
+            page.theme_animation_style = ft.AnimationStyle.no_animation()
+        page.update()
+
+    def handle_style_change(e: ft.Event[ft.SegmentedButton]):
+        apply_style(e.control.selected[0])
+
+    def handle_theme_toggle(e: ft.Event[ft.Button]):
+        if page.theme_mode == ft.ThemeMode.LIGHT:
+            page.theme_mode = ft.ThemeMode.DARK
+            toggle_button.icon = ft.Icons.LIGHT_MODE
+        else:
+            page.theme_mode = ft.ThemeMode.LIGHT
+            toggle_button.icon = ft.Icons.DARK_MODE
+        page.update()
+
+    toggle_button = ft.Button(
+        "Switch Theme Mode",
+        icon=ft.Icons.DARK_MODE,
+        on_click=handle_theme_toggle,
+    )
+
+    page.add(
+        ft.SafeArea(
+            content=ft.Column(
+                horizontal_alignment=ft.CrossAxisAlignment.CENTER,
+                spacing=16,
+                controls=[
+                    ft.SegmentedButton(
+                        selected=["default"],
+                        on_change=handle_style_change,
+                        segments=[
+                            ft.Segment(value="default", label=ft.Text("Default")),
+                            ft.Segment(value="custom", label=ft.Text("Custom")),
+                            ft.Segment(value="none", label=ft.Text("None")),
+                        ],
+                    ),
+                    toggle_button,
+                ],
+            )
+        )
+    )
+
+
+if __name__ == "__main__":
+    ft.run(main)

--- a/sdk/python/examples/controls/core/types/theme_animation_style/showcase/pyproject.toml
+++ b/sdk/python/examples/controls/core/types/theme_animation_style/showcase/pyproject.toml
@@ -1,0 +1,26 @@
+[project]
+name = "types-theme-animation-style-showcase"
+version = "1.0.0"
+description = "Demonstrates Page.theme_animation_style by switching between default, custom, and disabled theme transitions."
+requires-python = ">=3.10"
+keywords = ["theme animation style", "showcase"]
+authors = [{ name = "Flet team", email = "hello@flet.dev" }]
+dependencies = ["flet"]
+
+[dependency-groups]
+dev = ["flet-cli", "flet-desktop", "flet-web"]
+
+[tool.flet.gallery]
+categories = ["Utility/Types"]
+
+[tool.flet.metadata]
+title = "Theme Animation Style showcase"
+controls = ["SafeArea", "Column", "SegmentedButton", "Segment", "Button", "Page", "Icon"]
+layout_pattern = "single-panel"
+complexity = "basic"
+features = ["theme switching", "animation override"]
+
+[tool.flet]
+org = "dev.flet"
+company = "Flet"
+copyright = "Copyright (C) 2023-2026 by Flet"

--- a/sdk/python/packages/flet/src/flet/controls/base_page.py
+++ b/sdk/python/packages/flet/src/flet/controls/base_page.py
@@ -9,7 +9,7 @@ from typing import (
 
 from flet.components.public_utils import unwrap_component
 from flet.controls.adaptive_control import AdaptiveControl
-from flet.controls.animation import AnimationCurve
+from flet.controls.animation import AnimationCurve, AnimationStyle
 from flet.controls.base_control import BaseControl, control
 from flet.controls.box import BoxDecoration
 from flet.controls.control import Control
@@ -177,6 +177,17 @@ class BasePage(AdaptiveControl):
     dark_theme: Optional["Theme"] = None
     """
     Customizes the theme of the application when in dark theme mode.
+    """
+
+    theme_animation_style: Optional[AnimationStyle] = None
+    """
+    Overrides the default animation style used when the application's theme
+    is changed (for example, when :attr:`theme_mode` switches between light
+    and dark).
+
+    Tip:
+        Use :meth:`flet.AnimationStyle.no_animation` to disable the theme
+        transition entirely.
     """
 
     locale_configuration: Optional[LocaleConfiguration] = None


### PR DESCRIPTION
## Summary

- Adds `Page.theme_animation_style: Optional[AnimationStyle]`, exposing Flutter's [`MaterialApp.themeAnimationStyle`](https://api.flutter.dev/flutter/material/MaterialApp/themeAnimationStyle.html) so apps can tune the duration/curve of the cross-fade between `theme` and `dark_theme` — or disable it entirely via `AnimationStyle.no_animation()`.
- Wires the property through both `MaterialApp(...)` and `MaterialApp.router(...)` constructions in `packages/flet/lib/src/controls/page.dart` (CupertinoApp branches are unchanged — Flutter has no equivalent there).
- Adds a showcase example under `sdk/python/examples/controls/core/types/theme_animation_style/showcase/` that lets the user pick between **Default**, **Custom** (2 s easeInOutCubic), and **None** styles, with a "Switch Theme Mode" button that toggles light/dark so the chosen transition is observable.

## Test plan

- [ ] Run the new example: `cd sdk/python/examples/controls/core/types/theme_animation_style/showcase && flet run main.py`
- [ ] Select **Default** → click "Switch Theme Mode" → expect the standard short cross-fade
- [ ] Select **Custom** → toggle theme → expect a clearly slower (~2 s) cubic-eased fade
- [ ] Select **None** → toggle theme → expect an instantaneous swap with no fade
- [ ] Verify rapid toggling during an in-flight Custom transition behaves sensibly (no crash)
- [ ] Confirm an unrelated theme example (e.g. `core/types/theme_mode/showcase`) still runs unchanged with `theme_animation_style` defaulting to `None`

## Summary by Sourcery

Expose configurable theme animation style on Page and showcase its usage.

New Features:
- Add Page.theme_animation_style property to control theme transition animations between light and dark modes.
- Support forwarding theme_animation_style to underlying Flutter MaterialApp and MaterialApp.router constructors.
- Introduce a new Python example showcasing default, custom, and disabled theme animation styles for theme switching.

Documentation:
- Document Page.theme_animation_style usage and its ability to disable theme transition animations in the Python API docstring.

Tests:
- Add a gallery/showcase example project configuration for theme animation style to aid manual testing and demonstration.