### PR TITLE
feat(build): allow attributes on Android <uses-permission> entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Improvements
 
+* Allow `[tool.flet.android.permission]` values to be TOML inline tables in addition to booleans — each `key = "value"` entry adds an `android:<key>="<value>"` attribute to the generated `<uses-permission>` element, unlocking modifiers like `android:maxSdkVersion` and `android:usesPermissionFlags` that real-world Android permissions (e.g. Bluetooth LE) require. The boolean form and the `--android-permissions` CLI flag are unchanged; a non-empty inline table is always emitted, an empty table (`{}`) is treated as `false`, and invalid value types fail the build with a clear error ([#6550](https://github.com/flet-dev/flet/issues/6550), [#6551](https://github.com/flet-dev/flet/pull/6551)) by @FeodorFitsner.
 * Upgrade the bundled Pyodide runtime in the `flet build web` template from `0.27.5` to `0.27.7` (includes `micropip` `0.9.0`) ([#6549](https://github.com/flet-dev/flet/pull/6549)) by @FeodorFitsner.
 * Drop generated `web/canvaskit/` build artifacts (`canvaskit.js`/`.wasm`/`.symbols` and the `chromium/` and `skwasm`/`skwasm_st` variants) from the `flet build web` template — these are produced by the Flutter web build and should not have been committed into the cookiecutter template ([#6549](https://github.com/flet-dev/flet/pull/6549)) by @FeodorFitsner.
 

--- a/sdk/python/examples/apps/flet_build_test/pyproject.toml
+++ b/sdk/python/examples/apps/flet_build_test/pyproject.toml
@@ -85,6 +85,12 @@ build_number = 1
 [tool.flet.app]
 path = "src"
 
+[tool.flet.android.permission]
+"android.permission.READ_EXTERNAL_STORAGE" = true
+"android.permission.WRITE_EXTERNAL_STORAGE" = true
+"android.permission.ACCESS_FINE_LOCATION" = { maxSdkVersion = "30" }
+"android.permission.BLUETOOTH_SCAN" = { usesPermissionFlags = "neverForLocation" }
+
 [tool.flet.android.meta_data]
 "com.google.android.gms.ads.APPLICATION_ID" = "ca-app-pub-3940256099942544~3347511713"
 

--- a/sdk/python/packages/flet-cli/src/flet_cli/commands/build_base.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/commands/build_base.py
@@ -922,6 +922,25 @@ class BaseBuildCommand(BaseFlutterCommand):
             else:
                 self.cleanup(1, f"Invalid Android permission option: {p}")
 
+        for key, value in android_permissions.items():
+            if isinstance(value, bool):
+                continue
+            if isinstance(value, dict):
+                for ak, av in value.items():
+                    if not isinstance(av, (str, bool, int, float)):
+                        self.cleanup(
+                            1,
+                            f"Invalid Android permission attribute value for "
+                            f"{key}.{ak}: {type(av).__name__}. "
+                            "Expected string, boolean, or number.",
+                        )
+                continue
+            self.cleanup(
+                1,
+                f"Invalid Android permission value for {key}: "
+                f"{type(value).__name__}. Expected boolean or inline table.",
+            )
+
         android_features = merge_dict(
             android_features,
             self.get_pyproject("tool.flet.android.feature") or {},

--- a/sdk/python/templates/build/{{cookiecutter.out_dir}}/android/app/src/main/AndroidManifest.xml
+++ b/sdk/python/templates/build/{{cookiecutter.out_dir}}/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <!-- flet: permission {% for k, v in cookiecutter.options.android_permissions.items() %} {% if v == True %} -->
-    <uses-permission android:name="{{ k }}" />
+    <!-- flet: permission {% for k, v in cookiecutter.options.android_permissions.items() %} {% if v %} -->
+    <uses-permission android:name="{{ k }}"{% if v is mapping %}{% for ak, av in v.items() %} android:{{ ak }}="{{ av }}"{% endfor %}{% endif %} />
     <!-- flet: end of permission {% endif %} {% endfor %} -->
 
     <!-- flet: feature {% for k, v in cookiecutter.options.android_features.items() %} -->

--- a/website/docs/publish/android.md
+++ b/website/docs/publish/android.md
@@ -521,6 +521,11 @@ Permissions with `false` are omitted from the generated manifest.
 <TabItem value="pyproject-toml" label="pyproject.toml">
 Use boolean values. TOML booleans must be lowercase: `true` or `false`.
 Permissions set to `false` are omitted from the generated manifest.
+
+A value can also be a TOML inline table whose entries become extra
+`android:<key>="<value>"` attributes on the generated `<uses-permission>`
+element — useful for attributes like `maxSdkVersion` or `usesPermissionFlags`.
+A non-empty table is always emitted; an empty table `{}` is treated as `false`.
 </TabItem>
 </Tabs>
 #### Example
@@ -538,6 +543,8 @@ flet build apk \
 [tool.flet.android.permission]
 "android.permission.READ_EXTERNAL_STORAGE" = true
 "android.permission.WRITE_EXTERNAL_STORAGE" = true
+"android.permission.ACCESS_FINE_LOCATION" = { maxSdkVersion = "30" }
+"android.permission.BLUETOOTH_SCAN" = { usesPermissionFlags = "neverForLocation" }
 ```
 </TabItem>
 </Tabs>
@@ -551,6 +558,8 @@ the `pyproject.toml` example above will be translated accordingly into this:
 <manifest>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" />
 </manifest>
 ```
 </details>


### PR DESCRIPTION
## Summary

- `[tool.flet.android.permission]` now accepts a TOML inline table as a value, whose entries become extra `android:<key>="<value>"` attributes on the generated `<uses-permission>` element — unlocking attributes like `android:maxSdkVersion` and `android:usesPermissionFlags` that real-world Android permissions (e.g. Bluetooth LE) need.
- Boolean form (`true` / `false`) and the `--android-permissions` CLI flag are unchanged. A non-empty inline table is always emitted; `{}` is treated as `false`. Invalid value types fail the build with a clear error.
- Documentation updated under `website/docs/publish/android.md` with the new value form and a `bleekWare`-style BLE example.

Closes #6550. Originally requested in discussion [#6547](https://github.com/flet-dev/flet/discussions/6547).

### Example

```toml
[tool.flet.android.permission]
"android.permission.INTERNET" = true
"android.permission.ACCESS_FINE_LOCATION" = { maxSdkVersion = "30" }
"android.permission.BLUETOOTH_SCAN" = { usesPermissionFlags = "neverForLocation" }
```

renders to:

```xml
<uses-permission android:name="android.permission.INTERNET" />
<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:maxSdkVersion="30" />
<uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" />
```

## Test plan

- [ ] `flet build apk` against a pyproject containing the BLE example above and inspect `build/flutter/android/app/src/main/AndroidManifest.xml` — both lines carry the extra attributes, the default `android.permission.INTERNET` still renders bare.
- [ ] Regression: existing pyprojects using `"android.permission.X" = true` still render the bare `<uses-permission android:name="..." />` with no extra whitespace before `/>`.
- [ ] Validation: setting a permission value to a list (e.g. `["a"]`) or a dict-of-list (`{ foo = [1] }`) exits with the new error messages instead of producing malformed XML.
- [ ] Docs: `website/docs/publish/android.md` renders cleanly under the docs build.

## Summary by Sourcery

Add support for specifying extra attributes on generated Android <uses-permission> manifest entries via pyproject configuration, with validation and documentation updates.

New Features:
- Allow Android permissions in pyproject configuration to be defined as inline tables whose entries become additional attributes on the corresponding <uses-permission> manifest elements.

Enhancements:
- Validate Android permission configuration values and attributes at build time, rejecting unsupported value types with clear error messages.

Documentation:
- Document the new inline-table syntax for Android permissions and demonstrate usage with examples in the Android publishing guide.