### PR TITLE
Rich progress bars for client and pyodide downloads

### DIFF
--- a/sdk/python/packages/flet-cli/pyproject.toml
+++ b/sdk/python/packages/flet-cli/pyproject.toml
@@ -14,7 +14,8 @@ dependencies = [
     "tomli >= 1.1.0 ; python_version < '3.11'",
     "cookiecutter >=2.6.0",
     "binaryornot <0.5",
-    "chardet <6"
+    "chardet <6",
+    "rich >=13.0.0"
 ]
 
 [project.urls]

--- a/sdk/python/packages/flet-cli/src/flet_cli/utils/distros.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/utils/distros.py
@@ -7,14 +7,17 @@ from typing import Optional
 from rich.progress import Progress
 
 
-def download_with_progress(url, dest_path, progress: Optional[Progress] = None):
+def download_with_progress(
+    url, dest_path, progress: Optional[Progress] = None, description="Downloading..."
+):
     """Downloads a file with a progress bar."""
     with urllib.request.urlopen(url) as response:
-        total_size = int(response.info().get("Content-Length").strip())
+        content_length = response.headers.get("Content-Length")
+        total_size = int(content_length) if content_length else None
         block_size = 8192  # 8 KB chunks
 
         if progress:
-            task = progress.add_task("Downloading...", total=total_size)
+            task = progress.add_task(description, total=total_size)
         with open(dest_path, "wb") as out_file:
             while chunk := response.read(block_size):
                 out_file.write(chunk)

--- a/sdk/python/packages/flet-cli/src/flet_cli/utils/pyodide.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/utils/pyodide.py
@@ -12,9 +12,13 @@ from __future__ import annotations
 import json
 import shutil
 import tarfile
-import urllib.request
 from collections.abc import Iterable
 from pathlib import Path
+
+from rich.progress import Progress
+
+from flet_cli.utils.distros import download_with_progress
+from flet_cli.utils.template_cache import get_cache_root
 
 _GITHUB_TARBALL_URL = "https://github.com/pyodide/pyodide/releases/download/{version}/pyodide-core-{version}.tar.bz2"
 _CDN_FILE_URL = "https://cdn.jsdelivr.net/pyodide/v{version}/full/{filename}"
@@ -25,13 +29,12 @@ _EXTRA_RUNTIME_PACKAGES = ("micropip", "packaging")
 
 
 def _flet_cache_root() -> Path:
-    return Path.home() / ".flet" / "pyodide"
+    return get_cache_root() / "pyodide"
 
 
-def _download(url: str, dest: Path) -> None:
+def _download(url: str, dest: Path, progress: Progress, description: str) -> None:
     dest.parent.mkdir(parents=True, exist_ok=True)
-    with urllib.request.urlopen(url) as resp, dest.open("wb") as f:
-        shutil.copyfileobj(resp, f)
+    download_with_progress(url, str(dest), progress, description=description)
 
 
 def _resolve_runtime_wheel_filenames(
@@ -55,7 +58,13 @@ def _populate_cache(version: str, cache_dir: Path) -> None:
     cache_dir.mkdir(parents=True, exist_ok=True)
     tarball = cache_dir / f"pyodide-core-{version}.tar.bz2"
 
-    _download(_GITHUB_TARBALL_URL.format(version=version), tarball)
+    with Progress(transient=True) as progress:
+        _download(
+            _GITHUB_TARBALL_URL.format(version=version),
+            tarball,
+            progress,
+            f"Downloading Pyodide {version}...",
+        )
     with tarfile.open(tarball, "r:bz2") as tf:
         # The core tarball nests everything under a top-level "pyodide/" dir.
         # Strip that prefix as we extract so files land directly in cache_dir.
@@ -79,11 +88,19 @@ def _populate_cache(version: str, cache_dir: Path) -> None:
     lock_json = cache_dir / "pyodide-lock.json"
     if not lock_json.exists():
         raise RuntimeError(f"pyodide-core-{version} did not contain pyodide-lock.json")
-    for wheel in _resolve_runtime_wheel_filenames(lock_json, _EXTRA_RUNTIME_PACKAGES):
-        wheel_path = cache_dir / wheel
-        if wheel_path.exists():
-            continue
-        _download(_CDN_FILE_URL.format(version=version, filename=wheel), wheel_path)
+    with Progress(transient=True) as progress:
+        for wheel in _resolve_runtime_wheel_filenames(
+            lock_json, _EXTRA_RUNTIME_PACKAGES
+        ):
+            wheel_path = cache_dir / wheel
+            if wheel_path.exists():
+                continue
+            _download(
+                _CDN_FILE_URL.format(version=version, filename=wheel),
+                wheel_path,
+                progress,
+                f"Downloading {wheel}...",
+            )
 
 
 def _cache_matches_version(cache_dir: Path, version: str) -> bool:
@@ -101,7 +118,7 @@ def _cache_matches_version(cache_dir: Path, version: str) -> bool:
 def ensure_pyodide(version: str, dest_dir: Path) -> None:
     """Ensure a working Pyodide runtime of `version` exists at `dest_dir`.
 
-    Cached per version under `~/.flet/pyodide/<version>/`. Idempotent: if
+    Cached per version under `~/.flet/cache/pyodide/<version>/`. Idempotent: if
     `dest_dir/pyodide-lock.json` already pins `version`, no work is done.
     """
 

--- a/sdk/python/packages/flet-desktop/pyproject.toml
+++ b/sdk/python/packages/flet-desktop/pyproject.toml
@@ -7,7 +7,8 @@ license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "flet"
+    "flet",
+    "rich >=13.0.0"
 ]
 
 [project.urls]

--- a/sdk/python/packages/flet-desktop/src/flet_desktop/__init__.py
+++ b/sdk/python/packages/flet-desktop/src/flet_desktop/__init__.py
@@ -14,6 +14,8 @@ import urllib.request
 import zipfile
 from pathlib import Path
 
+from rich.progress import Progress
+
 import flet_desktop
 import flet_desktop.version
 from flet.utils import (
@@ -174,6 +176,19 @@ def __get_client_storage_dir():
     )
 
 
+def __download_with_progress(url, dest_path, description):
+    """Download a file to dest_path, showing a rich progress bar."""
+    with urllib.request.urlopen(url) as response, Progress(transient=True) as progress:
+        content_length = response.headers.get("Content-Length")
+        task = progress.add_task(
+            description, total=int(content_length) if content_length else None
+        )
+        with open(dest_path, "wb") as f:
+            while chunk := response.read(8192):
+                f.write(chunk)
+                progress.update(task, advance=len(chunk))
+
+
 def __download_flet_client(file_name):
     """
     Download a Flet client archive from GitHub Releases.
@@ -195,7 +210,7 @@ def __download_flet_client(file_name):
     logger.info(f"Downloading Flet v{ver} from {flet_url}")
     print(f"Preparing Flet v{ver} for the first use. This is a one-time operation...")
     temp_arch = Path(tempfile.gettempdir()).joinpath(f"{file_name}.{random_string(10)}")
-    urllib.request.urlretrieve(flet_url, str(temp_arch))
+    __download_with_progress(flet_url, str(temp_arch), f"Downloading Flet v{ver}...")
     return str(temp_arch)
 
 

--- a/website/src/components/crocodocs/utils.js
+++ b/website/src/components/crocodocs/utils.js
@@ -652,11 +652,17 @@ function preprocessRestCrossReferenceMarkdown(text, context) {
 }
 
 /**
- * Escape bare '<' characters (not followed by tag-start or '!') to '&lt;' in non-code text.
- * Prevents MDX from treating angle brackets in docstrings as JSX elements.
- * Skips fenced code blocks and inline backtick spans.
+ * Escape MDX-unsafe characters in non-code text so docstring prose can't be
+ * misparsed as MDX syntax:
+ *  - bare '<' (not followed by tag-start or '!') becomes '&lt;', so it isn't
+ *    treated as the start of a JSX element;
+ *  - '{' and '}' become '&#123;'/'&#125;', so content like
+ *    `boot_screen_options={'spinner_size': 30}` isn't parsed as a (broken)
+ *    JSX expression.
+ * Skips fenced code blocks and inline backtick spans, where these characters
+ * are already safe and should be preserved verbatim.
  */
-function escapeMdxUnsafeAngles(text) {
+function escapeMdxUnsafe(text) {
   if (!text) {
     return text;
   }
@@ -673,7 +679,10 @@ function escapeMdxUnsafeAngles(text) {
           if (inlineSegment.startsWith("`") && inlineSegment.endsWith("`")) {
             return inlineSegment;
           }
-          return inlineSegment.replace(/<(?![A-Za-z!/])/g, "&lt;");
+          return inlineSegment
+            .replace(/<(?![A-Za-z!/])/g, "&lt;")
+            .replace(/\{/g, "&#123;")
+            .replace(/\}/g, "&#125;");
         })
         .join("");
     })
@@ -1138,7 +1147,7 @@ export function renderInlineMarkdown(text, context) {
     return null;
   }
   const tree = MARKDOWN_PARSER.parse(
-    escapeMdxUnsafeAngles(
+    escapeMdxUnsafe(
       preprocessRestCrossReferenceMarkdown(
         preprocessCrossReferenceMarkdown(text, context),
         context
@@ -1164,7 +1173,7 @@ export function renderDocstring(docstring, context = {}, keyPrefix = "doc") {
     return null;
   }
   const tree = MARKDOWN_PARSER.parse(
-    escapeMdxUnsafeAngles(
+    escapeMdxUnsafe(
       preprocessRestCrossReferenceMarkdown(
         preprocessCrossReferenceMarkdown(
           normalizeDocstringMarkdown(docstring),


### PR DESCRIPTION
## Description

Adds a live **rich** progress bar to the two downloads that were previously silent, matching the bars already shown for Flutter/JDK/Android SDK installs:

- **flet-desktop first-run client download** — replaces a frozen "Preparing Flet..." line (and supersedes #6605, which used a hand-rolled stdlib bar with no TTY guard, Unicode chars that break on legacy Windows consoles, and a fragile `percent==100` newline).
- **pyodide runtime download** (the largest download in the project) — previously a silent `urlopen` + `copyfileobj`.

flet core stays **rich-free**; `rich` is added only to the packages that actually render bars (`flet-cli`, `flet-desktop`).

## Changes

- **distros**: `download_with_progress` tolerates a missing `Content-Length` header (indeterminate bar instead of crashing on `.strip()` of `None`) and takes a `description` arg so call sites can label bars.
- **pyodide**: downloads via `download_with_progress` with self-managed `Progress` bars; cache moved from `~/.flet/pyodide` to `~/.flet/cache/pyodide` (now honors `$FLET_CACHE_DIR`, consistent with the python-build and build-template caches).
- **flet-desktop**: downloads the client via a small local rich progress helper (can't import flet-cli; core must stay rich-free).
- Declares `rich` in `flet-cli` (was imported but never declared — only present transitively via cookiecutter) and `flet-desktop`.

rich auto-detects non-TTY/CI and suppresses the bar, so there's no `\r` spam when piped and no manual `isatty()` guard needed.

> Note: also includes a pre-existing `fix(website)` commit that was already on this branch.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have performed a self-review of my own code.
- [x] My code follows the style guidelines of this project.

## Summary by Sourcery

Add rich-based progress bars for Pyodide runtime and Flet desktop client downloads and align Pyodide caching with the shared Flet cache layout.

New Features:
- Show a rich progress bar during initial Flet desktop client downloads instead of a static message.
- Show rich progress bars for Pyodide core and wheel downloads during cache population.

Enhancements:
- Update Pyodide cache location to use the shared Flet cache root under ~/.flet/cache/pyodide, honoring the global cache directory setting.
- Make the generic download helper tolerate missing Content-Length headers and allow custom progress descriptions.
- Extend website markdown preprocessing to escape additional MDX-unsafe characters in docstrings so inline examples are parsed safely.

Chores:
- Declare rich as an explicit dependency of the flet-cli and flet-desktop packages.