### PR TITLE
Support Android TV in device info retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * Fix `flet build apk` failing at `mergeDebugNativeLibs` with `N files found with path 'lib/<abi>/libc++_shared.so'` when an app combines `serious_python_android` with another Flutter plugin that also bundles the NDK C++ runtime ([#6570](https://github.com/flet-dev/flet/issues/6570), [#6571](https://github.com/flet-dev/flet/pull/6571)) by @ndonkoHenri.
 * Specify `handler` signatures in `subscribe` and `subscribe_topic` methods of `PubSubClient` for better type checking ([#6549](https://github.com/flet-dev/flet/pull/6564)) by @Iaw4tch
 * Fix `FilePicker.pick_files()` on web for slow network shares or slow machines: pass `cancel_upload_on_window_blur=False` to prevent valid file selections from being reported as cancelled when the browser window loses focus during file picking ([#771](https://github.com/flet-dev/flet/issues/771), [#6573](https://github.com/flet-dev/flet/pull/6573)) by @ndonkoHenri.
+* Support `PagePlatform.ANDROID_TV` in `Page.get_device_info()` retrieval ([#6604](https://github.com/flet-dev/flet/pull/6604)) by @bl1nch.
 
 ### Documentation
 

--- a/sdk/python/packages/flet/src/flet/controls/page.py
+++ b/sdk/python/packages/flet/src/flet/controls/page.py
@@ -1386,7 +1386,7 @@ class Page(BasePage):
 
         if self.web:
             return from_dict(WebDeviceInfo, info)
-        elif self.platform == PagePlatform.ANDROID:
+        elif self.platform == PagePlatform.ANDROID or self.platform == PagePlatform.ANDROID_TV:
             return from_dict(AndroidDeviceInfo, info)
         elif self.platform == PagePlatform.IOS:
             return from_dict(IosDeviceInfo, info)

--- a/sdk/python/packages/flet/src/flet/controls/page.py
+++ b/sdk/python/packages/flet/src/flet/controls/page.py
@@ -1386,7 +1386,7 @@ class Page(BasePage):
 
         if self.web:
             return from_dict(WebDeviceInfo, info)
-        elif self.platform == PagePlatform.ANDROID or self.platform == PagePlatform.ANDROID_TV:
+        elif self.platform in [PagePlatform.ANDROID, PagePlatform.ANDROID_TV]:
             return from_dict(AndroidDeviceInfo, info)
         elif self.platform == PagePlatform.IOS:
             return from_dict(IosDeviceInfo, info)


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change, relevant motivation, and context. -->

<!-- If this PR fixes an open issue, please link to the issue here. Ex: Fixes #4562 -->

`Page.get_device_info()` -> `AndroidDeviceInfo` if `Page.platform == PagePlatform.ANDROID_TV`

## Test code

```python
# Minimal test/reproduction code for reviewers, if applicable.
```

## Type of change

<!-- select only options relevant to your PR -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I signed the CLA.
- [ ] I have performed a self-review of my own code.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] New and existing tests pass locally with my changes.
- [ ] I have made corresponding documentation changes, if applicable.
- [ ] I have added changelog entries for user-facing changes, if applicable.
- [ ] I have updated release guide pages and `website/sidebars.yml` for breaking changes, removals, and deprecations, if applicable.

## Screenshots

<!-- Add screenshots here if applicable. -->

## Additional details

<!-- Any additional details to be known about this PR. -->

## Summary by Sourcery

Bug Fixes:
- Ensure Android TV pages return AndroidDeviceInfo when calling get_device_info instead of being unsupported or misclassified.