### PR TITLE
fix(build): keep web apps on path routing through boot (no /#/, deep links survive)

### DIFF
--- a/sdk/python/templates/build/{{cookiecutter.out_dir}}/lib/main.dart
+++ b/sdk/python/templates/build/{{cookiecutter.out_dir}}/lib/main.dart
@@ -43,6 +43,20 @@ String appDir = "";
 Map<String, String> environmentVariables = Map.from(Platform.environment);
 
 void main(List<String> args) async {
+  // On web the URL strategy must be selected before ANYTHING reads the initial
+  // location: FletDeepLinkingBootstrap.install() (below) calls
+  // WidgetsFlutterBinding.ensureInitialized() and starts observing route pushes,
+  // and the first runApp() wires up the router. Whatever strategy is active at
+  // that point latches how the cold-start URL maps to a route — under Flutter's
+  // default hash strategy a hard refresh of `/apps/x` reads an empty fragment
+  // (route "/"), so the deep link is lost and the app rewrites the URL to "/".
+  // Applying the strategy that `flet build` baked into window.flet here, as the
+  // very first statement, keeps both the running URLs (no `/#/`) and cold-start
+  // deep links on the path strategy.
+  if (kIsWeb && getFletRouteUrlStrategy() == "path") {
+    usePathUrlStrategy();
+  }
+
   FletDeepLinkingBootstrap.install();
 
   _args = List<String>.from(args);
@@ -301,12 +315,9 @@ Future prepareApp() async {
   );
 
   if (kIsWeb) {
-    // web mode - connect via HTTP
+    // web mode - connect via HTTP. The URL strategy is applied in main() before
+    // runApp(); doing it here would be too late (see the note there).
     pageUrl = Uri.base.toString();
-    var routeUrlStrategy = getFletRouteUrlStrategy();
-    if (routeUrlStrategy == "path") {
-      usePathUrlStrategy();
-    }
     assetsDir = getAssetsDir();
   } else if (_args.isNotEmpty && isDesktopPlatform()) {
     // developer mode

--- a/sdk/python/templates/build/{{cookiecutter.out_dir}}/lib/main.dart
+++ b/sdk/python/templates/build/{{cookiecutter.out_dir}}/lib/main.dart
@@ -282,9 +282,16 @@ class _BootOverlayState extends State<_BootOverlay> {
         // resolveBootScreen is built once here (status changes update the
         // message via the screen's own ValueListenableBuilder), so the spinner
         // keeps animating across preparing → starting up.
+        // Use `builder:` rather than `home:` so this MaterialApp creates NO
+        // Navigator. A MaterialApp with `home` builds a Navigator with
+        // `reportsRouteUpdateToEngine: true`, which pushes the home route "/"
+        // to the browser URL on mount — clobbering a cold-start deep link
+        // (e.g. `/gallery`) before FletApp's real router reads it. The boot
+        // overlay never navigates, so it doesn't need a Navigator; this keeps
+        // theme/Directionality while leaving the URL untouched.
         child: MaterialApp(
           debugShowCheckedModeBanner: false,
-          home: resolveBootScreen(
+          builder: (context, _) => resolveBootScreen(
             name: bootScreenName,
             options: bootScreenOptions,
             extensions: extensions,


### PR DESCRIPTION
## Summary

Fixes two web-routing regressions in the `flet build web` boot template introduced by the 0.86 boot-screen rework (#6616). Both worked in 0.85.3. Symptoms in a path-routed web app:

1. **Running URLs carried a `/#/` fragment** (e.g. `/#/apps/<id>`) instead of clean path URLs.
2. **A cold-start deep link reset to `/`** — opening/refreshing `/gallery` or `/apps/<id>` bounced to the app root.

## Root causes

**1. URL strategy applied too late.** `usePathUrlStrategy()` was called from `prepareApp()`, which runs *after* the boot UI mounts (`BootHost._boot` / the `FLET_TEST` `FutureBuilder`). By then Flutter's web routing had already initialized under the default **hash** strategy. → moved the strategy selection to the first statement in `main()`, before `FletDeepLinkingBootstrap.install()` (which calls `ensureInitialized()`) and any `runApp()`. Matches the before-boot ordering already used in `client/lib/main.dart`. `usePathUrlStrategy()` only sets `ui_web.urlStrategy`, so it's safe before `ensureInitialized()`.

**2. Boot-screen `MaterialApp` clobbered the deep link.** The boot overlay wrapped the boot screen in `MaterialApp(home: …)`. A `MaterialApp` with `home` builds its `Navigator` with `reportsRouteUpdateToEngine: true`, so on web it pushes the home route `/` to the browser URL the moment it mounts — during boot, before `FletApp`'s real router reads the location. → render the boot screen via `builder:` instead of `home:`. With no `home`/`routes`/`onGenerateRoute`, `WidgetsApp` creates no `Navigator` (per its own docs) and reports nothing to the engine, so the deep link survives. The overlay never navigates, so it needs no Navigator. In 0.85.3 the boot phase rendered a bare `SizedBox`, which reported nothing.

Both fixes are required: (1) restores path routing; (2) preserves cold-start deep links.

## Verification

Built a path-routed web app and drove it with headless Chromium against a static server:

| Cold load | Before | After |
|---|---|---|
| `/gallery` | reset to `/` ~1.7s after "Flutter app loaded" (before the Python worker ran) | holds `/gallery` |
| `/apps/testid123` | reset to `/` | holds |
| `/` | ok | ok |

Boot screen still renders and the app boots normally with `builder:`.

## Files

- `sdk/python/templates/build/{{cookiecutter.out_dir}}/lib/main.dart`

## Summary by Sourcery

Ensure web builds use path-based URL routing from application startup and prevent the boot screen from overwriting deep-link URLs.

Bug Fixes:
- Fix web builds incorrectly using hash-based URLs instead of clean path URLs when path routing is configured.
- Preserve cold-start deep links in path-routed web apps by preventing the boot overlay from resetting the browser URL to the root path.