### PR TITLE
Flet Studio update and skip builds for website/tools-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,6 @@ on:
       - 'sdk/python/packages/**'
       - 'sdk/python/templates/**'
       - 'packages/flet/**'
-      - 'tools/crocodocs/**'
-      - 'website/**'
       - '.fvmrc'
   pull_request:
     paths:
@@ -25,8 +23,6 @@ on:
       - 'sdk/python/packages/**'
       - 'sdk/python/templates/**'
       - 'packages/flet/**'
-      - 'tools/crocodocs/**'
-      - 'website/**'
       - '.fvmrc'
   workflow_dispatch:
 

--- a/.github/workflows/release-pr-changelog.yml
+++ b/.github/workflows/release-pr-changelog.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - 'release/**'
+    paths-ignore:
+      - 'website/**'
+      - 'tools/**'
     types:
       - opened
       - synchronize

--- a/website/docs/studio/whats-new.md
+++ b/website/docs/studio/whats-new.md
@@ -8,6 +8,10 @@ New features, improvements, and bug fixes in Flet Studio, listed in
 reverse-chronological order. Flet Studio ships independently of the Flet SDK — see
 [Flet release notes](../updates/release-notes.md) for SDK changes.
 
+## May 29, 2026
+
+* New sign in options: Google and Microsoft.
+
 ## May 26, 2026
 
 * The initial public release of Flet Studio.


### PR DESCRIPTION
## Summary
- Remove `website/**` and `tools/crocodocs/**` from the `paths` allow-list in `ci.yml` (push + pull_request), so changes confined to those directories no longer trigger the build/publish matrix.
- Add `paths-ignore` for `website/**` and `tools/**` to `release-pr-changelog.yml`, so docs/tooling-only PRs to `release/**` branches skip the changelog-record requirement.
- docs(studio): add a May 29 "what's new" entry for Google/Microsoft sign in options.

Note: GitHub path filters skip a run only when *every* changed file matches — mixed PRs (e.g. website + client code) still run CI, and the `docs_build` job continues to gate releases against broken docs whenever code changes.

## Test plan
- [ ] Open a website-only PR and confirm Build & Publish does not start.
- [ ] Open a PR touching client/sdk and confirm CI runs as before.

## Summary by Sourcery

Relax CI triggers and changelog requirements for website/tools-only changes while documenting new Studio sign-in options.

New Features:
- Document new Google and Microsoft sign-in options in the Flet Studio "what's new" page.

Enhancements:
- Exclude website and tools-only changes from triggering the main build and publish matrix in the primary CI workflow.
- Allow release PRs that modify only website or tools paths to bypass the changelog requirement.