### PR TITLE
fix(build): preserve flutter-packages on incremental builds (--skip-site-packages)

### DIFF
--- a/sdk/python/packages/flet-cli/src/flet_cli/commands/build_base.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/commands/build_base.py
@@ -89,6 +89,7 @@ class BaseBuildCommand(BaseFlutterCommand):
         self.flutter_dir: Optional[Path] = None
         self.flutter_packages_dir = None
         self.flutter_packages_temp_dir = None
+        self.site_packages_skipped = False
         self.platforms = {
             "windows": {
                 "package_platform": "Windows",
@@ -1637,11 +1638,20 @@ class BaseBuildCommand(BaseFlutterCommand):
         # when the app has no Flutter extensions — so always clear the old copy
         # first, otherwise an extension removed since the previous build (e.g.
         # dropping flet-video) would linger here and stay in the built app.
-        if self.flutter_packages_dir.exists():
-            shutil.rmtree(self.flutter_packages_dir, ignore_errors=True)
-        if self.flutter_packages_temp_dir.exists():
-            # copy packages from temp to permanent location
-            shutil.move(self.flutter_packages_temp_dir, self.flutter_packages_dir)
+        #
+        # Skip this when the package step ran with --skip-site-packages: in that
+        # mode serious_python does not repopulate the temp dir, so an absent temp
+        # dir means "unchanged" rather than "no extensions". Wiping here would
+        # delete the previous build's extensions and never restore them, breaking
+        # the Flutter build (unresolved web plugins). A removed extension changes
+        # the package requirements, flips the package hash, and takes the full
+        # (non-skip) path above instead.
+        if not self.site_packages_skipped:
+            if self.flutter_packages_dir.exists():
+                shutil.rmtree(self.flutter_packages_dir, ignore_errors=True)
+            if self.flutter_packages_temp_dir.exists():
+                # copy packages from temp to permanent location
+                shutil.move(self.flutter_packages_temp_dir, self.flutter_packages_dir)
 
         if self.flutter_packages_dir.exists():
             self.update_status("[bold blue]Registering Flutter user extensions...")
@@ -2380,6 +2390,11 @@ class BaseBuildCommand(BaseFlutterCommand):
         if not dev_packages_configured:
             if not hash.has_changed():
                 package_args.append("--skip-site-packages")
+                # serious_python skips copying Flutter packages to the temp dir
+                # under --skip-site-packages, so register_flutter_extensions must
+                # keep (not wipe) the permanent flutter-packages copy from the
+                # previous build.
+                self.site_packages_skipped = True
             else:
                 if self.flutter_packages_dir.exists():
                     shutil.rmtree(self.flutter_packages_dir, ignore_errors=True)


### PR DESCRIPTION
## Problem

Running `flet build web` a second time (without deleting `build/`) fails at `dart2wasm`:

```
Error: Couldn't resolve the package 'audioplayers_web' ...
Error: Couldn't resolve the package 'camera_web' ...
Error: Couldn't resolve the package 'webview_flutter_web' ...
Target dart2wasm failed: ProcessException: Process exited abnormally with exit code 254
```

The first build succeeds; the second (incremental) build fails. This hits the normal incremental workflow for any app that uses Flutter extensions.

## Root cause

On an incremental build the package hash is unchanged, so `package_python_app()` passes `--skip-site-packages` to `serious_python`. That flag makes serious_python skip **both** the site-packages install **and** the "Copying Flutter packages to …/flutter-packages-temp" step — so `flutter-packages-temp` is never created that run.

`register_flutter_extensions()` then **unconditionally** `rmtree`s the permanent `build/flutter-packages` dir (populated by the first build) and only repopulates it *if the temp dir exists*. Since the temp dir is absent on a skip build, the flet extension packages (`flet_audio`, `flet_camera`, `flet_webview`, …) are wiped and never restored, so the Flutter build can't resolve the web plugins they provide.

The `rmtree` was written assuming "temp dir absent ⟹ app has no extensions." `--skip-site-packages` broke that assumption: an absent temp dir now also means "extensions unchanged."

## Regression

This is a regression from #6608. Before that PR the `rmtree` was nested inside `if flutter_packages_temp_dir.exists():`, so a skip build preserved the permanent copy. #6608 hoisted the `rmtree` out of the guard (to clear a *removed* extension lingering in the permanent dir) without accounting for the skip-site-packages path.

## Fix

Track when the package step ran with `--skip-site-packages` (`self.site_packages_skipped`) and skip the wipe/move in that case, keeping the previous build's extension copy intact.

This preserves #6608's removed-extension handling: dropping an extension changes the package requirements, which flips the package hash and takes the full (non-skip) path that still clears stale extensions.

## Testing

- Back-to-back `flet build web` (no `rm -rf build`) now completes on the second run instead of failing at `dart2wasm`.

## Summary by Sourcery

Prevent incremental Flutter web builds from deleting and failing to restore previously copied Flutter extension packages when site-packages are skipped.

Bug Fixes:
- Fix incremental Flutter web builds failing at dart2wasm due to missing flutter-packages when running with --skip-site-packages.

Enhancements:
- Track whether the packaging step skipped site-packages to preserve existing Flutter extension packages across incremental builds.