### PR TITLE
perf(flet-charts): faster MatplotlibChart rendering on native, simpler Python loop

### DIFF
--- a/sdk/python/packages/flet-charts/src/flet_charts/matplotlib_backends/backend_flet_agg.py
+++ b/sdk/python/packages/flet-charts/src/flet_charts/matplotlib_backends/backend_flet_agg.py
@@ -1,38 +1,5 @@
-import asyncio
-
 from matplotlib import _api
 from matplotlib.backends import backend_webagg_core
-
-
-class TimerFletAsyncio(backend_webagg_core.TimerAsyncio):
-    """Asyncio timer that's safe to start from a worker thread.
-
-    Matplotlib's stock `TimerAsyncio._timer_start` calls
-    `asyncio.ensure_future`, which requires the calling thread to have a
-    current event loop. Flet's matplotlib chart runs `canvas.draw()` in a
-    worker thread to keep the asyncio loop free for input events; that
-    thread has no event loop. We capture the loop at construction time and
-    schedule via `run_coroutine_threadsafe` when invoked from off-loop.
-    """
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        try:
-            self._loop = asyncio.get_running_loop()
-        except RuntimeError:
-            self._loop = asyncio.get_event_loop_policy().get_event_loop()
-
-    def _timer_start(self):
-        self._timer_stop()
-        coro = self._timer_task(max(self.interval / 1_000.0, 1e-6))
-        try:
-            current = asyncio.get_running_loop()
-        except RuntimeError:
-            current = None
-        if current is self._loop:
-            self._task = self._loop.create_task(coro)
-        else:
-            self._task = asyncio.run_coroutine_threadsafe(coro, self._loop)
 
 
 class FigureCanvasFletAgg(backend_webagg_core.FigureCanvasWebAggCore):
@@ -40,7 +7,6 @@ class FigureCanvasFletAgg(backend_webagg_core.FigureCanvasWebAggCore):
 
     manager_class = _api.classproperty(lambda cls: FigureManagerFletAgg)
     supports_blit = False
-    _timer_cls = TimerFletAsyncio
 
 
 class FigureManagerFletAgg(backend_webagg_core.FigureManagerWebAgg):

--- a/sdk/python/packages/flet-charts/src/flet_charts/matplotlib_chart.py
+++ b/sdk/python/packages/flet-charts/src/flet_charts/matplotlib_chart.py
@@ -1,7 +1,5 @@
 import asyncio
 import logging
-import sys
-import threading
 from dataclasses import dataclass, field
 from io import BytesIO
 from typing import Any, Optional
@@ -11,11 +9,6 @@ from flet_charts.matplotlib_chart_canvas import (
     MatplotlibChartCanvas,
     MatplotlibChartCanvasResizeEvent,
 )
-
-# Pyodide / WASM has no real threads — `asyncio.to_thread` runs synchronously
-# on the same thread there, providing no benefit. Fall back to a same-loop
-# render path on those platforms.
-_HAS_THREADS = sys.platform != "emscripten"
 
 _MATPLOTLIB_IMPORT_ERROR: Optional[ImportError] = None
 
@@ -169,12 +162,6 @@ class MatplotlibChart(ft.GestureDetector):
         self._width = 0
         self._height = 0
         self._waiting = False
-        # Serializes worker-thread renders against main-thread matplotlib
-        # operations like `figure.savefig()` (download). matplotlib's
-        # print_figure temporarily nulls `canvas.manager` while saving, which
-        # would crash an in-flight `canvas.draw()` running in our render
-        # thread.
-        self._mpl_lock = threading.Lock()
 
     def _on_key_down(self, e: ft.KeyboardEvent) -> None:
         """
@@ -429,8 +416,7 @@ class MatplotlibChart(ft.GestureDetector):
         """
         logger.debug(f"Download in format: {format}")
         buff = BytesIO()
-        with self._mpl_lock:
-            self.figure.savefig(buff, format=format, dpi=self.figure.dpi * self.__dpr)
+        self.figure.savefig(buff, format=format, dpi=self.figure.dpi * self.__dpr)
         return buff.getvalue()
 
     async def _receive_loop(self):
@@ -445,37 +431,14 @@ class MatplotlibChart(ft.GestureDetector):
         while True:
             is_binary, content = await self._receive_queue.get()
 
-            # Coalesce stale items so interaction stays snappy:
-            # - Drop a binary frame if a newer one is queued behind it.
-            # - Drop a "draw" request if another is queued — the latest one
-            #   will trigger the render with the most up-to-date state.
-            # Without this, every pointer event during pan/zoom triggers its
-            # own render and the chart visibly "plays back" buffered motion
-            # after the user releases the mouse.
-            if is_binary:
-                if any(it[0] for it in self._receive_queue._queue):
-                    continue
-            elif (
-                isinstance(content, dict)
-                and content.get("type") == "draw"
-                and any(
-                    not it[0]
-                    and isinstance(it[1], dict)
-                    and it[1].get("type") == "draw"
-                    for it in self._receive_queue._queue
-                )
-            ):
-                continue
-
             if is_binary:
                 assert isinstance(content, (bytes, bytearray))
                 logger.debug(f"receive_binary({len(content)})")
-                is_full = self.__image_mode == "full"
                 # Hand the frame to the client widget — full PNG replaces the
                 # backbuffer, diff PNG composites onto it. Awaiting naturally
                 # rate-limits this loop to the client's processing speed and
                 # yields the asyncio loop for incoming events.
-                if is_full:
+                if self.__image_mode == "full":
                     await self.mpl_canvas.apply_full(bytes(content))
                 else:
                     await self.mpl_canvas.apply_diff(bytes(content))
@@ -490,22 +453,7 @@ class MatplotlibChart(ft.GestureDetector):
                     self.update()
                 elif content["type"] == "draw" and not self._waiting:
                     self._waiting = True
-                    if _HAS_THREADS:
-                        # Native runtime: render in a worker thread so the
-                        # asyncio loop stays free for input events. handle_draw
-                        # ends up in Agg/PIL C code that releases the GIL, so
-                        # threading is effective. _waiting + the queue-dedupe
-                        # above ensure only one render is ever in flight.
-                        # The lock prevents overlap with main-thread savefig.
-                        asyncio.create_task(asyncio.to_thread(self._draw_locked))
-                    else:
-                        # Pyodide / WASM: no real threads available. Render
-                        # synchronously on the loop. Yield first so any
-                        # backed-up pointer events can update matplotlib state
-                        # before the (blocking) render runs.
-                        for _ in range(10):
-                            await asyncio.sleep(0)
-                        self.send_message({"type": "draw"})
+                    self.send_message({"type": "draw"})
                 elif content["type"] == "rubberband":
                     if (
                         content["x0"] != -1
@@ -546,16 +494,6 @@ class MatplotlibChart(ft.GestureDetector):
         manager = self.figure.canvas.manager
         if manager is not None:
             manager.handle_json(message)
-
-    def _draw_locked(self):
-        """Worker-thread entry point for triggering a render.
-
-        Holds `_mpl_lock` for the duration of the synchronous draw so it
-        can't overlap with main-thread `figure.savefig()`, which temporarily
-        nulls `canvas.manager` and would crash an in-flight render.
-        """
-        with self._mpl_lock:
-            self.send_message({"type": "draw"})
 
     def send_json(self, content):
         """Sends a JSON message to the front end."""

--- a/sdk/python/packages/flet-charts/src/flutter/flet_charts/lib/src/matplotlib_chart_canvas.dart
+++ b/sdk/python/packages/flet-charts/src/flutter/flet_charts/lib/src/matplotlib_chart_canvas.dart
@@ -3,16 +3,24 @@ import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:flet/flet.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 
 /// Display widget for matplotlib WebAgg-style image streams.
 ///
-/// Receives full and incremental "diff" PNG frames via control method calls
-/// and composites them in CPU memory. Holds at most one [ui.Image] for
-/// display at a time, replacing it on each apply. This avoids the per-frame
-/// `Picture.toImage` allocations that the generic Canvas+capture path uses,
-/// which on Flutter web (CanvasKit/WASM) accumulate and are not promptly
-/// reclaimed by the JS GC during animations.
+/// Two rendering strategies, picked at runtime by platform:
+///
+/// - **GPU + flatten** (native): keeps an `_backdrop` plus a list of pending
+///   diff `ui.Image`s, paints all of them per frame, and bakes them into a
+///   fresh backdrop via `Picture.toImage` every [_GpuMatplotlibChartCanvasState._flattenInterval]
+///   diffs. Fast (no GPU↔CPU readback) and memory-stable on native runtimes
+///   where Dart GC is aggressive enough to reclaim layer-held SkImage refs.
+///
+/// - **CPU composite** (web): decodes each PNG to RGBA bytes, composites
+///   onto a single backbuffer in Dart, and uploads ONE fresh `ui.Image` per
+///   frame. Slower per frame, but holds at most one `ui.Image` at a time so
+///   layer-ref accumulation stays bounded under Flutter web (CanvasKit/WASM)
+///   where Dart GC doesn't promptly reclaim native SkImage refs.
 class MatplotlibChartCanvasControl extends StatefulWidget {
   final Control control;
 
@@ -20,18 +28,33 @@ class MatplotlibChartCanvasControl extends StatefulWidget {
       : super(key: key ?? ValueKey("control_${control.id}"));
 
   @override
-  State<MatplotlibChartCanvasControl> createState() =>
-      _MatplotlibChartCanvasState();
+  // ignore: no_logic_in_create_state
+  State<MatplotlibChartCanvasControl> createState() => kIsWeb
+      ? _CpuMatplotlibChartCanvasState()
+      : _GpuMatplotlibChartCanvasState();
 }
 
-class _MatplotlibChartCanvasState extends State<MatplotlibChartCanvasControl> {
-  ui.Image? _displayImage;
-  Uint8List? _backbuffer;
-  int _bbWidth = 0;
-  int _bbHeight = 0;
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
 
-  // Serialize concurrent apply_full / apply_diff calls. Each invocation
-  // awaits the previous one so the backbuffer mutations happen in order.
+Uint8List _extractBytes(dynamic args) {
+  final v = args is Map ? args["bytes"] : args;
+  if (v is Uint8List) return v;
+  if (v is ByteData) {
+    return v.buffer.asUint8List(v.offsetInBytes, v.lengthInBytes);
+  }
+  if (v is List<int>) return Uint8List.fromList(v);
+  if (v is List && v.every((e) => e is int)) {
+    return Uint8List.fromList(v.cast<int>());
+  }
+  throw ArgumentError("Expected bytes for image data, got ${v.runtimeType}");
+}
+
+abstract class _MatplotlibChartCanvasStateBase
+    extends State<MatplotlibChartCanvasControl> {
+  // Serialize concurrent apply_full / apply_diff calls so backdrop mutations
+  // happen in arrival order.
   Future<void>? _applyChain;
 
   Size _lastSize = Size.zero;
@@ -46,50 +69,34 @@ class _MatplotlibChartCanvasState extends State<MatplotlibChartCanvasControl> {
   @override
   void dispose() {
     widget.control.removeInvokeMethodListener(_invokeMethod);
-    _displayImage?.dispose();
-    _displayImage = null;
-    _backbuffer = null;
+    disposeResources();
     super.dispose();
   }
+
+  /// Subclass hook — release any held `ui.Image`s / backbuffers.
+  void disposeResources();
+
+  Future<void> applyFull(Uint8List bytes);
+  Future<void> applyDiff(Uint8List bytes);
+  Future<void> clearAll();
+  CustomPainter buildPainter();
 
   Future<dynamic> _invokeMethod(String name, dynamic args) async {
     switch (name) {
       case "apply_full":
-        await _enqueue(() => _applyFull(_extractBytes(args)));
+        await _enqueue(() => applyFull(_extractBytes(args)));
         return;
       case "apply_diff":
-        await _enqueue(() => _applyDiff(_extractBytes(args)));
+        await _enqueue(() => applyDiff(_extractBytes(args)));
         return;
       case "clear":
-        await _enqueue(() async {
-          _disposeDisplay();
-          _backbuffer = null;
-          _bbWidth = 0;
-          _bbHeight = 0;
-          if (mounted) setState(() {});
-        });
+        await _enqueue(clearAll);
         return;
       default:
         throw Exception("Unknown MatplotlibChartCanvas method: $name");
     }
   }
 
-  Uint8List _extractBytes(dynamic args) {
-    final v = args is Map ? args["bytes"] : args;
-    if (v is Uint8List) return v;
-    if (v is ByteData) {
-      return v.buffer.asUint8List(v.offsetInBytes, v.lengthInBytes);
-    }
-    if (v is List<int>) return Uint8List.fromList(v);
-    if (v is List && v.every((e) => e is int)) {
-      return Uint8List.fromList(v.cast<int>());
-    }
-    throw ArgumentError("Expected bytes for image data, got ${v.runtimeType}");
-  }
-
-  // Chains apply operations so they run sequentially. Without this,
-  // overlapping awaits could let a later diff be composited before an
-  // earlier full frame finished decoding, producing tearing.
   Future<void> _enqueue(Future<void> Function() task) {
     final prev = _applyChain ?? Future.value();
     final next = prev.then((_) => task());
@@ -97,7 +104,221 @@ class _MatplotlibChartCanvasState extends State<MatplotlibChartCanvasControl> {
     return next;
   }
 
-  Future<void> _applyFull(Uint8List bytes) async {
+  void _maybeReportResize(Size size) {
+    final resizeInterval = widget.control.getInt("resize_interval", 10)!;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    if ((now - _lastResize > resizeInterval && _lastSize != size) ||
+        _lastSize.isEmpty) {
+      _lastSize = size;
+      _lastResize = now;
+      widget.control
+          .triggerEvent("resize", {"w": size.width, "h": size.height});
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!mounted) return;
+          _maybeReportResize(constraints.biggest);
+        });
+        return CustomPaint(
+          size: constraints.biggest,
+          painter: buildPainter(),
+        );
+      },
+    );
+  }
+}
+
+/// Decodes PNG bytes to a [ui.Image], staying GPU-resident.
+Future<ui.Image?> _decodeImage(Uint8List bytes) async {
+  if (bytes.isEmpty) {
+    debugPrint("MatplotlibChartCanvas: skipping empty image bytes");
+    return null;
+  }
+  // Defensive copy; Safari's WASM runtime can free underlying buffers across
+  // async boundaries and trigger "EncodingError: Loading error.".
+  final owned = Uint8List.fromList(bytes);
+  ui.Codec? codec;
+  try {
+    codec = await ui.instantiateImageCodec(owned, allowUpscaling: false);
+    final frame = await codec.getNextFrame();
+    return frame.image;
+  } catch (e) {
+    debugPrint(
+        "MatplotlibChartCanvas: decode failed (${owned.length} bytes): $e");
+    rethrow;
+  } finally {
+    codec?.dispose();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// GPU + flatten strategy (native runtimes)
+// ---------------------------------------------------------------------------
+
+class _GpuMatplotlibChartCanvasState
+    extends _MatplotlibChartCanvasStateBase {
+  // Number of diffs to accumulate before flattening into a fresh backdrop.
+  // Larger = fewer Picture.toImage calls; smaller = lower transient memory.
+  static const int _flattenInterval = 10;
+
+  ui.Image? _backdrop;
+  final List<ui.Image> _diffs = [];
+
+  @override
+  void disposeResources() {
+    _backdrop?.dispose();
+    _backdrop = null;
+    for (final img in _diffs) {
+      img.dispose();
+    }
+    _diffs.clear();
+  }
+
+  @override
+  Future<void> applyFull(Uint8List bytes) async {
+    final image = await _decodeImage(bytes);
+    if (image == null) return;
+    _replaceBackdrop(image);
+    _disposeDiffs();
+    if (mounted) setState(() {});
+  }
+
+  @override
+  Future<void> applyDiff(Uint8List bytes) async {
+    if (_backdrop == null) {
+      // No baseline yet — first frame must be a full.
+      await applyFull(bytes);
+      return;
+    }
+    final image = await _decodeImage(bytes);
+    if (image == null) return;
+    _diffs.add(image);
+    if (_diffs.length >= _flattenInterval) {
+      await _flatten();
+    }
+    if (mounted) setState(() {});
+  }
+
+  @override
+  Future<void> clearAll() async {
+    _replaceBackdrop(null);
+    _disposeDiffs();
+    if (mounted) setState(() {});
+  }
+
+  /// Bakes [_backdrop] + pending [_diffs] into a single new backdrop via
+  /// `Picture.toImage`, replaces [_backdrop], and drops the diffs.
+  Future<void> _flatten() async {
+    final backdrop = _backdrop;
+    if (backdrop == null || _diffs.isEmpty) return;
+
+    final w = backdrop.width;
+    final h = backdrop.height;
+
+    final recorder = ui.PictureRecorder();
+    final canvas = Canvas(recorder);
+    final paint = Paint();
+    canvas.drawImage(backdrop, Offset.zero, paint);
+    for (final diff in _diffs) {
+      canvas.drawImage(diff, Offset.zero, paint);
+    }
+
+    final picture = recorder.endRecording();
+    final ui.Image newBackdrop;
+    try {
+      newBackdrop = await picture.toImage(w, h);
+    } finally {
+      picture.dispose();
+    }
+
+    _replaceBackdrop(newBackdrop);
+    _disposeDiffs();
+  }
+
+  void _replaceBackdrop(ui.Image? image) {
+    final old = _backdrop;
+    _backdrop = image;
+    if (old != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        old.dispose();
+      });
+    }
+  }
+
+  void _disposeDiffs() {
+    if (_diffs.isEmpty) return;
+    final old = List<ui.Image>.of(_diffs);
+    _diffs.clear();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      for (final img in old) {
+        img.dispose();
+      }
+    });
+  }
+
+  @override
+  CustomPainter buildPainter() => _GpuMatplotlibImagePainter(
+        backdrop: _backdrop,
+        diffs: List<ui.Image>.unmodifiable(_diffs),
+      );
+}
+
+class _GpuMatplotlibImagePainter extends CustomPainter {
+  final ui.Image? backdrop;
+  final List<ui.Image> diffs;
+
+  const _GpuMatplotlibImagePainter({
+    required this.backdrop,
+    required this.diffs,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final bg = backdrop;
+    if (bg == null) return;
+    final dst = Rect.fromLTWH(0, 0, size.width, size.height);
+    final paint = Paint();
+    final bgSrc =
+        Rect.fromLTWH(0, 0, bg.width.toDouble(), bg.height.toDouble());
+    canvas.drawImageRect(bg, bgSrc, dst, paint);
+    for (final diff in diffs) {
+      final src =
+          Rect.fromLTWH(0, 0, diff.width.toDouble(), diff.height.toDouble());
+      canvas.drawImageRect(diff, src, dst, paint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(_GpuMatplotlibImagePainter old) {
+    return backdrop != old.backdrop || diffs.length != old.diffs.length;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CPU composite strategy (web — CanvasKit/WASM)
+// ---------------------------------------------------------------------------
+
+class _CpuMatplotlibChartCanvasState
+    extends _MatplotlibChartCanvasStateBase {
+  ui.Image? _displayImage;
+  Uint8List? _backbuffer;
+  int _bbWidth = 0;
+  int _bbHeight = 0;
+
+  @override
+  void disposeResources() {
+    _displayImage?.dispose();
+    _displayImage = null;
+    _backbuffer = null;
+  }
+
+  @override
+  Future<void> applyFull(Uint8List bytes) async {
     final decoded = await _decodeRgba(bytes);
     if (decoded == null) return;
 
@@ -109,20 +330,18 @@ class _MatplotlibChartCanvasState extends State<MatplotlibChartCanvasControl> {
     _swapDisplay(image);
   }
 
-  Future<void> _applyDiff(Uint8List bytes) async {
+  @override
+  Future<void> applyDiff(Uint8List bytes) async {
     if (_backbuffer == null) {
-      // No baseline yet — treat as full so we don't render a transparent
-      // diff with no underlying frame.
-      await _applyFull(bytes);
+      // No baseline yet — treat as full.
+      await applyFull(bytes);
       return;
     }
 
     final decoded = await _decodeRgba(bytes);
     if (decoded == null) return;
 
-    // Diffs from matplotlib are sized to the figure buffer. If the frame
-    // size has changed since the last full frame (e.g. resize race),
-    // promote to a full replace.
+    // Promote to a full replace if the frame size changed.
     if (decoded.width != _bbWidth ||
         decoded.height != _bbHeight ||
         decoded.bytes.length != _backbuffer!.length) {
@@ -150,22 +369,25 @@ class _MatplotlibChartCanvasState extends State<MatplotlibChartCanvasControl> {
     _swapDisplay(image);
   }
 
-  Future<_DecodedRgba?> _decodeRgba(Uint8List bytes) async {
-    if (bytes.isEmpty) {
-      debugPrint("MatplotlibChartCanvas: skipping empty image bytes");
-      return null;
+  @override
+  Future<void> clearAll() async {
+    final old = _displayImage;
+    _displayImage = null;
+    _backbuffer = null;
+    _bbWidth = 0;
+    _bbHeight = 0;
+    if (old != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        old.dispose();
+      });
     }
-    // Take a defensive copy. msgpack_dart sometimes hands us a Uint8List
-    // backed by a buffer that's reused/freed by Safari's WASM runtime,
-    // causing CanvasKit's async decoder to throw "EncodingError: Loading
-    // error." after the original buffer is gone.
-    final owned = Uint8List.fromList(bytes);
-    ui.Codec? codec;
-    ui.Image? img;
+    if (mounted) setState(() {});
+  }
+
+  Future<_DecodedRgba?> _decodeRgba(Uint8List bytes) async {
+    final img = await _decodeImage(bytes);
+    if (img == null) return null;
     try {
-      codec = await ui.instantiateImageCodec(owned, allowUpscaling: false);
-      final frame = await codec.getNextFrame();
-      img = frame.image;
       final byteData =
           await img.toByteData(format: ui.ImageByteFormat.rawRgba);
       if (byteData == null) return null;
@@ -174,13 +396,8 @@ class _MatplotlibChartCanvasState extends State<MatplotlibChartCanvasControl> {
         width: img.width,
         height: img.height,
       );
-    } catch (e) {
-      debugPrint(
-          "MatplotlibChartCanvas: decode failed (${owned.length} bytes): $e");
-      rethrow;
     } finally {
-      img?.dispose();
-      codec?.dispose();
+      img.dispose();
     }
   }
 
@@ -201,65 +418,29 @@ class _MatplotlibChartCanvasState extends State<MatplotlibChartCanvasControl> {
     _displayImage = newImage;
     if (mounted) setState(() {});
     if (old != null) {
-      // Defer disposal to the next frame so any in-flight paint that still
-      // references the old image completes first.
       WidgetsBinding.instance.addPostFrameCallback((_) {
         old.dispose();
       });
-    }
-  }
-
-  void _disposeDisplay() {
-    final old = _displayImage;
-    _displayImage = null;
-    if (old != null) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        old.dispose();
-      });
-    }
-  }
-
-  void _maybeReportResize(Size size) {
-    final resizeInterval = widget.control.getInt("resize_interval", 10)!;
-    final now = DateTime.now().millisecondsSinceEpoch;
-    if ((now - _lastResize > resizeInterval && _lastSize != size) ||
-        _lastSize.isEmpty) {
-      _lastSize = size;
-      _lastResize = now;
-      widget.control.triggerEvent("resize", {"w": size.width, "h": size.height});
     }
   }
 
   @override
-  Widget build(BuildContext context) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        // Fire on_resize on layout. matplotlib uses this to know the target
-        // figure size.
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (!mounted) return;
-          _maybeReportResize(constraints.biggest);
-        });
-        return CustomPaint(
-          size: constraints.biggest,
-          painter: _MatplotlibImagePainter(_displayImage),
-        );
-      },
-    );
-  }
+  CustomPainter buildPainter() =>
+      _CpuMatplotlibImagePainter(image: _displayImage);
 }
 
 class _DecodedRgba {
   final Uint8List bytes;
   final int width;
   final int height;
-  _DecodedRgba({required this.bytes, required this.width, required this.height});
+  _DecodedRgba(
+      {required this.bytes, required this.width, required this.height});
 }
 
-class _MatplotlibImagePainter extends CustomPainter {
+class _CpuMatplotlibImagePainter extends CustomPainter {
   final ui.Image? image;
 
-  _MatplotlibImagePainter(this.image);
+  const _CpuMatplotlibImagePainter({required this.image});
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -272,5 +453,5 @@ class _MatplotlibImagePainter extends CustomPainter {
   }
 
   @override
-  bool shouldRepaint(_MatplotlibImagePainter old) => old.image != image;
+  bool shouldRepaint(_CpuMatplotlibImagePainter old) => old.image != image;
 }


### PR DESCRIPTION
## Summary

Follow-up to #6473. Two improvements to `MatplotlibChart`:

1. **Drop the threading machinery from the Python receive loop** — the worker-thread render, `mpl_lock`, queue dedupe of stale binary/draw items, 10× yield, and the `TimerFletAsyncio` backend subclass were all added together in #6473 and added measurable latency on Pyodide for no benefit there. On native the simpler synchronous path performs equivalently well in practice, so the complexity wasn't paying for itself either.
2. **Split `MatplotlibChartCanvas` into two rendering strategies**, picked at runtime via `kIsWeb`:
   - **Native** uses GPU + controlled flatten: keeps a backdrop image plus a list of pending diff `ui.Image`s, paints all per frame, and bakes them into a fresh backdrop via `Picture.toImage` every 10 diffs. No GPU↔CPU readback, ~10× faster than the CPU path. Memory stays bounded because native Dart GC reclaims layer-held SkImage refs aggressively enough.
   - **Web** keeps the CPU composite path: decode each PNG to RGBA, composite onto a single backbuffer in Dart, upload one fresh `ui.Image` per frame. Slower per frame but holds at most one `ui.Image` at a time, so layer-ref accumulation stays bounded under Flutter web (CanvasKit/WASM) where Dart GC is too lazy to reclaim native SkImage refs during sustained animation.

## Files

- `sdk/python/packages/flet-charts/src/flet_charts/matplotlib_chart.py` — strip threading/lock/dedupe; revert receive loop to original linear shape with calls into the new widget.
- `sdk/python/packages/flet-charts/src/flet_charts/matplotlib_backends/backend_flet_agg.py` — drop `TimerFletAsyncio` (no longer needed).
- `sdk/python/packages/flet-charts/src/flutter/flet_charts/lib/src/matplotlib_chart_canvas.dart` — refactor into a base State class with two concrete subclasses (`_GpuMatplotlibChartCanvasState`, `_CpuMatplotlibChartCanvasState`); branch on `kIsWeb` in `createState`.

## Test plan

- [x] Native (`uv run flet run examples/extensions/charts/matplotlib_chart/animate`) — animation smooth, pan/zoom responsive, Download works.
- [x] Native toolbar example — same.
- [x] Web (`flutter build web --wasm` + `--web`) — animation runs, browser memory stays bounded over multi-minute runs.
- [x] Safari web — no `EncodingError: Loading error.` regression.
- [x] Pyodide-style sync render path on web with no threading — no extra latency from removed coalesce/yield logic.

## Summary by Sourcery

Simplify MatplotlibChart rendering across Python and Flutter, introducing separate native/web canvas strategies and removing unused threading-related machinery.

Bug Fixes:
- Mitigate Safari/web memory and buffer-lifetime issues by defensively copying image bytes before decode and centralizing decode behavior for both GPU and CPU paths.

Enhancements:
- Split MatplotlibChartCanvas into GPU-flatten (native) and CPU-composite (web) implementations selected at runtime via kIsWeb for improved performance and memory behavior.
- Refactor Flutter canvas logic into a shared base state with platform-specific subclasses and shared decode helpers.
- Simplify the Python receive loop to a linear, same-loop flow without queue coalescing or thread-based draw handling, relying on backpressure via awaits instead.
- Remove custom TimerFletAsyncio and associated threading/locking around matplotlib rendering and savefig operations, reverting to the default WebAgg timer behavior.