### PR TITLE
fix(ci): version flet-mcp like the other packages on publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -823,6 +823,7 @@ jobs:
         run: |
           source "$SCRIPTS/common.sh"
           patch_python_package_versions
+          patch_toml_versions "packages/flet-mcp/pyproject.toml" "$PYPI_VER"
           uv build --package flet-mcp
 
       - name: Upload artifacts


### PR DESCRIPTION
## Problem

The `v0.86.0.dev0` publish failed ([run](https://github.com/flet-dev/flet/actions/runs/28612140406/job/84849155397)) with:

```
error: Failed to publish dist/flet_mcp-0.1.0-py3-none-any.whl
  Caused by: 400 Bad Request. Server says: 400 File already exists ('flet_mcp-0.1.0-py3-none-any.whl' ...)
```

Every other package published at the release version `0.86.0.dev0`; only `flet_mcp` went up as `0.1.0` (its static `pyproject.toml` version), which was already on PyPI from an earlier run — so `uv publish` 400s and, under `bash -eo pipefail`, aborts the whole publish job.

## Root cause

Extension wheels get their version stamped at build time — `build_flet_extensions` runs `patch_toml_versions "packages/<pkg>/pyproject.toml" "$PYPI_VER"` before `uv build` for each package. `flet-mcp` has its **own** build job (`build_flet_mcp`, because it needs the `flet mcp build` data step), and that job only calls `patch_python_package_versions` — which stamps just the core `flet` / `flet-cli` / `flet-desktop` / `flet-web` packages. So `flet-mcp` was never stamped and built at `0.1.0`.

## Fix

Add the same per-package stamp to the `build_flet_mcp` job so `flet-mcp` ships at the unified release version like every other package:

```yaml
patch_toml_versions "packages/flet-mcp/pyproject.toml" "$PYPI_VER"
```

## Notes

- `flet-mcp 0.1.0` already exists on PyPI and can't be reused, but that's harmless — future releases now publish `flet-mcp` at the release version (`0.86.0.dev0`, `0.86.0`, …), which supersedes it.
- The other `0.86.0.dev0` wheels from the failed run were all uploaded successfully before the abort, so this only affects future publishes.

Based on / targets `flet-0.86`.

## Summary by Sourcery

Build:
- Update the CI build job for flet-mcp to patch its pyproject.toml version with the release PYPI_VER before building.