### PR TITLE
Fix auto_scroll end-following past code blocks / nested scrollables

### DIFF
--- a/client/web/python-worker.js
+++ b/client/web/python-worker.js
@@ -170,8 +170,15 @@ self.initPyodide = async function () {
             import msgpack as _msgpack
 
         def _send_python_output(text, is_stderr):
+            # Frame exactly like PyodideConnection.send_message: a 0x00 type
+            # byte (0x00 = MsgPack Flet protocol frame, 0x01 = raw DataChannel
+            # frame) in front of the packed [action, body]. Without the prefix
+            # the Dart side reads msgpack's leading 0x92 as an unknown packet
+            # type and silently drops the line. bytes([0]) avoids a literal
+            # NUL escape inside this JS template string.
             flet_js.receive_callback(
-                _msgpack.packb(
+                bytes([0])
+                + _msgpack.packb(
                     [7, {"text": text, "is_stderr": bool(is_stderr)}]
                 )
             )

--- a/packages/flet/lib/src/controls/scrollable_control.dart
+++ b/packages/flet/lib/src/controls/scrollable_control.dart
@@ -43,6 +43,7 @@ class _ScrollableControlState extends State<ScrollableControl>
   static const double _autoScrollThreshold = 40.0;
   bool _pinnedToEnd = true;
   double _lastMaxScrollExtent = 0;
+  double _lastPixels = 0;
   bool _autoScrollScheduled = false;
   // When set (via the `auto_scroll_animation` property) auto-scroll animates
   // to the end with this duration/curve; otherwise it jumps instantly.
@@ -64,9 +65,17 @@ class _ScrollableControlState extends State<ScrollableControl>
   void _onScroll() {
     if (!_controller.hasClients) return;
     final pos = _controller.position;
-    // "At the end" if within a small threshold of the max extent — so a
-    // partially-visible last line still counts as pinned.
-    _pinnedToEnd = pos.pixels >= pos.maxScrollExtent - _autoScrollThreshold;
+    // Unpin only when the user scrolls *up* (pixels decrease). Content growing
+    // beneath a stationary position (e.g. a tall Markdown code block inserted
+    // at the end) leaves pixels unchanged, so it must NOT unpin — otherwise a
+    // big extent jump would strand the view above the new content. Re-pin once
+    // the position returns to within a small threshold of the end.
+    if (pos.pixels < _lastPixels - 0.5) {
+      _pinnedToEnd = false;
+    } else if (pos.pixels >= pos.maxScrollExtent - _autoScrollThreshold) {
+      _pinnedToEnd = true;
+    }
+    _lastPixels = pos.pixels;
   }
 
   void _scheduleScrollToEnd({bool force = false}) {
@@ -95,6 +104,11 @@ class _ScrollableControlState extends State<ScrollableControl>
   Widget _wrapAutoScroll(Widget child) {
     return NotificationListener<ScrollMetricsNotification>(
       onNotification: (notification) {
+        // Only react to this scrollable's own metrics. Nested scrollables
+        // (e.g. a Markdown code block's horizontal scroller) bubble their
+        // notifications through with depth > 0; responding to those would
+        // track the wrong extent and break end-following.
+        if (notification.depth != 0) return false;
         final max = notification.metrics.maxScrollExtent;
         if (max > _lastMaxScrollExtent + 0.5 && _pinnedToEnd) {
           _scheduleScrollToEnd();

--- a/sdk/python/templates/build/{{cookiecutter.out_dir}}/web/python-worker.js
+++ b/sdk/python/templates/build/{{cookiecutter.out_dir}}/web/python-worker.js
@@ -170,8 +170,15 @@ self.initPyodide = async function () {
             import msgpack as _msgpack
 
         def _send_python_output(text, is_stderr):
+            # Frame exactly like PyodideConnection.send_message: a 0x00 type
+            # byte (0x00 = MsgPack Flet protocol frame, 0x01 = raw DataChannel
+            # frame) in front of the packed [action, body]. Without the prefix
+            # the Dart side reads msgpack's leading 0x92 as an unknown packet
+            # type and silently drops the line. bytes([0]) avoids a literal
+            # NUL escape inside this JS template string.
             flet_js.receive_callback(
-                _msgpack.packb(
+                bytes([0])
+                + _msgpack.packb(
                     [7, {"text": text, "is_stderr": bool(is_stderr)}]
                 )
             )


### PR DESCRIPTION
Follow-up to the `auto_scroll` end-following behavior: it stopped following once a tall child was inserted — most visibly a Markdown **code block** (streamed text scrolled fine, code blocks did not).

Two root causes in `ScrollableControl`:

1. **Nested scrollables.** A Markdown code block renders inside its own horizontally-scrollable widget. The `ScrollMetricsNotification` listener reacted to *those* nested notifications too, tracking the wrong (horizontal) extent. Now it ignores nested scrollables (`notification.depth != 0`), per the standard Flutter guidance.

2. **Extent-jump unpin.** `_onScroll` recomputed the pinned state purely from proximity (`pixels >= maxScrollExtent - threshold`). Inserting a tall child jumps `maxScrollExtent` past that threshold in a single frame while `pixels` stays put, so it flipped to *unpinned* and stopped following. Streamed text grows in sub-threshold steps so it never tripped. Now it only unpins when the user scrolls **up** (`pixels` decrease) and re-pins when the position returns to the end; content growing beneath a stationary position keeps it pinned.

`flutter analyze` on the changed control: no issues.

Companion to #6637 (the original follow-content-growth change).

## Summary by Sourcery

Ensure scrollable auto-follow behavior remains pinned to the end when content grows, while ignoring nested scrollable metrics.

Bug Fixes:
- Prevent auto-scroll from stopping when tall content such as Markdown code blocks is appended at the end of a scrollable.
- Avoid incorrect end-following behavior caused by reacting to nested scrollables’ ScrollMetrics notifications instead of the main scrollable.
- Fix unintended unpinning after large maxScrollExtent jumps by only changing pin state in response to user upward scrolling.