### PR TITLE
docs(studio): give Studio its own footer column

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -126,9 +126,22 @@ module.exports = {
               label: 'Reference',
               to: '/docs/reference',
             },
+          ],
+        },
+        {
+          title: 'Studio',
+          items: [
             {
-              label: 'Studio',
-              to: '/studio',
+              label: 'Flet Studio app',
+              href: 'https://flet.app',
+            },
+            {
+              label: 'Docs',
+              to: '/docs/studio',
+            },
+            {
+              label: "What's new",
+              to: '/docs/studio/whats-new',
             },
           ],
         },


### PR DESCRIPTION
Replace the lone Studio link under the Docs column with a dedicated Studio section containing the app link, docs link, and What's new.

## Summary by Sourcery

Documentation:
- Update the website footer to add a separate Studio section with links to the Studio app, documentation, and "What’s new" content.