### PR TITLE
Rewrite pubspec with a comment-preserving YAML library in patch_pubspec_version.py

### DIFF
--- a/.github/scripts/patch_pubspec_version.py
+++ b/.github/scripts/patch_pubspec_version.py
@@ -1,5 +1,5 @@
 # /// script
-# dependencies = ["pyyaml"]
+# dependencies = ["ruamel.yaml"]
 # ///
 
 """
@@ -32,7 +32,14 @@ import argparse
 import sys
 from pathlib import Path
 
-import yaml
+from ruamel.yaml import YAML
+
+# Round-trip mode: build templates carry cookiecutter/jinja directives inside
+# YAML comments (e.g. `#{% if ... %}` gating the web-only app.zip assets), so
+# patching must preserve comments or the rendered template breaks.
+yaml = YAML()
+yaml.preserve_quotes = True
+yaml.width = 4096
 
 
 def main() -> None:
@@ -75,7 +82,7 @@ def main() -> None:
         sys.exit(1)
 
     with pubspec_path.open(encoding="utf-8") as f:
-        data = yaml.safe_load(f)
+        data = yaml.load(f)
 
     if args.git_ref:
         # Pin flet to a git commit
@@ -109,7 +116,7 @@ def main() -> None:
                 data["dependency_overrides"][dep] = pin
 
     with pubspec_path.open("w", encoding="utf-8") as f:
-        yaml.dump(data, f, sort_keys=False)
+        yaml.dump(data, f)
 
     print(f"Successfully patched {pubspec_path}")
 


### PR DESCRIPTION
## Description

Fixes #6655.

The CI step that publishes `flet-build-template.zip` rewrites the pubspec's `flet` dependency via `.github/scripts/patch_pubspec_version.py`, which round-trips the file through `yaml.safe_load` + `yaml.dump` and discards all comments, including the cookiecutter conditional markers that gate the `app/app.zip` assets to web builds. The published zip therefore declares the assets unconditionally, and desktop builds require a file the packaging step never produces.

This PR rewrites the pubspec in `patch_pubspec_version.py` with a comment-preserving YAML library (ruamel.yaml round-trip mode). Tested against the `v0.86.0.dev1` template in both patch modes; the conditionals survive and the dependency rewrite is unchanged.

## Test code

Repro repo demonstrating the failure on a stock GitHub macOS runner: https://github.com/jtullos-bt/flet-build-appzip-repro (failing run: https://github.com/jtullos-bt/flet-build-appzip-repro/actions/runs/28890234132)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Additional details

The same patch step runs on stable release tags (with an exact version pin instead of a git ref), so an eventual 0.86.0 stable template zip is expected to carry the same defect unless the script is fixed first.

## Summary by Sourcery

Preserve YAML comments when patching the pubspec dependency in the build template patching script so template conditionals continue to work.

Bug Fixes:
- Fix loss of YAML comments and template conditionals when rewriting pubspec during the build template publish step.

Enhancements:
- Switch the pubspec patching script to use ruamel.yaml round-trip mode to retain comments and original formatting while updating the flet dependency.

Build:
- Update the script dependency metadata to require ruamel.yaml instead of PyYAML for the pubspec patching step.