### PR TITLE
在android_sdk.py中令cmdline-tools-url检测到windows使用arm64架构时返回与x64相同的下载链接

### DIFF
--- a/sdk/python/packages/flet-cli/src/flet_cli/utils/android_sdk.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/utils/android_sdk.py
@@ -229,7 +229,7 @@ class AndroidSDK:
                 },
                 "Windows": {
                     "AMD64": "win",
-                    "ARM64": "win"
+                    "ARM64": "win"            # If it is an ARM-based Windows device, return the download link for x64 devices.
                 },
             }[platform.system()][platform.machine()]
         except KeyError:

--- a/sdk/python/packages/flet-cli/src/flet_cli/utils/android_sdk.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/utils/android_sdk.py
@@ -229,6 +229,7 @@ class AndroidSDK:
                 },
                 "Windows": {
                     "AMD64": "win",
+                    "ARM64": "win"
                 },
             }[platform.system()][platform.machine()]
         except KeyError:


### PR DESCRIPTION
## Description

Running the Android SDK using the Windows ARM64 compatibility layer.

## Test code (This test is only meaningful if your packaging device uses the ARM architecture.)

```shell
flet create
flet build apk
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I signed the CLA.
- [x] I have performed a self-review of my own code.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] New and existing tests pass locally with my changes.
- [x] I have made corresponding documentation changes, if applicable.
- [x] I have added changelog entries for user-facing changes, if applicable.
- [x] I have updated release guide pages and `website/sidebars.yml` for breaking changes, removals, and deprecations, if applicable.

## Summary by Sourcery

Bug Fixes:
- Treat Windows ARM64 machines as using the Windows x64 Android command-line tools package to avoid missing or incorrect SDK downloads.