### PR TITLE
fix: reject session reuse when existing connection is still active

### DIFF
--- a/sdk/python/packages/flet-web/src/flet_web/fastapi/flet_app.py
+++ b/sdk/python/packages/flet-web/src/flet_web/fastapi/flet_app.py
@@ -255,9 +255,13 @@ class FletApp(Connection):
 
             # try to retrieve existing session
             if req.session_id:
-                self.__session = await app_manager.get_session(
+                candidate = await app_manager.get_session(
                     self.__get_unique_session_id(req.session_id)
                 )
+                if candidate is not None and candidate.connection is None:
+                    self.__session = candidate
+                else:
+                    self.__session = None
 
             oauth_state = None
             if self.__oauth_state_id:


### PR DESCRIPTION
## Description

When running a Flet app in web browser mode, opening the same URL in multiple browser tabs
causes cross-tab session contamination. Events triggered in Tab1 affect Tab2's UI, while
Tab1 becomes unresponsive.

**Root cause:** The `REGISTER_CLIENT` handler in `flet_app.py` unconditionally reuses an
existing session when the client provides a matching `session_id`, without checking whether
that session is still actively connected. When a second browser tab inherits the same
`_flet_session_id` via `sessionStorage` cloning (standard HTML5 behavior for duplicated tabs),
it steals the session's output connection from the original tab via `attach_connection()`.

**Fix:** Before reusing a session, check if its connection is still alive
(`session.connection is not None`). If so, the request is from a different tab — create a
new session instead. This preserves legitimate reconnect scenarios (page refresh / network
blip) where `connection` is already `None` after `disconnect()`.

Fixes #6512

## Test Code

```python
import flet as ft

def main(page: ft.Page):
    page.title = "Flet counter example"
    page.vertical_alignment = ft.MainAxisAlignment.CENTER

    input = ft.TextField(value="0", text_align=ft.TextAlign.RIGHT, width=100)

    def minus_click(e):
        input.value = str(int(input.value) - 1)

    def plus_click(e):
        input.value = str(int(input.value) + 1)

    page.add(
        ft.Row(
            alignment=ft.MainAxisAlignment.CENTER,
            controls=[
                ft.IconButton(ft.Icons.REMOVE, on_click=minus_click),
                input,
                ft.IconButton(ft.Icons.ADD, on_click=plus_click),
            ],
        )
    )


ft.run(
    main=main,
    view=ft.AppView.WEB_BROWSER,
    web_renderer=ft.WebRenderer.CANVAS_KIT,
    port=6006
)
```

## Type of change

<!-- Please delete options that are not relevant. -->

Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I signed the CLA.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] If this PR targets a `release/*` branch, I added a new record to the active root `CHANGELOG.md` section
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes
- [ ] I have made corresponding changes to the [[documentation](https://github.com/flet-dev/website)](https://github.com/flet-dev/website) (if applicable)

## Screenshots

<!-- Add screenshots here if applicable. -->

## Additional details

- Only 1 file changed: `sdk/python/packages/flet-web/src/flet_web/fastapi/flet_app.py`
- The fix is backward-compatible: legitimate single-tab reconnects still work because
  `Session.disconnect()` sets `__conn = None` before any reconnect attempt.
- No documentation changes needed.

## Summary by Sourcery

Bug Fixes:
- Reject reuse of an existing session if its connection is still active, ensuring duplicated browser tabs receive separate sessions and do not interfere with each other.