### PR TITLE
fix(router): pop to previous view, not the outlet layout URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.85.3
+
+### Bug fixes
+
+* Fix `flet.Router`'s default `on_view_pop` navigating to the wrong URL when an `outlet=True` layout sits between two views in `manage_views=True` mode. Popping such a view now targets the previous view entry's resolved URL — skipping outlet layouts and componentless grouping routes — instead of `chain[-2]`, which could equal the current view's URL and strand the page route, making the next navigation to it a no-op ([#6533](https://github.com/flet-dev/flet/pull/6533)) by @FeodorFitsner.
+
 ## 0.85.2
 
 ### New features

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -359,7 +359,7 @@ packages:
       path: "../packages/flet"
       relative: true
     source: path
-    version: "0.85.2"
+    version: "0.85.3"
   flet_ads:
     dependency: "direct main"
     description:

--- a/packages/flet/CHANGELOG.md
+++ b/packages/flet/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.85.3
+
+_No changes in the `flet` Dart package; version bumped for release coordination with a `flet.Router` view-pop fix on the Python side._
+
 ## 0.85.2
 
 _No changes in the `flet` Dart package; version bumped for release coordination with `flet.Router` enhancements on the Python side (modal/recursive route flags, chain-based default pop)._

--- a/packages/flet/pubspec.yaml
+++ b/packages/flet/pubspec.yaml
@@ -2,7 +2,7 @@ name: flet
 description: Write entire Flutter app in Python or add server-driven UI experience into existing Flutter app.
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/flet/tree/main/packages/flet
-version: 0.85.2
+version: 0.85.3
 
 # Supported platforms
 platforms:

--- a/sdk/python/packages/flet/integration_tests/examples/apps/test_router.py
+++ b/sdk/python/packages/flet/integration_tests/examples/apps/test_router.py
@@ -534,6 +534,14 @@ async def test_nested_routes(flet_app_function: ftt.FletTestApp):
     go_products_btn = await flet_app_function.tester.find_by_text("Go to Products")
     assert go_products_btn.count == 1
 
+    # Navigation idempotency: re-tap from Home after popping all the way
+    # back must navigate again (the route must not be stranded by the pop).
+    await flet_app_function.tester.tap(go_products_btn)
+    await flet_app_function.tester.pump_and_settle()
+
+    products_title = await flet_app_function.tester.find_by_text("All Products")
+    assert products_title.count == 1
+
 
 @pytest.mark.parametrize(
     "flet_app_function",
@@ -571,6 +579,29 @@ async def test_nested_outlet_views(flet_app_function: ftt.FletTestApp):
     back_btn = await flet_app_function.tester.find_by_tooltip("Back")
     assert back_btn.count == 1
     await flet_app_function.tester.tap(back_btn)
+    await flet_app_function.tester.pump_and_settle()
+
+    products_title = await flet_app_function.tester.find_by_text("All Products")
+    assert products_title.count == 1
+
+    # AppBar back → Home. Popping the products view must navigate to "/"
+    # (the previous *view*), not to the outlet layout's own "/products"
+    # URL. If it lands on the layout URL, the page route stays at
+    # "/products" while Flutter shows Home — and the next "Browse
+    # Products" tap becomes a no-op navigation to the current URL.
+    back_btn = await flet_app_function.tester.find_by_tooltip("Back")
+    assert back_btn.count == 1
+    await flet_app_function.tester.tap(back_btn)
+    await flet_app_function.tester.pump_and_settle()
+
+    welcome = await flet_app_function.tester.find_by_text("Welcome!")
+    assert welcome.count == 1
+
+    # Re-navigate to products — proves the route wasn't stranded on the
+    # layout URL after the pop.
+    browse_btn = await flet_app_function.tester.find_by_text("Browse Products")
+    assert browse_btn.count == 1
+    await flet_app_function.tester.tap(browse_btn)
     await flet_app_function.tester.pump_and_settle()
 
     products_title = await flet_app_function.tester.find_by_text("All Products")

--- a/sdk/python/packages/flet/src/flet/components/router.py
+++ b/sdk/python/packages/flet/src/flet/components/router.py
@@ -686,17 +686,26 @@ def Router(
                     page.navigate(current_modal_pop_to_ref.current)
                     return
 
-                # Non-modal pop: use the matched chain's parent route
-                # (route-tree-structural) rather than
-                # `views[-2].route`. This survives shared view keys
-                # like a tab-root layout that emits `route="/"` for
+                # Non-modal pop: navigate to the previous *view entry*'s
+                # resolved URL rather than `chain[-2]` or
+                # `views[-2].route`. Classifying into view entries skips
+                # `outlet=True` layouts and componentless grouping routes
+                # — otherwise `chain[-2]` can point at a layout whose URL
+                # equals the current view's URL, making the pop navigate
+                # to where we already are (a no-op that strands the URL).
+                # Staying route-tree-structural also survives shared view
+                # keys like a tab-root layout emitting `route="/"` for
                 # multiple sibling sections.
                 chain_now = current_chain_ref.current
-                if chain_now and len(chain_now) > 1:
-                    parent_match = chain_now[-2]
-                    target = parent_match.resolved_path or parent_match.full_path or "/"
-                    page.navigate(target)
-                    return
+                if chain_now:
+                    _, view_entries = _split_chain_into_view_levels(chain_now)
+                    if len(view_entries) > 1:
+                        parent_match = view_entries[-2][0]
+                        target = (
+                            parent_match.resolved_path or parent_match.full_path or "/"
+                        )
+                        page.navigate(target)
+                        return
 
                 # Stack of length 1 — nothing to pop to. (Flutter's
                 # `Navigator.canPop` is False here anyway.)

--- a/sdk/python/packages/flet/tests/test_router_pop.py
+++ b/sdk/python/packages/flet/tests/test_router_pop.py
@@ -1,0 +1,94 @@
+"""Unit tests for the non-modal view-pop target computation.
+
+The `Router`'s default `on_view_pop` handler navigates to the previous
+*view entry*'s resolved URL when the top view is popped. It must derive
+that target from the chain's view entries (`_split_chain_into_view_levels`)
+rather than `chain[-2]`: an intermediate `outlet=True` layout sits in the
+chain between two views but is NOT a view of its own, and its resolved URL
+can equal the current view's URL. Using `chain[-2]` there would navigate to
+the URL we're already at — a no-op that leaves the page route stranded so
+the next navigation to the same URL does nothing.
+
+This replicates the handler's target computation (the handler itself is a
+closure inside `Router`) the same way `test_router_modal` replicates the
+modal-index lookup.
+"""
+
+from flet.components.router import (
+    Route,
+    _match_routes,
+    _split_chain_into_view_levels,
+)
+
+
+def _dummy():  # placeholder component — Route requires a callable
+    pass
+
+
+def _pop_target(chain):
+    """Replicates the Router's non-modal pop-target computation."""
+    if not chain:
+        return None
+    _, view_entries = _split_chain_into_view_levels(chain)
+    if len(view_entries) > 1:
+        parent_match = view_entries[-2][0]
+        return parent_match.resolved_path or parent_match.full_path or "/"
+    return None
+
+
+# Mirrors examples/apps/router/nested_outlet_views: a Home route whose
+# child is an `outlet=True` products layout wrapping its own children.
+_routes = [
+    Route(
+        component=_dummy,
+        children=[
+            Route(
+                path="products",
+                component=_dummy,
+                outlet=True,
+                children=[
+                    Route(
+                        component=_dummy,
+                        children=[
+                            Route(path=":pid", component=_dummy),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    ),
+]
+
+
+def test_pop_from_outlet_layout_view_skips_layout():
+    """`/products` builds views [Home(/), Products(/products)] but the
+    chain is [Home, products-layout, ProductsList]. Popping the Products
+    view must land on Home (`/`) — not the layout's own `/products`,
+    which `chain[-2]` would wrongly yield."""
+    chain = _match_routes(_routes, "/products")
+
+    assert chain is not None
+    # The layout really is `chain[-2]` and shares the leaf's resolved URL,
+    # which is exactly the trap the view-entry computation avoids.
+    assert chain[-2].route.outlet is True
+    assert chain[-2].resolved_path == "/products"
+
+    assert _pop_target(chain) == "/"
+
+
+def test_pop_from_nested_product_lands_on_products_list():
+    """`/products/1` builds views [Home(/), ProductsList(/products),
+    ProductDetails(/products/1)]. Popping the details view lands on the
+    products list (`/products`)."""
+    chain = _match_routes(_routes, "/products/1")
+
+    assert chain is not None
+    assert _pop_target(chain) == "/products"
+
+
+def test_single_view_has_no_pop_target():
+    """At `/` the stack is one view — nothing to pop to."""
+    chain = _match_routes(_routes, "/")
+
+    assert chain is not None
+    assert _pop_target(chain) is None


### PR DESCRIPTION
## Summary

The Router's default `on_view_pop` handler computed the non-modal pop target as `chain[-2].resolved_path`. When the chain contains an `outlet=True` layout between two view entries (e.g. `[Home, products-layout, ProductsList]`), `chain[-2]` is the **layout**, whose resolved URL equals the leaf view's URL. Popping that view navigated to the URL already shown, leaving the page route stranded — so the next navigation to the same URL became a no-op.

Reproduced with `examples/apps/router/nested_outlet_views`: go Home → Products → back to Home → tap "Browse Products" again → nothing happens.

The fix computes the pop target from the chain's **view entries** (via `_split_chain_into_view_levels`), skipping outlet layouts and componentless grouping routes, so a pop lands on the actual previous view.

## Changes

- `components/router.py` — non-modal pop now targets the previous view entry, not `chain[-2]`.
- `tests/test_router_pop.py` — new unit tests for the pop-target computation (outlet-layout skip, nested case, single-view no-op).
- `integration_tests/.../test_router.py` — extend `test_nested_outlet_views` to pop back to Home and re-navigate; add a navigation-idempotency step to `test_nested_routes`.

## Test plan

- [x] `pytest tests/test_router_pop.py tests/test_router_modal.py tests/test_router_recursive.py` — 18 passed
- [x] `test_nested_outlet_views` integration test (Flutter harness) — passed with the new back-to-Home + re-navigate steps
- [x] `test_nested_routes` integration test — passed with the idempotency step
- [x] Full `test_router.py` integration suite — 17 passed; the one error (`test_featured_views`) was a startup flake that passes in isolation and is unrelated to this change

## Summary by Sourcery

Ensure router view pops navigate to the correct previous view rather than leaving the page route stranded on an outlet layout URL.

Bug Fixes:
- Fix non-modal router view pop to compute the target from view entries instead of the raw matched chain, so pops skip outlet layouts and grouping routes and land on the actual previous view.

Tests:
- Add unit tests covering non-modal pop-target computation, including outlet-layout chains, nested product routes, and single-view stacks.
- Extend nested router integration tests to verify back navigation returns to Home and that repeated navigations from Home remain effective after popping.