### PR TITLE
fix: add CMake definition to silence MSVC coroutine deprecation error

### DIFF
--- a/client/windows/CMakeLists.txt
+++ b/client/windows/CMakeLists.txt
@@ -42,6 +42,7 @@ function(APPLY_STANDARD_SETTINGS TARGET)
   target_compile_options(${TARGET} PRIVATE /W4 /WX /wd"4100")
   target_compile_options(${TARGET} PRIVATE /EHsc)
   target_compile_definitions(${TARGET} PRIVATE "_HAS_EXCEPTIONS=0")
+  target_compile_definitions(${TARGET} PRIVATE "_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS")
   target_compile_definitions(${TARGET} PRIVATE "$<$<CONFIG:Debug>:_DEBUG>")
 endfunction()
 

--- a/sdk/python/templates/build/{{cookiecutter.out_dir}}/windows/CMakeLists.txt
+++ b/sdk/python/templates/build/{{cookiecutter.out_dir}}/windows/CMakeLists.txt
@@ -42,6 +42,7 @@ function(APPLY_STANDARD_SETTINGS TARGET)
   target_compile_options(${TARGET} PRIVATE /W4 /WX /wd"4100")
   target_compile_options(${TARGET} PRIVATE /EHsc)
   target_compile_definitions(${TARGET} PRIVATE "_HAS_EXCEPTIONS=0")
+  target_compile_definitions(${TARGET} PRIVATE "_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS")
   target_compile_definitions(${TARGET} PRIVATE "$<$<CONFIG:Debug>:_DEBUG>")
 endfunction()
 


### PR DESCRIPTION
## Description

This PR fixes a build failure on Windows when using the latest Visual Studio 2026 (MSVC 14.51+) toolchain.

**Motivation & Context:**
Recent updates to the MSVC compiler (specifically version 14.51+) have promoted the deprecation of `<experimental/coroutine>` to a hard error (`error C2338: static assertion failed: error STL1011`). 
This issue is particularly critical in **CI/CD environments** (such as GitHub Actions), where the `windows-latest` runner has recently been updated to use Visual Studio 2026 Preview/Early Access tools. 
This breaks the build for plugins relying on legacy coroutine headers (e.g., `audioplayers_windows`, `permission_handler_windows`) even though the application code itself is correct.

**Changes:**
- Added `_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS` to the `APPLY_STANDARD_SETTINGS` function in `windows/CMakeLists.txt`.
- This suppresses the static assertion error, allowing the project to compile successfully with newer MSVC versions while maintaining backward compatibility.

**Evidence:**
- Affected CI Run: https://github.com/ihmily/flet/actions/runs/26486063073/job/77993900408#annotation:5:126

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I signed the CLA.
- [x] I have performed a self-review of my own code.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] New and existing tests pass locally with my changes.
- [ ] I have made corresponding documentation changes, if applicable.
- [ ] I have added changelog entries for user-facing changes, if applicable.
- [ ] I have updated release guide pages and `website/sidebars.yml` for breaking changes, removals, and deprecations, if applicable.

## Summary by Sourcery

Silence MSVC coroutine deprecation errors in the Windows client build to restore compatibility with newer Visual Studio toolchains.

Bug Fixes:
- Prevent build failures on Windows with recent MSVC versions by suppressing hard errors from deprecated experimental coroutine headers.

Build:
- Add a CMake compile definition to Windows client targets to silence experimental coroutine deprecation warnings in newer MSVC toolchains.