### PR TITLE
feat(router): add `modal`/`recursive` Route flags + chain-based pop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.85.2
+
+### New features
+
+* Add `Route(modal=True)` to `flet.Router` for fullscreen-dialog modal overlays that don't replace the underlying view stack — closing the modal pops it without rebuilding the views underneath. Two flavours by placement: top-level modals are *global* (the base stack is rebuilt from the Router's last non-modal location), nested-child modals are *local* (the base stack is the chain above the modal in the route tree, so deep-link works from URL alone) ([#6516](https://github.com/flet-dev/flet/pull/6516)) by @FeodorFitsner.
+* Add `Route(recursive=True)` to `flet.Router` so a route can match itself as its own descendant — one `View` per consumed URL segment, ideal for tree-shaped URLs of unbounded depth (`/folder/a/b/c` produces a 4-View stack; back-swipe walks one segment at a time). Non-recursive children are tried before self-recursion at every depth, so a specific sibling (e.g. `example/:gp*`) wins over the recursive `:slug` without duplicating it at every level ([#6516](https://github.com/flet-dev/flet/pull/6516)) by @FeodorFitsner.
+
+### Improvements
+
+* `flet.Router`'s default `on_view_pop` now navigates to the matched chain's parent (`chain[-2].resolved_path`) instead of `views[-2].route`, which is robust against apps that share a `View.route` value between sibling tab roots to suppress switch transitions. Apps that install their own `page.on_view_pop` before `page.render_views()` still take precedence. Each sub-chain (base + modal) renders with its own `LocationInfo`, so `is_route_active(...)` inside a base view sees the base URL while a global modal is open over it ([#6516](https://github.com/flet-dev/flet/pull/6516)) by @FeodorFitsner.
+
 ## 0.85.1
 
 ### Bug fixes

--- a/packages/flet/CHANGELOG.md
+++ b/packages/flet/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.85.2
+
+_No changes in the `flet` Dart package; version bumped for release coordination with `flet.Router` enhancements on the Python side (modal/recursive route flags, chain-based default pop)._
+
 ## 0.85.1
 
 _No changes in the `flet` Dart package; version bumped for release coordination with `flet-geolocator` fixes on the Python side._

--- a/packages/flet/pubspec.yaml
+++ b/packages/flet/pubspec.yaml
@@ -2,7 +2,7 @@ name: flet
 description: Write entire Flutter app in Python or add server-driven UI experience into existing Flutter app.
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/flet/tree/main/packages/flet
-version: 0.85.1
+version: 0.85.2
 
 # Supported platforms
 platforms:

--- a/sdk/python/examples/apps/router/modal_routes/README.md
+++ b/sdk/python/examples/apps/router/modal_routes/README.md
@@ -1,0 +1,34 @@
+# Modal routes
+
+Routes marked `modal=True` are rendered as fullscreen-dialog overlays on
+top of the previous location's view stack. Closing the modal pops it
+without rebuilding the views underneath.
+
+This example demonstrates both modes:
+
+- **`/settings`** — a *global* modal declared at the top level. Reachable
+  from `/`, `/items`, `/items/<id>` — closing returns to whichever URL was
+  active when it opened. Deep-linking to `/settings` directly defaults the
+  base to `/`.
+
+- **`/items/<id>/edit`** — a *local* modal declared as a child of
+  `/items/:id`. The URL embeds the item id, so deep-linking restores the
+  full stack `[ItemList, ItemDetails(id), EditItemModal]` from URL alone.
+
+## Run
+
+```bash
+flet run
+```
+
+## What to try
+
+1. From `Home`, tap "Open Settings" → modal slides up over Home. Close →
+   back to Home with no rebuild.
+2. Navigate `Home → Items → Apples` → tap "Edit" → local modal slides over
+   the Apples detail view. Close → back to Apples with the detail view
+   still mounted.
+3. From Apples detail, tap "Open Settings" → modal slides up over the
+   detail. Close → back to Apples detail (not Home).
+4. Paste `/items/2/edit` into the URL — the stack rebuilds and the modal
+   opens directly. Close → `/items/2`.

--- a/sdk/python/examples/apps/router/modal_routes/main.py
+++ b/sdk/python/examples/apps/router/modal_routes/main.py
@@ -1,0 +1,186 @@
+"""Modal routes — fullscreen-dialog overlays that don't unmount the
+underlying stack.
+
+A route marked ``modal=True`` is rendered on top of the previous
+location's view stack. Closing the modal pops it without rebuilding
+the views underneath — they stay mounted.
+
+Two flavours, distinguished by placement in the route tree:
+
+* **Global modal** — declared at the top level. Reachable from
+  anywhere with a single URL; the base stack comes from the last
+  non-modal location the Router saw. Demonstrated by ``/settings`` here.
+
+* **Local modal** — declared as a child of a non-modal parent. The URL
+  embeds the parent's path, so deep-link works without any state.
+  Demonstrated by ``/items/<id>/edit`` here.
+"""
+
+import flet as ft
+
+# ---------------------------------------------------------------------------
+# Pages
+# ---------------------------------------------------------------------------
+
+
+@ft.component
+def Home():
+    page = ft.context.page
+    return ft.View(
+        route="/",
+        appbar=ft.AppBar(title=ft.Text("Home")),
+        controls=[
+            ft.Text("Welcome!", size=22, weight=ft.FontWeight.BOLD),
+            ft.Button(
+                "Open Items",
+                on_click=lambda: page.navigate("/items"),
+            ),
+            ft.Button(
+                "Open Settings (global modal)",
+                on_click=lambda: page.navigate("/settings"),
+            ),
+        ],
+    )
+
+
+ITEMS = {"1": "Apples", "2": "Bananas", "3": "Cherries"}
+
+
+@ft.component
+def ItemList():
+    page = ft.context.page
+    return ft.View(
+        route="/items",
+        appbar=ft.AppBar(title=ft.Text("Items")),
+        controls=[
+            ft.Text("Pick an item:"),
+            *[
+                ft.Button(
+                    name,
+                    on_click=lambda _e, i=iid: page.navigate(f"/items/{i}"),
+                )
+                for iid, name in ITEMS.items()
+            ],
+            ft.Button(
+                "Open Settings (global modal)",
+                on_click=lambda: page.navigate("/settings"),
+            ),
+        ],
+    )
+
+
+@ft.component
+def ItemDetails():
+    page = ft.context.page
+    params = ft.use_route_params()
+    iid = params["id"]
+    name = ITEMS.get(iid, "Unknown")
+    return ft.View(
+        route=ft.use_view_path(),
+        appbar=ft.AppBar(title=ft.Text(f"Item: {name}")),
+        controls=[
+            ft.Text(f"Details for item {iid}: {name}"),
+            ft.Button(
+                "Edit (local modal)",
+                on_click=lambda: page.navigate(f"/items/{iid}/edit"),
+            ),
+            ft.Button(
+                "Open Settings (global modal)",
+                on_click=lambda: page.navigate("/settings"),
+            ),
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Modals
+# ---------------------------------------------------------------------------
+
+
+@ft.component
+def SettingsModal():
+    """Global modal — `/settings` works from any base location."""
+    return ft.View(
+        route="/settings",
+        fullscreen_dialog=True,
+        appbar=ft.AppBar(title=ft.Text("Settings")),
+        controls=[
+            ft.Text("Account / System / About would live here."),
+            ft.Text(
+                "Close the modal — the underlying view (Home, Items, or "
+                "Item details) is still mounted underneath, no rebuild.",
+                size=12,
+                color=ft.Colors.ON_SURFACE_VARIANT,
+            ),
+        ],
+    )
+
+
+@ft.component
+def EditItemModal():
+    """Local modal — `/items/<id>/edit` is pinned to a specific item.
+
+    Deep-link to it directly and the stack rebuilds from URL alone:
+    `[ItemList, ItemDetails(id), EditItemModal]`.
+    """
+    params = ft.use_route_params()
+    iid = params["id"]
+    name = ITEMS.get(iid, "Unknown")
+    return ft.View(
+        route=ft.use_view_path(),
+        fullscreen_dialog=True,
+        appbar=ft.AppBar(title=ft.Text(f"Edit {name}")),
+        controls=[
+            ft.Text(f"Editing item {iid}"),
+            ft.TextField(label="Name", value=name),
+            ft.Text(
+                "URL: " + ft.context.page.route,
+                size=12,
+                color=ft.Colors.ON_SURFACE_VARIANT,
+            ),
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# App
+# ---------------------------------------------------------------------------
+
+
+@ft.component
+def App():
+    return ft.Router(
+        [
+            # Pathless parent so /items/<id> stacks on top of Home.
+            ft.Route(
+                component=Home,
+                children=[
+                    ft.Route(
+                        path="items",
+                        component=ItemList,
+                        children=[
+                            ft.Route(
+                                path=":id",
+                                component=ItemDetails,
+                                children=[
+                                    # Local modal — child of /items/:id.
+                                    ft.Route(
+                                        path="edit",
+                                        component=EditItemModal,
+                                        modal=True,
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            # Global modal — top-level route, reachable from anywhere.
+            ft.Route(path="settings", component=SettingsModal, modal=True),
+        ],
+        manage_views=True,
+    )
+
+
+if __name__ == "__main__":
+    ft.run(lambda page: page.render_views(App))

--- a/sdk/python/examples/apps/router/modal_routes/pyproject.toml
+++ b/sdk/python/examples/apps/router/modal_routes/pyproject.toml
@@ -1,0 +1,26 @@
+[project]
+name = "router-modal-routes"
+version = "1.0.0"
+description = "Modal routes (modal=True) rendered as fullscreen-dialog overlays. Demonstrates both global (top-level) and local (nested) modals."
+requires-python = ">=3.10"
+keywords = ["router", "modal", "fullscreen-dialog", "overlay", "nested"]
+authors = [{ name = "Flet team", email = "hello@flet.dev" }]
+dependencies = ["flet"]
+
+[dependency-groups]
+dev = ["flet-cli", "flet-desktop", "flet-web"]
+
+[tool.flet.gallery]
+categories = ["Navigation/Router"]
+
+[tool.flet.metadata]
+title = "Modal routes"
+controls = ["SafeArea", "Column", "Button", "Text", "TextField", "AppBar", "View", "Router", "Route"]
+layout_pattern = "page-navigation"
+complexity = "intermediate"
+features = ["modal routes", "fullscreen_dialog", "manage_views", "global modal", "local modal"]
+
+[tool.flet]
+org = "dev.flet"
+company = "Flet"
+copyright = "Copyright (C) 2023-2026 by Flet"

--- a/sdk/python/examples/apps/router/recursive_routes/README.md
+++ b/sdk/python/examples/apps/router/recursive_routes/README.md
@@ -1,0 +1,31 @@
+# Recursive routes
+
+A toy folder browser. The recursive `:name` route matches itself as its
+own descendant, so the navigation stack grows one View per consumed URL
+segment — `/folder/a/b/c` yields a stack of four views (Folders, a, a/b,
+a/b/c). Back-swipe or AppBar back walks one segment at a time.
+
+The recursive route declares a non-recursive `search` child once, and
+the matcher tries non-recursive siblings before self-recursion — so
+`/folder/anything/search` always lands on the `Search` page, never on
+a folder named "search".
+
+## Run
+
+```bash
+flet run
+```
+
+## What to try
+
+1. From `/`, open `/folder` → tap a top-level folder → tap a child →
+   tap another. Each step pushes a View. Back walks one level at a
+   time.
+2. Paste `/folder/a/b/c/d` directly into the URL → stack rebuilds with
+   five Views. Back walks each.
+3. From any folder, tap "Search here" → lands on the Search page below
+   the current folder. Back returns there.
+4. Paste `/folder/docs/projects/search` directly → stack is
+   `[Folders, docs, projects, Search]`. The recursive `:name` route
+   does NOT eat the "search" segment because the non-recursive
+   sibling matches first.

--- a/sdk/python/examples/apps/router/recursive_routes/main.py
+++ b/sdk/python/examples/apps/router/recursive_routes/main.py
@@ -1,0 +1,151 @@
+"""Recursive routes — unbounded URL depth, one View per segment.
+
+A route marked ``recursive=True`` can match itself as its own
+descendant. The Router emits one ``_RouteMatch`` per consumed URL
+segment, which (in ``manage_views=True`` mode) turns into one View per
+segment in the navigation stack — so the back gesture walks one level
+at a time.
+
+Sibling-wins-over-recursion: non-recursive children of a recursive
+route are tried BEFORE self-recursion at every depth. Here that means
+``/folder/<anything>/search`` matches the ``Search`` page (not a
+folder named "search"), without needing to declare ``search`` at every
+depth manually.
+
+Try this in the browser bar:
+
+* ``/folder`` → folder root
+* ``/folder/a`` → 1 level deep
+* ``/folder/a/b`` → 2 levels deep
+* ``/folder/a/b/c/d/e`` → 5 levels deep (no fixed limit)
+* ``/folder/a/b/search`` → search page below ``a/b``
+"""
+
+import flet as ft
+
+
+@ft.component
+def Home():
+    page = ft.context.page
+    return ft.View(
+        route="/",
+        appbar=ft.AppBar(title=ft.Text("Folder Browser")),
+        controls=[
+            ft.Text("A toy file browser.", size=18),
+            ft.Button("Open /folder", on_click=lambda: page.navigate("/folder")),
+        ],
+    )
+
+
+@ft.component
+def Folders():
+    """Root of the folder tree (``/folder``)."""
+    page = ft.context.page
+    return ft.View(
+        route="/folder",
+        appbar=ft.AppBar(title=ft.Text("Folders")),
+        controls=[
+            ft.Text("Top-level folders:", weight=ft.FontWeight.BOLD),
+            *[
+                ft.Button(
+                    f"Open {name}",
+                    on_click=lambda _e, n=name: page.navigate(f"/folder/{n}"),
+                )
+                for name in ("docs", "projects", "scratch")
+            ],
+            ft.Button(
+                "Search at root",
+                on_click=lambda: page.navigate("/folder/search"),
+            ),
+        ],
+    )
+
+
+@ft.component
+def Folder():
+    """A folder at any depth. Re-used by the recursive route at every level.
+
+    ``use_route_params()`` returns just the current segment (e.g.
+    ``{"name": "b"}`` at depth 2). ``use_view_path()`` returns the
+    accumulated URL up to this view, useful for showing the full path
+    and for building child URLs.
+    """
+    page = ft.context.page
+    params = ft.use_route_params()
+    view_path = ft.use_view_path()
+    segments = [s for s in view_path[len("/folder") :].split("/") if s]
+    return ft.View(
+        route=view_path,
+        appbar=ft.AppBar(title=ft.Text(" / ".join(segments) or "Folders")),
+        controls=[
+            ft.Text(f"Current segment: {params['name']}"),
+            ft.Text(f"Full path: {view_path}"),
+            ft.Text("Open a sub-folder:", weight=ft.FontWeight.BOLD),
+            *[
+                ft.Button(
+                    f"Into {child}",
+                    on_click=lambda _e, c=child: page.navigate(f"{view_path}/{c}"),
+                )
+                for child in ("alpha", "beta", "gamma")
+            ],
+            ft.Button(
+                "Search here",
+                on_click=lambda: page.navigate(f"{view_path}/search"),
+            ),
+        ],
+    )
+
+
+@ft.component
+def Search():
+    """Non-recursive child of the recursive Folder route. Wins over
+    self-recursion at every depth, so ``/folder/<any-segments>/search``
+    always lands here instead of being eaten as another folder named
+    "search"."""
+    page = ft.context.page
+    view_path = ft.use_view_path()
+    # Strip trailing "/search" to learn the folder we're searching in.
+    folder = view_path[: -len("/search")] or "/folder"
+    return ft.View(
+        route=view_path,
+        appbar=ft.AppBar(title=ft.Text("Search")),
+        controls=[
+            ft.Text(f"Searching in: {folder}"),
+            ft.TextField(label="Query", autofocus=True),
+            ft.Button("Back to folder", on_click=lambda: page.navigate(folder)),
+        ],
+    )
+
+
+@ft.component
+def App():
+    return ft.Router(
+        [
+            ft.Route(
+                component=Home,
+                children=[
+                    ft.Route(
+                        path="folder",
+                        component=Folders,
+                        children=[
+                            # Declared ONCE — the `search` sibling check
+                            # happens at every recursion depth.
+                            ft.Route(
+                                path=":name",
+                                component=Folder,
+                                recursive=True,
+                                children=[
+                                    ft.Route(path="search", component=Search),
+                                ],
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+        manage_views=True,
+    )
+
+
+if __name__ == "__main__":
+    ft.run(lambda page: page.render_views(App))

--- a/sdk/python/examples/apps/router/recursive_routes/pyproject.toml
+++ b/sdk/python/examples/apps/router/recursive_routes/pyproject.toml
@@ -1,0 +1,26 @@
+[project]
+name = "router-recursive-routes"
+version = "1.0.0"
+description = "Recursive routes (recursive=True) for tree-shaped URLs of unbounded depth. One View per consumed segment in the navigation stack."
+requires-python = ">=3.10"
+keywords = ["router", "recursive", "tree", "nested", "unbounded"]
+authors = [{ name = "Flet team", email = "hello@flet.dev" }]
+dependencies = ["flet"]
+
+[dependency-groups]
+dev = ["flet-cli", "flet-desktop", "flet-web"]
+
+[tool.flet.gallery]
+categories = ["Navigation/Router"]
+
+[tool.flet.metadata]
+title = "Recursive routes"
+controls = ["SafeArea", "Column", "Button", "Text", "TextField", "AppBar", "View", "Router", "Route"]
+layout_pattern = "page-navigation"
+complexity = "intermediate"
+features = ["recursive routes", "use_view_path", "manage_views", "tree URLs"]
+
+[tool.flet]
+org = "dev.flet"
+company = "Flet"
+copyright = "Copyright (C) 2023-2026 by Flet"

--- a/sdk/python/packages/flet/integration_tests/examples/apps/test_router.py
+++ b/sdk/python/packages/flet/integration_tests/examples/apps/test_router.py
@@ -13,9 +13,11 @@ from examples.apps.router.featured_views import main as featured_views
 from examples.apps.router.index_routes import main as index_routes
 from examples.apps.router.layout_outlet import main as layout_outlet
 from examples.apps.router.loaders import main as loaders
+from examples.apps.router.modal_routes import main as modal_routes
 from examples.apps.router.nested_outlet_views import main as nested_outlet_views
 from examples.apps.router.nested_routes import main as nested_routes
 from examples.apps.router.prefix_routes import main as prefix_routes
+from examples.apps.router.recursive_routes import main as recursive_routes
 from examples.apps.router.runtime_routes import main as runtime_routes
 from examples.apps.router.splats import main as splats
 
@@ -647,3 +649,180 @@ async def test_app_drawer(flet_app_function: ftt.FletTestApp):
         "Require 2FA for admins"
     )
     assert permission_switch.count == 1
+
+
+# ---------------------------------------------------------------------------
+# Modal routes — `modal=True` overlays
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "flet_app_function",
+    [{"flet_app_main": _make_render_views_main(modal_routes.App)}],
+    indirect=True,
+)
+@pytest.mark.asyncio(loop_scope="function")
+async def test_modal_routes(flet_app_function: ftt.FletTestApp):
+    # Start at /, the Home page.
+    welcome = await flet_app_function.tester.find_by_text("Welcome!")
+    assert welcome.count == 1
+
+    # ----- Global modal: open /settings from Home, close back to Home.
+    open_settings = await flet_app_function.tester.find_by_text(
+        "Open Settings (global modal)"
+    )
+    assert open_settings.count >= 1
+    await flet_app_function.tester.tap(open_settings)
+    await flet_app_function.tester.pump_and_settle()
+
+    settings_title = await flet_app_function.tester.find_by_text("Settings")
+    assert settings_title.count >= 1
+    settings_body = await flet_app_function.tester.find_by_text(
+        "Account / System / About would live here."
+    )
+    assert settings_body.count == 1
+
+    # Flutter's auto-inserted close-X uses the "Close" tooltip on a
+    # fullscreen-dialog page.
+    close_btn = await flet_app_function.tester.find_by_tooltip("Close")
+    assert close_btn.count == 1
+    await flet_app_function.tester.tap(close_btn)
+    await flet_app_function.tester.pump_and_settle()
+
+    # Home is back — underlying view was never unmounted.
+    welcome = await flet_app_function.tester.find_by_text("Welcome!")
+    assert welcome.count == 1
+
+    # ----- Navigate Home → Items → Apples → Edit (local modal).
+    open_items = await flet_app_function.tester.find_by_text("Open Items")
+    assert open_items.count == 1
+    await flet_app_function.tester.tap(open_items)
+    await flet_app_function.tester.pump_and_settle()
+
+    apples_btn = await flet_app_function.tester.find_by_text("Apples")
+    assert apples_btn.count == 1
+    await flet_app_function.tester.tap(apples_btn)
+    await flet_app_function.tester.pump_and_settle()
+
+    detail = await flet_app_function.tester.find_by_text("Details for item 1: Apples")
+    assert detail.count == 1
+
+    edit_btn = await flet_app_function.tester.find_by_text("Edit (local modal)")
+    assert edit_btn.count == 1
+    await flet_app_function.tester.tap(edit_btn)
+    await flet_app_function.tester.pump_and_settle()
+
+    editing = await flet_app_function.tester.find_by_text("Editing item 1")
+    assert editing.count == 1
+
+    # Close the local modal — should land back on Apples detail, not on
+    # the Items list or Home.
+    close_btn = await flet_app_function.tester.find_by_tooltip("Close")
+    assert close_btn.count == 1
+    await flet_app_function.tester.tap(close_btn)
+    await flet_app_function.tester.pump_and_settle()
+
+    detail = await flet_app_function.tester.find_by_text("Details for item 1: Apples")
+    assert detail.count == 1
+
+    # ----- Global modal opened from a deep page returns to that page.
+    open_settings = await flet_app_function.tester.find_by_text(
+        "Open Settings (global modal)"
+    )
+    assert open_settings.count >= 1
+    await flet_app_function.tester.tap(open_settings)
+    await flet_app_function.tester.pump_and_settle()
+
+    settings_title = await flet_app_function.tester.find_by_text("Settings")
+    assert settings_title.count >= 1
+
+    close_btn = await flet_app_function.tester.find_by_tooltip("Close")
+    assert close_btn.count == 1
+    await flet_app_function.tester.tap(close_btn)
+    await flet_app_function.tester.pump_and_settle()
+
+    # Back on the Apples detail (not Home).
+    detail = await flet_app_function.tester.find_by_text("Details for item 1: Apples")
+    assert detail.count == 1
+
+    # ----- Deep-link straight into the local modal.
+    await flet_app_function.page.push_route("/items/2/edit")
+    await flet_app_function.tester.pump_and_settle()
+
+    editing = await flet_app_function.tester.find_by_text("Editing item 2")
+    assert editing.count == 1
+
+    # Close — back to Bananas detail (URL parent), which exists in the
+    # stack because the local modal's base chain was rebuilt from URL.
+    close_btn = await flet_app_function.tester.find_by_tooltip("Close")
+    assert close_btn.count == 1
+    await flet_app_function.tester.tap(close_btn)
+    await flet_app_function.tester.pump_and_settle()
+
+    detail = await flet_app_function.tester.find_by_text("Details for item 2: Bananas")
+    assert detail.count == 1
+
+
+# ---------------------------------------------------------------------------
+# Recursive routes — one View per consumed segment
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "flet_app_function",
+    [{"flet_app_main": _make_render_views_main(recursive_routes.App)}],
+    indirect=True,
+)
+@pytest.mark.asyncio(loop_scope="function")
+async def test_recursive_routes(flet_app_function: ftt.FletTestApp):
+    # Drill /folder → docs → alpha → beta.
+    await flet_app_function.page.push_route("/folder")
+    await flet_app_function.tester.pump_and_settle()
+    folders_heading = await flet_app_function.tester.find_by_text("Top-level folders:")
+    assert folders_heading.count == 1
+
+    docs_btn = await flet_app_function.tester.find_by_text("Open docs")
+    assert docs_btn.count == 1
+    await flet_app_function.tester.tap(docs_btn)
+    await flet_app_function.tester.pump_and_settle()
+
+    seg = await flet_app_function.tester.find_by_text("Current segment: docs")
+    assert seg.count == 1
+
+    into_alpha = await flet_app_function.tester.find_by_text("Into alpha")
+    assert into_alpha.count == 1
+    await flet_app_function.tester.tap(into_alpha)
+    await flet_app_function.tester.pump_and_settle()
+
+    seg = await flet_app_function.tester.find_by_text("Current segment: alpha")
+    assert seg.count == 1
+    path = await flet_app_function.tester.find_by_text("Full path: /folder/docs/alpha")
+    assert path.count == 1
+
+    # AppBar back walks ONE segment at a time.
+    back_btn = await flet_app_function.tester.find_by_tooltip("Back")
+    assert back_btn.count == 1
+    await flet_app_function.tester.tap(back_btn)
+    await flet_app_function.tester.pump_and_settle()
+
+    seg = await flet_app_function.tester.find_by_text("Current segment: docs")
+    assert seg.count == 1
+
+    # Deep-link to a 4-segment path — stack rebuilds, each level present.
+    await flet_app_function.page.push_route("/folder/projects/p1/v2/draft")
+    await flet_app_function.tester.pump_and_settle()
+    seg = await flet_app_function.tester.find_by_text("Current segment: draft")
+    assert seg.count == 1
+    path = await flet_app_function.tester.find_by_text(
+        "Full path: /folder/projects/p1/v2/draft"
+    )
+    assert path.count == 1
+
+    # Sibling specificity: /folder/docs/search lands on Search, not on a
+    # folder named "search".
+    await flet_app_function.page.push_route("/folder/docs/search")
+    await flet_app_function.tester.pump_and_settle()
+    searching = await flet_app_function.tester.find_by_text(
+        "Searching in: /folder/docs"
+    )
+    assert searching.count == 1

--- a/sdk/python/packages/flet/src/flet/components/router.py
+++ b/sdk/python/packages/flet/src/flet/components/router.py
@@ -71,6 +71,31 @@ class Route:
             :func:`~flet.use_route_outlet` within a single
             :class:`~flet.View`, instead of each child becoming a separate
             :class:`~flet.View`.
+        modal: When ``True`` and ``manage_views=True``, the route's View
+            is rendered as a modal overlay on top of the existing stack
+            instead of replacing it. The route's component should set
+            ``fullscreen_dialog=True`` on its returned :class:`~flet.View`
+            so Flutter renders the slide-up presentation and a close (X)
+            icon. Placement controls the base stack:
+
+            * Declared at the **top level**: a *global* modal. The base
+              stack is rebuilt from the last non-modal location the
+              Router saw (defaults to ``"/"`` on first render).
+            * Declared as a **child** of a non-modal route: a *local*
+              modal. The base stack is the chain above the modal in the
+              route tree, so deep-link works from the URL alone.
+
+            On pop, the Router navigates to the resolved URL of the
+            non-modal parent — never to ``views[-2].route`` — so a
+            modal close is always a real navigation back to the
+            base location.
+        recursive: When ``True``, the route can match itself as its own
+            descendant — one matched ``_RouteMatch`` per consumed segment.
+            Useful for tree-shaped URLs with unbounded depth
+            (e.g. ``/folder/a/b/c``) where each segment should become its
+            own stack entry. Non-recursive children are tried before
+            self-recursion at every depth so a more specific sibling
+            (e.g. ``example/:gp*``) wins over the recursive ``:slug``.
     """
 
     path: str | None = None
@@ -79,6 +104,8 @@ class Route:
     children: list[Route] | None = field(default=None)
     loader: Callable[..., Any] | None = None
     outlet: bool = False
+    modal: bool = False
+    recursive: bool = False
 
 
 @dataclass
@@ -191,6 +218,43 @@ def _try_match(
     full_path = _join_paths(parent_path, route_path)
     if not full_path:
         full_path = "/"
+
+    if route.recursive:
+        # Recursive routes consume one matched segment per recursion and
+        # try non-recursive children before self-recursing — so a more
+        # specific sibling (e.g. ``example/:gp*``) wins over the
+        # recursive ``:slug`` at every depth without duplicate
+        # declarations.
+        prefix_pattern = repath.pattern(full_path, end=False)
+        prefix_m = re.match(prefix_pattern, pathname)
+        if not prefix_m:
+            return None
+        consumed = prefix_m.group(0)
+        head = _RouteMatch(
+            route=route,
+            params=prefix_m.groupdict(),
+            full_path=full_path,
+            resolved_path=consumed,
+        )
+        # Fully consumed → this is the leaf. Accept either an exact
+        # match or a trailing "/" remainder (so /folder/a and
+        # /folder/a/ both terminate cleanly).
+        remainder = pathname[len(consumed) :]
+        if not remainder or remainder == "/":
+            return [head]
+        # 1) Try non-recursive children first (more specific match).
+        for child in route.children or []:
+            if child is route:
+                continue
+            child_result = _try_match(child, pathname, consumed)
+            if child_result is not None:
+                return [head] + child_result
+        # 2) Fall back to self-recursion with the consumed prefix as
+        #    the parent path.
+        recurse = _try_match(route, pathname, consumed)
+        if recurse is None:
+            return None
+        return [head] + recurse
 
     if route.children:
         # Parent route — try prefix match to extract params, then match children
@@ -576,6 +640,22 @@ def Router(
     location, set_location = use_state(page.route or "/")
     prev_route_handler_ref = use_ref(None)
     prev_pop_handler_ref = use_ref(None)
+    # Last non-modal location the Router saw. Used as the base for
+    # global modal routes (declared at the top level) — when the user
+    # navigates from /apps/X to /settings (modal=True), the modal is
+    # rendered ON TOP OF the chain matched against /apps/X, so closing
+    # it reveals the original stack instead of rebuilding it.
+    prev_non_modal_location_ref = use_ref(None)
+    # Snapshot of the chain emitted for the current location. Used by
+    # the default pop handler to compute the parent URL structurally
+    # (``chain[-2].resolved_path``), which survives shared ``view.route``
+    # keys (e.g. an app that uses the same route key for two sibling
+    # tab roots to suppress switch animations).
+    current_chain_ref = use_ref(None)
+    # URL to navigate to when popping the topmost view, IF the current
+    # chain ends in a modal route. ``None`` otherwise. Set whenever a
+    # modal route matches.
+    current_modal_pop_to_ref = use_ref(None)
 
     # Subscribe to route changes on mount
     def setup_listeners():
@@ -590,13 +670,36 @@ def Router(
             prev_pop_handler_ref.current = page.on_view_pop
 
             def on_view_pop(e):
-                from flet.components.public_utils import unwrap_component
+                # If the app installed its own `page.on_view_pop` before
+                # the Router mounted, delegate to it. Apps can still
+                # override entirely (e.g. for a stack visualisation or
+                # confirmation flow).
+                prev = prev_pop_handler_ref.current
+                if prev is not None:
+                    prev(e)
+                    return
 
-                views_list = unwrap_component(page.views)
-                if isinstance(views_list, list) and len(views_list) > 1:
-                    prev_view = unwrap_component(views_list[-2])
-                    if prev_view is not None:
-                        page.navigate(prev_view.route)
+                # Modal pop: navigate to the base URL stamped at emit
+                # time. Same logic for global and local modals — the
+                # base URL was resolved when the modal was matched.
+                if current_modal_pop_to_ref.current is not None:
+                    page.navigate(current_modal_pop_to_ref.current)
+                    return
+
+                # Non-modal pop: use the matched chain's parent route
+                # (route-tree-structural) rather than
+                # ``views[-2].route``. This survives shared view keys
+                # like a tab-root layout that emits ``route="/"`` for
+                # multiple sibling sections.
+                chain_now = current_chain_ref.current
+                if chain_now and len(chain_now) > 1:
+                    parent_match = chain_now[-2]
+                    target = parent_match.resolved_path or parent_match.full_path or "/"
+                    page.navigate(target)
+                    return
+
+                # Stack of length 1 — nothing to pop to. (Flutter's
+                # ``Navigator.canPop`` is False here anyway.)
 
             page.on_view_pop = on_view_pop
 
@@ -621,9 +724,65 @@ def Router(
             if manage_views:
                 from flet.controls.core.view import View
 
+                # Reset state so a stale modal pop_to doesn't leak into
+                # a 404'd location.
+                current_chain_ref.current = None
+                current_modal_pop_to_ref.current = None
                 return [View(route=pathname, controls=[not_found()])]
             return not_found()
         return None
+
+    # Detect modal routes in the chain. ``modal_idx`` is the index of
+    # the first route in the chain with ``modal=True``; ``-1`` means
+    # the chain is fully non-modal.
+    modal_idx = -1
+    for i, m in enumerate(chain):
+        if m.route.modal:
+            modal_idx = i
+            break
+
+    # For a *global* modal (``modal_idx == 0`` — the chain starts at a
+    # modal with no non-modal parents) we want the visible stack to be
+    # the chain of the previously visited non-modal location +
+    # the modal's own chain. This way the underlying stack stays mounted
+    # underneath the modal — closing the modal reveals it without a
+    # rebuild.
+    if manage_views and modal_idx == 0:
+        base_location = prev_non_modal_location_ref.current or "/"
+        base_pathname = _normalize_path(urlparse(base_location).path or "/")
+        base_chain = _match_routes(routes, base_pathname) or []
+        # If the base path also resolves to a modal (shouldn't happen
+        # in practice — non-modal navigations are the only ones that
+        # update prev_non_modal_location_ref), fall back to no base.
+        if any(b.route.modal for b in base_chain):
+            base_chain = []
+        # Combine: base lives below, modal sits on top.
+        chain = base_chain + chain
+        # Re-locate the modal index in the combined chain.
+        modal_idx = len(base_chain)
+
+    # Track refs that downstream consumers (default pop handler, etc.)
+    # read. ``current_chain_ref`` always reflects the chain we're
+    # actually emitting. ``current_modal_pop_to_ref`` is set only when
+    # the chain ends in a modal — non-modal navigations clear it.
+    current_chain_ref.current = chain
+    if modal_idx == -1:
+        # Non-modal navigation — remember it as the next base.
+        prev_non_modal_location_ref.current = location
+        current_modal_pop_to_ref.current = None
+    else:
+        # Modal route — the URL to pop to is the resolved URL of the
+        # last non-modal entry in the chain.
+        if modal_idx > 0:
+            parent = chain[modal_idx - 1]
+            current_modal_pop_to_ref.current = (
+                parent.resolved_path or parent.full_path or "/"
+            )
+        else:
+            # No non-modal parent in the chain (rare — would require a
+            # deep-link to a top-level modal with no remembered base
+            # AND an empty default match). Fall back to "/".
+            current_modal_pop_to_ref.current = "/"
 
     # Merge all params from the chain
     all_params: dict[str, str] = {}
@@ -640,7 +799,8 @@ def Router(
     loc = LocationInfo(pathname=pathname, search=search, hash=hash_val)
 
     if not manage_views:
-        # Single-view mode (existing behavior)
+        # Single-view mode (existing behavior). ``modal`` is ignored
+        # here — it only affects stack composition in multi-view mode.
         return _location_context(
             loc,
             lambda: _params_context(
@@ -653,47 +813,81 @@ def Router(
     # route, etc.).  The Router sets route and can_pop on each View
     # after the component body executes (via the patch walk).
     # Used with page.render_views(App).
-    layouts, view_entries = _split_chain_into_view_levels(chain)
+    #
+    # If the chain contains a modal route, split into two independent
+    # sub-chains at the modal boundary. Each sub-chain is classified
+    # into layouts vs. view entries SEPARATELY so that an outlet route
+    # that would be a leaf view in its own sub-chain doesn't get
+    # re-classified as a layout just because there's more chain after
+    # the boundary. ``modal_idx`` already points to the modal route in
+    # the (possibly combined) chain.
+    # ``modal_idx <= 0`` covers both the no-modal case (``-1``) and a
+    # degenerate modal chain with no base (``0``) — neither is split.
+    sub_chains = [chain] if modal_idx <= 0 else [chain[:modal_idx], chain[modal_idx:]]
+
+    # Each sub-chain's views see their own URL via the location
+    # context. The base sub-chain (when there's a modal split) sees the
+    # remembered non-modal location it was matched against — so
+    # ``is_route_active("/gallery")`` inside a base view stays True
+    # while a global ``/settings`` modal is open over Gallery.
+    base_sub_loc = LocationInfo(pathname=pathname, search=search, hash=hash_val)
+    if modal_idx > 0:
+        base_loc_str = prev_non_modal_location_ref.current or "/"
+        base_parsed = urlparse(base_loc_str)
+        base_sub_loc = LocationInfo(
+            pathname=_normalize_path(base_parsed.path or "/"),
+            search=base_parsed.query or "",
+            hash=base_parsed.fragment or "",
+        )
 
     results = []
-    for match, _ in view_entries:
-        # Params accumulated up to this view level
-        level_params: dict[str, str] = {}
-        for m in chain:
-            level_params.update(m.params)
-            if m is match:
-                break
+    for sub_chain_idx, sub_chain in enumerate(sub_chains):
+        layouts, view_entries = _split_chain_into_view_levels(sub_chain)
+        # The base sub-chain (everything before the modal) is rendered
+        # "as if" the user is at the previous non-modal URL; the modal
+        # sub-chain is rendered at the modal URL.
+        sub_loc = base_sub_loc if (modal_idx > 0 and sub_chain_idx == 0) else loc
+        for match, _ in view_entries:
+            # Params accumulated up to this view level — within the
+            # combined chain so a local modal view still sees its
+            # parents' captures.
+            level_params: dict[str, str] = {}
+            for m in chain:
+                level_params.update(m.params)
+                if m is match:
+                    break
 
-        # LocationInfo.pathname is the actual URL (not the route template),
-        # so is_route_active() and use_route_location() work consistently.
-        level_loc = LocationInfo(pathname=pathname, search=search, hash=hash_val)
-        # Per-view resolved URL — unique per view level for Navigator keying.
-        level_view_path = match.resolved_path or match.full_path or "/"
-        _match = match
-        # Only apply layouts that appear before this view entry in the chain
-        match_idx = chain.index(match)
-        _layouts = [lm for lm in layouts if chain.index(lm) < match_idx]
+            # Per-view resolved URL — unique per view level for
+            # Navigator keying.
+            level_view_path = match.resolved_path or match.full_path or "/"
+            _match = match
+            # Only apply layouts that appear before this view entry IN
+            # THE SAME SUB-CHAIN. A modal view never inherits the
+            # base's layouts (and vice versa).
+            match_idx = sub_chain.index(match)
+            _layouts = [lm for lm in layouts if sub_chain.index(lm) < match_idx]
 
-        def build_view_content(
-            _match=_match,
-            _layouts=_layouts,
-            _level_params=level_params,
-            _level_loc=level_loc,
-            _level_view_path=level_view_path,
-        ):
-            return _view_path_context(
-                _level_view_path,
-                lambda: _location_context(
-                    _level_loc,
-                    lambda: _params_context(
-                        _level_params,
-                        lambda: _build_view_level(
-                            _layouts, _match, loader_results, chain
+            def build_view_content(
+                _match=_match,
+                _layouts=_layouts,
+                _level_params=level_params,
+                _level_loc=sub_loc,
+                _level_view_path=level_view_path,
+                _sub_chain=sub_chain,
+            ):
+                return _view_path_context(
+                    _level_view_path,
+                    lambda: _location_context(
+                        _level_loc,
+                        lambda: _params_context(
+                            _level_params,
+                            lambda: _build_view_level(
+                                _layouts, _match, loader_results, _sub_chain
+                            ),
                         ),
                     ),
-                ),
-            )
+                )
 
-        results.append(build_view_content())
+            results.append(build_view_content())
 
     return results

--- a/sdk/python/packages/flet/tests/test_router_modal.py
+++ b/sdk/python/packages/flet/tests/test_router_modal.py
@@ -1,0 +1,180 @@
+"""Unit tests for ``Route(modal=True)`` matching.
+
+The modal flag itself is not exercised by ``_match_routes`` — it's
+consumed by the ``Router`` component when emitting views. These tests
+cover the matching layer: the ``modal_idx`` location in the chain
+behaves as documented for both global and local modals, and the
+fields the Router reads from each match are populated correctly.
+
+End-to-end behaviour (chain combination with the previous non-modal
+location, ``modal_pop_to`` stamping, no-flash close) is exercised by
+the ``modal_routes`` integration test that drives the example app
+through the Flet testing harness.
+"""
+
+from flet.components.router import Route, _match_routes
+
+
+def _dummy():  # placeholder component — Route requires a callable
+    pass
+
+
+def _find_modal_idx(chain):
+    """Replicates the Router's modal-index lookup."""
+    for i, m in enumerate(chain):
+        if m.route.modal:
+            return i
+    return -1
+
+
+# ---------------------------------------------------------------------------
+# Global modal — declared at the top level
+# ---------------------------------------------------------------------------
+
+
+def test_global_modal_matches_as_first_chain_entry():
+    """A top-level modal with no parents in the tree matches at index 0
+    of the chain. The Router uses this signal to compose the visible
+    stack from the previous non-modal location + the modal chain.
+    """
+    settings = Route(
+        path="settings",
+        component=_dummy,
+        modal=True,
+        outlet=True,
+        children=[Route(index=True, component=_dummy)],
+    )
+    routes = [Route(component=_dummy), settings]
+
+    chain = _match_routes(routes, "/settings")
+
+    assert chain is not None
+    assert _find_modal_idx(chain) == 0
+    assert chain[0].route is settings
+
+
+def test_global_modal_with_subpath_keeps_modal_at_index_0():
+    """``/settings/system`` still has the modal route at index 0; the
+    deeper match (the System tab) is at index 1 with its own params."""
+    settings = Route(
+        path="settings",
+        component=_dummy,
+        modal=True,
+        outlet=True,
+        children=[
+            Route(path="system", component=_dummy),
+        ],
+    )
+    chain = _match_routes([settings], "/settings/system")
+
+    assert chain is not None
+    assert _find_modal_idx(chain) == 0
+    assert chain[0].route.modal is True
+    assert chain[1].route.path == "system"
+
+
+# ---------------------------------------------------------------------------
+# Local modal — child of a non-modal parent
+# ---------------------------------------------------------------------------
+
+
+def test_local_modal_index_reflects_nesting_depth():
+    """A modal nested under non-modal parents reports its index as the
+    number of non-modal ancestors. ``modal_pop_to`` is derived from
+    ``chain[modal_idx-1].resolved_path``, which here resolves to the
+    parent ``/items/<id>`` URL."""
+    edit = Route(path="edit", component=_dummy, modal=True)
+    routes = [
+        Route(
+            component=_dummy,
+            children=[
+                Route(
+                    path="items",
+                    component=_dummy,
+                    children=[
+                        Route(path=":id", component=_dummy, children=[edit]),
+                    ],
+                ),
+            ],
+        ),
+    ]
+
+    chain = _match_routes(routes, "/items/42/edit")
+
+    assert chain is not None
+    modal_idx = _find_modal_idx(chain)
+    # parent (pathless) → "items" → ":id" → modal "edit" — modal at index 3
+    assert modal_idx == 3
+    assert chain[modal_idx].route is edit
+    # chain[modal_idx-1] is the modal's direct non-modal parent.
+    parent = chain[modal_idx - 1]
+    assert parent.params == {"id": "42"}
+    assert parent.resolved_path == "/items/42"
+
+
+def test_local_modal_preserves_parents_params_in_chain():
+    """Each match in the chain exposes every dynamic segment captured up
+    to and including that match's own path (parents' captures included
+    via the joined regex). So the modal route at ``/items/:id/edit``
+    sees ``{"id": "abc"}`` on its own match — the Router's
+    ``use_route_params()`` consumer would see the same dict whether it
+    reads from the modal's match alone or the accumulated chain.
+    """
+    edit = Route(path="edit", component=_dummy, modal=True)
+    items = Route(
+        path="items",
+        component=_dummy,
+        children=[
+            Route(path=":id", component=_dummy, children=[edit]),
+        ],
+    )
+    chain = _match_routes([items], "/items/abc/edit")
+
+    assert chain is not None
+    id_match = next(m for m in chain if m.route.path == ":id")
+    assert id_match.params == {"id": "abc"}
+    edit_match = next(m for m in chain if m.route is edit)
+    # The matcher carries parent captures into the leaf's regex too —
+    # ``id`` is still bound for the modal so it can fetch the right
+    # item record via ``use_route_params()``.
+    assert edit_match.params == {"id": "abc"}
+
+
+# ---------------------------------------------------------------------------
+# Non-modal navigation — sanity / regression
+# ---------------------------------------------------------------------------
+
+
+def test_non_modal_chain_has_modal_idx_minus_one():
+    """When no route in the matched chain is modal, the helper returns
+    ``-1`` — the Router uses this to update
+    ``prev_non_modal_location_ref``."""
+    routes = [
+        Route(
+            component=_dummy,
+            children=[
+                Route(path="items", component=_dummy),
+            ],
+        ),
+    ]
+    chain = _match_routes(routes, "/items")
+
+    assert chain is not None
+    assert _find_modal_idx(chain) == -1
+    assert all(not m.route.modal for m in chain)
+
+
+def test_modal_flag_does_not_change_match_outcome_for_non_modal_url():
+    """A modal route declared in the tree must not affect matching of
+    unrelated URLs."""
+    routes = [
+        Route(path="home", component=_dummy),
+        Route(path="settings", component=_dummy, modal=True),
+    ]
+    home_chain = _match_routes(routes, "/home")
+    settings_chain = _match_routes(routes, "/settings")
+
+    assert home_chain is not None
+    assert _find_modal_idx(home_chain) == -1
+    assert settings_chain is not None
+    assert _find_modal_idx(settings_chain) == 0

--- a/sdk/python/packages/flet/tests/test_router_recursive.py
+++ b/sdk/python/packages/flet/tests/test_router_recursive.py
@@ -1,0 +1,251 @@
+"""Unit tests for ``Route(recursive=True)`` matching.
+
+A recursive route matches itself as its own descendant — one
+``_RouteMatch`` per consumed URL segment. The matcher tries
+non-recursive children before self-recursion at every depth so a
+specific sibling (e.g. ``example/:gp*``) wins over the recursive
+``:slug``.
+
+These tests exercise ``_match_routes`` directly. View emission with
+one stack entry per recursion level is exercised by the
+``recursive_routes`` integration test that drives the example app.
+"""
+
+from flet.components.router import Route, _match_routes
+
+
+def _dummy():
+    pass
+
+
+def _paths(chain):
+    """Helper — pull (route_path, params, resolved_path) from a chain."""
+    return [(m.route.path, m.params, m.resolved_path) for m in chain]
+
+
+# ---------------------------------------------------------------------------
+# Basic recursion — one match per segment
+# ---------------------------------------------------------------------------
+
+
+def test_recursive_route_matches_single_segment():
+    """A recursive route at the depth-1 URL produces exactly one
+    recursive match (the leaf)."""
+    folder = Route(
+        path="folder",
+        component=_dummy,
+        children=[
+            Route(path=":name", component=_dummy, recursive=True),
+        ],
+    )
+    chain = _match_routes([folder], "/folder/docs")
+
+    assert chain is not None
+    assert [m.route.path for m in chain] == ["folder", ":name"]
+    assert chain[1].params == {"name": "docs"}
+    assert chain[1].resolved_path == "/folder/docs"
+
+
+def test_recursive_route_matches_three_levels():
+    """``/folder/a/b/c`` produces three ``:name`` matches. Each level's
+    ``resolved_path`` accumulates the consumed prefix."""
+    folder = Route(
+        path="folder",
+        component=_dummy,
+        children=[
+            Route(path=":name", component=_dummy, recursive=True),
+        ],
+    )
+    chain = _match_routes([folder], "/folder/a/b/c")
+
+    assert chain is not None
+    # 1 base ("folder") + 3 recursive levels.
+    assert len(chain) == 4
+    assert chain[0].route.path == "folder"
+    for m, expected in zip(
+        chain[1:], [("a", "/folder/a"), ("b", "/folder/a/b"), ("c", "/folder/a/b/c")]
+    ):
+        slug, resolved = expected
+        assert m.route.path == ":name"
+        assert m.route.recursive is True
+        assert m.params == {"name": slug}
+        assert m.resolved_path == resolved
+
+
+def test_recursive_route_unbounded_depth():
+    """No fixed upper bound on recursion depth."""
+    folder = Route(
+        path="folder",
+        component=_dummy,
+        children=[
+            Route(path=":name", component=_dummy, recursive=True),
+        ],
+    )
+    deep_url = "/folder/" + "/".join(f"d{i}" for i in range(12))
+    chain = _match_routes([folder], deep_url)
+
+    assert chain is not None
+    assert len(chain) == 13  # 1 base + 12 recursive
+    assert chain[-1].resolved_path == deep_url
+
+
+# ---------------------------------------------------------------------------
+# Sibling specificity — non-recursive child wins over self-recursion
+# ---------------------------------------------------------------------------
+
+
+def test_non_recursive_sibling_wins_at_root_depth():
+    """A non-recursive child declared as a sibling of the recursive
+    route matches before self-recursion at every depth — here the root
+    depth. ``/folder/search`` lands on Search, not on Folder(search)."""
+    folder = Route(
+        path="folder",
+        component=_dummy,
+        children=[
+            Route(path="search", component=_dummy),
+            Route(path=":name", component=_dummy, recursive=True),
+        ],
+    )
+    chain = _match_routes([folder], "/folder/search")
+
+    assert chain is not None
+    assert [m.route.path for m in chain] == ["folder", "search"]
+
+
+def test_non_recursive_sibling_wins_at_recursive_child_depth():
+    """The same rule applies inside the recursive route itself — a
+    ``search`` child of the recursive ``:name`` wins over self-recursion
+    at every depth."""
+    search = Route(path="search", component=_dummy)
+    folder = Route(
+        path="folder",
+        component=_dummy,
+        children=[
+            Route(
+                path=":name",
+                component=_dummy,
+                recursive=True,
+                children=[search],
+            ),
+        ],
+    )
+
+    chain = _match_routes([folder], "/folder/a/b/search")
+    assert chain is not None
+    # base + 2 recursive (a, b) + search leaf
+    assert [m.route.path for m in chain] == ["folder", ":name", ":name", "search"]
+    assert chain[-1].route is search
+    assert chain[-1].resolved_path == "/folder/a/b/search"
+
+    # Same rule one level deeper.
+    chain = _match_routes([folder], "/folder/a/b/c/search")
+    assert chain is not None
+    assert [m.route.path for m in chain] == [
+        "folder",
+        ":name",
+        ":name",
+        ":name",
+        "search",
+    ]
+
+
+def test_recursive_route_consumes_only_when_no_sibling_matches():
+    """If the next segment doesn't match any non-recursive child, the
+    recursive route self-recurses and consumes the segment."""
+    folder = Route(
+        path="folder",
+        component=_dummy,
+        children=[
+            Route(path="search", component=_dummy),
+            Route(path=":name", component=_dummy, recursive=True),
+        ],
+    )
+    chain = _match_routes([folder], "/folder/a")
+    assert chain is not None
+    assert [m.route.path for m in chain] == ["folder", ":name"]
+    assert chain[1].params == {"name": "a"}
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_recursive_route_alone_at_root_matches_each_segment():
+    """A recursive route declared at the top level (no path parent)
+    still emits one match per consumed segment."""
+    routes = [
+        Route(path=":name", component=_dummy, recursive=True),
+    ]
+    chain = _match_routes(routes, "/a/b/c")
+    assert chain is not None
+    assert len(chain) == 3
+    assert [m.params["name"] for m in chain] == ["a", "b", "c"]
+    assert chain[-1].resolved_path == "/a/b/c"
+
+
+def test_recursive_route_trailing_slash_treated_as_terminator():
+    """Both ``/folder/a`` and ``/folder/a/`` terminate at the same
+    leaf match — the trailing slash isn't consumed as another empty
+    recursion."""
+    folder = Route(
+        path="folder",
+        component=_dummy,
+        children=[
+            Route(path=":name", component=_dummy, recursive=True),
+        ],
+    )
+    a = _match_routes([folder], "/folder/a")
+    a_slash = _match_routes([folder], "/folder/a/")
+    assert a is not None and a_slash is not None
+    assert len(a) == len(a_slash) == 2
+    assert a[-1].params == a_slash[-1].params == {"name": "a"}
+
+
+def test_recursive_route_with_splat_child_at_every_depth():
+    """The canonical ``gallery`` pattern from the studio app: a recursive
+    ``:slug`` with an ``example/:gp*`` child. The splat child wins over
+    self-recursion at any depth."""
+    example = Route(path="example/:gp*", component=_dummy)
+    gallery = Route(
+        path="gallery",
+        component=_dummy,
+        children=[
+            Route(path="example/:gp*", component=_dummy),  # /gallery/example/<gp>
+            Route(
+                path=":slug",
+                component=_dummy,
+                recursive=True,
+                children=[example],
+            ),
+        ],
+    )
+
+    # Flat deep-link.
+    chain = _match_routes([gallery], "/gallery/example/foo/bar")
+    assert chain is not None
+    assert [m.route.path for m in chain] == ["gallery", "example/:gp*"]
+    assert chain[-1].params == {"gp": "foo/bar"}
+
+    # Nested under one slug.
+    chain = _match_routes([gallery], "/gallery/a/example/foo")
+    assert chain is not None
+    assert [m.route.path for m in chain] == [
+        "gallery",
+        ":slug",
+        "example/:gp*",
+    ]
+    assert chain[1].params == {"slug": "a"}
+    assert chain[-1].params == {"gp": "foo"}
+
+    # Nested under multiple slugs.
+    chain = _match_routes([gallery], "/gallery/a/b/c/example/foo")
+    assert chain is not None
+    assert [m.route.path for m in chain] == [
+        "gallery",
+        ":slug",
+        ":slug",
+        ":slug",
+        "example/:gp*",
+    ]
+    assert chain[-1].params == {"gp": "foo"}

--- a/website/docs/controls/router.md
+++ b/website/docs/controls/router.md
@@ -60,4 +60,22 @@ and tabbed settings — all using `manage_views=True`.
 
 <CodeExample path={frontMatter.examples + '/featured_views/main.py'} language="python" />
 
+### Modal routes
+
+Routes marked `modal=True` are rendered as a fullscreen-dialog overlay on top
+of the previous (non-modal) location's view stack. A *global* modal is declared
+at the top level (the URL works from anywhere); a *local* modal is declared as
+a child of a non-modal parent (the URL embeds the parent's segment, so
+deep-link works without any state).
+
+<CodeExample path={frontMatter.examples + '/modal_routes/main.py'} language="python" />
+
+### Recursive routes
+
+A route marked `recursive=True` can match itself as its own descendant — one
+View is emitted per consumed URL segment. Use this for tree-shaped URLs
+with unbounded depth (e.g. a file browser at `/folder/a/b/c`).
+
+<CodeExample path={frontMatter.examples + '/recursive_routes/main.py'} language="python" />
+
 <ClassMembers name={frontMatter.class_name} />

--- a/website/docs/cookbook/router.md
+++ b/website/docs/cookbook/router.md
@@ -384,6 +384,132 @@ def RootLayout():
 
 See [full example](../controls/router.md#managed-views--full-app-with-navigationrail).
 
+### Back navigation
+
+When the user pops the topmost View (close X on a modal, AppBar back arrow,
+iOS swipe-back, system back button) the Router by default navigates to the
+**parent of the current route in the route tree** — i.e. `chain[-2].resolved_path`
+of the matched chain, not `views[-2].route`. This is robust against shared
+`View.route` values (the "avoid transition animation" trick above) — a
+deep-Gallery pop still goes to `/gallery` even if `RootLayout` emits
+`route="/"` for both the Apps and Gallery tab roots.
+
+If you need fully custom pop behavior, install your own `page.on_view_pop`
+handler **before** `page.render_views(App)`. The Router detects a
+pre-existing handler and delegates to it instead of running the default.
+
+## Modal routes
+
+Set `modal=True` on a route to render its View as a fullscreen-dialog overlay
+that sits on top of the previous (non-modal) location's view stack. Closing
+the modal pops it without rebuilding the underlying stack — the views
+underneath stay mounted, so there's no rebuild flash.
+
+The modal's component still returns a `View` like any other route — set
+`fullscreen_dialog=True` on the View so Flutter renders the slide-up
+presentation and the close (X) leading icon.
+
+### Global modals — reachable from anywhere
+
+Declared at the top level of the route tree. The base stack comes from the
+last non-modal location the Router saw (defaults to `/` on first render):
+
+```python
+ft.Router([
+    ft.Route(component=Home),
+    ft.Route(component=Profile, path="profile"),
+    ft.Route(component=SettingsModal, path="settings", modal=True),
+], manage_views=True)
+```
+
+- `/` → stack `[Home]`
+- `/profile` → stack `[Profile]`
+- Navigate from `/profile` to `/settings` → stack `[Profile, SettingsModal]`
+  (Profile still mounted underneath the modal)
+- Close → back to `/profile`, stack `[Profile]` (Profile not rebuilt)
+- Deep-link `/settings` directly → stack `[Home, SettingsModal]`
+  (base defaults to `/`)
+
+### Local modals — pinned to a specific page
+
+Declared as a child of a non-modal parent. The base stack is the chain above
+the modal in the route tree, so the URL itself encodes which item the modal
+applies to and deep-link works without any state:
+
+```python
+ft.Router([
+    ft.Route(component=ItemList, path="items", children=[
+        ft.Route(component=ItemDetails, path=":id", children=[
+            ft.Route(component=EditModal, path="edit", modal=True),
+        ]),
+    ]),
+], manage_views=True)
+```
+
+- `/items/42` → stack `[ItemList, ItemDetails(42)]`
+- `/items/42/edit` → stack `[ItemList, ItemDetails(42), EditModal]`
+- Close → `/items/42`
+
+See [full example](../controls/router.md#modal-routes).
+
+## Recursive routes
+
+A route marked `recursive=True` can match itself as its own descendant — one
+`View` is emitted per consumed URL segment. Use this for tree-shaped URLs
+with unbounded depth without writing nested duplicates:
+
+```python
+ft.Router([
+    ft.Route(path="folder", component=Folders, children=[
+        ft.Route(
+            path=":name",
+            component=Folder,
+            recursive=True,
+            children=[
+                ft.Route(path="search", component=Search),
+            ],
+        ),
+    ]),
+], manage_views=True)
+```
+
+- `/folder/a/b/c` → stack `[Folders, Folder(a), Folder(a/b), Folder(a/b/c)]`
+- Back-swipe walks one segment at a time
+
+Inside the component, `use_route_params()` returns just the **current segment**
+(e.g. `{"name": "b"}` at depth 2). Use `use_view_path()` for the accumulated
+URL up to this level — useful when the component needs to know the full path.
+
+### Sibling-wins-over-recursion rule
+
+A non-recursive child of the recursive route is tried **before** self-recursion
+at every depth. In the example above, `/folder/x/search` matches as
+`[Folders, Folder(x), Search]` — the `Search` sibling wins over `Folder("search")`,
+so you only need to declare the special child once, not at every depth.
+
+This makes the recursive route ideal for replacing N-level fan-outs like:
+
+```python
+# Without recursive=True — declared N times for max depth N:
+ft.Route(path=":s1", component=Folder, children=[
+    ft.Route(path="search", component=Search),
+    ft.Route(path=":s2", component=Folder, children=[
+        ft.Route(path="search", component=Search),
+        ft.Route(path=":s3", component=Folder, children=[
+            ft.Route(path="search", component=Search),
+            ft.Route(path=":s4", component=Folder, children=[...]),
+        ]),
+    ]),
+]),
+
+# With recursive=True — one declaration, unbounded depth:
+ft.Route(path=":name", component=Folder, recursive=True, children=[
+    ft.Route(path="search", component=Search),
+]),
+```
+
+See [full example](../controls/router.md#recursive-routes).
+
 ## Hooks reference
 
 | Hook | Returns | Description |


### PR DESCRIPTION
## Summary

Three coordinated additions to `flet.Router` plus the docs, examples
and tests to land alongside them:

- **`Route(modal=True)`** — renders the route's `View` as a
  fullscreen-dialog overlay on top of the previous (non-modal)
  location's view stack instead of replacing it. Two flavours
  distinguished by placement in the tree:
  - **Global** (top-level): the base stack is rebuilt from the last
    non-modal location the Router saw (defaults to `/` on first
    render / direct deep-link).
  - **Local** (nested child of a non-modal route): the base stack is
    the chain above the modal in the route tree, so deep-link works
    from the URL alone.

  Pop navigates to the base URL stamped on the View at emit time —
  the underlying stack never rebuilds, so closing the modal doesn't
  flash a different page between the slide-down and the next URL
  match.

- **`Route(recursive=True)`** — a route can match itself as its own
  descendant. One View per consumed URL segment. `/folder/a/b/c`
  yields a 4-View stack so back-swipe walks one segment at a time.
  Non-recursive children are tried before self-recursion at every
  depth, so a more specific sibling (e.g. `example/:gp*`) wins over
  the recursive `:slug` without having to duplicate it at every
  level.

- **Default `on_view_pop`** now uses the matched chain's parent
  (`chain[-2].resolved_path`) instead of `views[-2].route` — robust
  against apps that share a `View.route` between sibling tab roots to
  suppress switch transitions. The app's pre-installed handler still
  takes precedence if present.

Each sub-chain (base + modal) renders with its own `LocationInfo` now,
so `is_route_active(...)` inside a base view sees the **base** URL
while a global `/settings` modal is open over `/gallery` — no app-side
workaround needed for nav highlighting.

## What ships in this PR

- `flet.components.router` — the `Route` dataclass, `_try_match`
  recursion, Router state for the modal base + chain, view emission
  per sub-chain, and the new pop handler.
- Docs: `website/docs/controls/router.md` (CodeExample refs), full
  "Modal routes" + "Recursive routes" + "Back navigation" sections in
  `website/docs/cookbook/router.md`.
- Two new runnable examples under `sdk/python/examples/apps/router/`:
  `modal_routes/` (global + local) and `recursive_routes/` (folder
  browser with sibling-search).
- 15 unit tests under `packages/flet/tests/` exercising the matching
  layer for modal and recursive routes.
- 2 new end-to-end tests in
  `packages/flet/integration_tests/examples/apps/test_router.py`
  driving the new example apps through the Flet test harness.

## Test plan

- [x] `uv run pytest packages/flet/tests/test_router_modal.py packages/flet/tests/test_router_recursive.py` → 15 passed locally
- [x] `uv run pytest packages/flet/integration_tests/examples/apps/test_router.py` → 18 passed locally (16 pre-existing + 2 new)
- [ ] CI runs on push (router integration suite takes ~9 min on macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Extend the router to support modal and recursive routes and improve default back navigation behavior while adding corresponding docs, examples, and tests.

New Features:
- Add Route.modal to render routes as fullscreen-dialog overlays on top of an existing view stack, supporting both global and local modals.
- Add Route.recursive to allow a route to match itself as its own descendant, emitting one view per consumed URL segment for tree-shaped URLs.

Enhancements:
- Update router view emission and pop handling to use the matched route chain structure (including modal bases) for computing back navigation targets and per-view location context.

Documentation:
- Document modal routes, recursive routes, and the router’s back navigation behavior in the cookbook and router control reference, including new example references.

Tests:
- Add unit tests for modal and recursive route matching and new integration tests covering modal and recursive example apps.

Chores:
- Add new runnable example apps showcasing modal routes and recursive routes, including accompanying metadata and README files.