### PR TITLE
Bump serious_python 4.2.1 / python-build 20260701

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * Fix `FilePicker.pick_files()` on web for slow network shares or slow machines: pass `cancel_upload_on_window_blur=False` to prevent valid file selections from being reported as cancelled when the browser window loses focus during file picking ([#771](https://github.com/flet-dev/flet/issues/771), [#6573](https://github.com/flet-dev/flet/pull/6573)) by @ndonkoHenri.
 * Support `PagePlatform.ANDROID_TV` in `Page.get_device_info()` retrieval ([#6604](https://github.com/flet-dev/flet/pull/6604)) by @bl1nch.
 * Fix `ProgressRing.year_2023` being ignored, so the control correctly switches between the latest and 2023 Material Design appearances ([#6614](https://github.com/flet-dev/flet/issues/6614)) by @ndonkoHenri.
+* `flet build ipa` / `ios` apps that ship ctypes packages with plain `.dylib` shared libraries (e.g. `llama-cpp-python`) now load them on the **iOS simulator** instead of failing at launch with a `dlopen` platform mismatch (`have 'iOS', need 'iOS-simulator'`); the iOS runtime also now bundles the `_multiprocessing` extension (importable, not spawnable). Bumps the pinned bundle to `serious_python` 4.2.1 / python-build `20260701` ([serious_python#223](https://github.com/flet-dev/serious-python/pull/223)) by @ndonkoHenri, @FeodorFitsner.
 
 ### Documentation
 

--- a/sdk/python/packages/flet-cli/src/flet_cli/utils/python_versions.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/utils/python_versions.py
@@ -28,7 +28,7 @@ from flet_cli.utils.template_cache import get_cache_root
 # python-build release this flet pins. Keep in sync with serious_python's
 # `pythonReleaseDate` (lib/src/python_versions.dart) — both should track the
 # same python-build release.
-PYTHON_BUILD_RELEASE_DATE = "20260630"
+PYTHON_BUILD_RELEASE_DATE = "20260701"
 
 RELEASE_DATE_ENV = "FLET_PYTHON_BUILD_RELEASE_DATE"
 MANIFEST_PATH_ENV = "FLET_PYTHON_BUILD_MANIFEST"

--- a/sdk/python/templates/build/{{cookiecutter.out_dir}}/pubspec.yaml
+++ b/sdk/python/templates/build/{{cookiecutter.out_dir}}/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   flet:
     path: ../../../../../packages/flet
 
-  serious_python: 4.2.0
+  serious_python: 4.2.1
 
   # MsgPack codec used by the dart_bridge FletBackendChannel implementation
   # in lib/main.dart — matches the wire format flet's existing socket


### PR DESCRIPTION
## Summary

Re-pins the bundled Python runtime to the latest `serious_python` / `python-build` releases.

- **`python_versions.py`**: `PYTHON_BUILD_RELEASE_DATE` `20260630` → `20260701`. The new python-build release only rebuilds the **iOS** runtime (which now bundles the `_multiprocessing` extension — importable, not spawnable). Its `manifest.json` is otherwise byte-identical to `20260630`, so the supported Python (3.12.13 / 3.13.14 / 3.14.6) / Pyodide / `dart_bridge` (1.4.1) / ABI set is unchanged — flet fetches the manifest at build time, so no version table needs regenerating.
- **build template `pubspec.yaml`**: `serious_python` `4.2.0` → `4.2.1`, which ships the ctypes `.dylib` iOS-**simulator** load fix (flet-dev/serious-python#223): `.dylib`-shipping packages like `llama-cpp-python` now `dlopen` on the simulator instead of failing with `incompatible platform (have 'iOS', need 'iOS-simulator')`.
- **CHANGELOG**: one Bug-fixes bullet covering the simulator fix + `_multiprocessing`.

Based on `flet-0.86` (targets `flet-0.86`).

## ⚠️ Merge sequencing

The template pins `serious_python: 4.2.1` **exactly**, so `flet build` will not resolve until `serious_python` **4.2.1 is published to pub.dev**. That release is still in flight (flet-dev/serious-python#224). **Do not merge/release this ahead of the `serious_python` 4.2.1 publish.** python-build `20260701` is already published, so that half is live.

## Summary by Sourcery

Update bundled Python runtime references to the latest serious_python and python-build releases for iOS and document the related simulator loading and multiprocessing changes.

Bug Fixes:
- Ensure ctypes-based packages shipping plain .dylib libraries load correctly on the iOS simulator instead of failing with a platform mismatch.
- Include the _multiprocessing extension in the iOS Python runtime bundle (importable, not spawnable).

Enhancements:
- Re-pin the Python runtime to python-build release 20260701 to align with the latest serious_python configuration.
- Bump the build template dependency to serious_python 4.2.1 for improved iOS simulator compatibility.

Documentation:
- Add CHANGELOG entry describing the updated iOS runtime behavior, simulator load fix, and version bumps.