### PR TITLE
Preserve ResponsiveRow child state across Row/Wrap layout switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 * Fix `ProgressRing.year_2023` being ignored, so the control correctly switches between the latest and 2023 Material Design appearances ([#6614](https://github.com/flet-dev/flet/issues/6614)) by @ndonkoHenri.
 * `flet build ipa` / `ios` apps that ship ctypes packages with plain `.dylib` shared libraries (e.g. `llama-cpp-python`) now load them on the **iOS simulator** instead of failing at launch with a `dlopen` platform mismatch (`have 'iOS', need 'iOS-simulator'`); the iOS runtime also now bundles the `_multiprocessing` extension (importable, not spawnable). Bumps the pinned bundle to `serious_python` 4.2.1 / python-build `20260701` ([serious_python#223](https://github.com/flet-dev/serious-python/pull/223)) by @ndonkoHenri, @FeodorFitsner.
 * Improve performance of checking added/removed controls in Session.patch_control from O(N²) to O(N) ([#6651](https://github.com/flet-dev/flet/pull/6651)) by @davidlawson.
+* Fix stateful controls inside `ResponsiveRow` (video players, WebViews, scroll positions) losing their state whenever a window resize crossed a breakpoint and the layout switched between a single row and wrapping ([#6661](https://github.com/flet-dev/flet/issues/6661), [#6663](https://github.com/flet-dev/flet/pull/6663)) by @FeodorFitsner.
 
 ### Documentation
 

--- a/packages/flet/lib/src/controls/responsive_row.dart
+++ b/packages/flet/lib/src/controls/responsive_row.dart
@@ -79,10 +79,16 @@ class ResponsiveRowControl extends StatelessWidget with FletStoreMixin {
             childWidth = 0;
           }
 
+          // Key the child with a GlobalKey tied to its Control identity so
+          // that when this build switches between Row and Wrap (a different
+          // widget type at the same slot), Flutter re-parents the existing
+          // Element instead of re-inflating the subtree — otherwise stateful
+          // descendants (video players, WebViews, scroll positions) would
+          // lose their State on every breakpoint change.
           controls.add(ConstrainedBox(
             constraints:
                 BoxConstraints(minWidth: childWidth, maxWidth: childWidth),
-            child: ControlWidget(key: key, control: ctrl),
+            child: ControlWidget(key: GlobalObjectKey(ctrl), control: ctrl),
           ));
         }
 


### PR DESCRIPTION
## Description

`ResponsiveRowControl.build()` returns a `Row` when the resolved `col` values fit within `columns` and a `Wrap` when they don't. When a window resize crosses a breakpoint, the widget type at that slot changes, so Flutter's reconciliation unmounts the whole child subtree and inflates a new one — destroying any Flutter `State` below (video players, WebViews, scroll positions, focus).

This PR keys each child's `ControlWidget` with a `GlobalObjectKey` tied to its `Control` model identity. Since Dart-side `Control` instances are patched in place, the key is stable across rebuilds with no cache, and Flutter re-parents the existing elements into the new `Row`/`Wrap` within the same frame — child state now survives breakpoint changes.

This also fixes a latent bug on the same line: the `ResponsiveRowControl`'s own widget `key` was passed to every child's `ControlWidget`, which would produce duplicate-key errors if ever non-null.

## Verification

Scripted repro with a scrollable `Column` inside `ResponsiveRow` (scroll offset lives in Flutter `State`, same class of state as a video player's): scroll to 300, resize the window 900→500 px across the MD breakpoint, probe with `scroll_to(delta=5)`.

Before (0.86 client): offset resets to 0 on every Row↔Wrap flip (probe lands at 5).
After: offset is preserved (probe lands at 305, and 310 after flipping back).

## Related issues

Fixes #6661

## Summary by Sourcery

Preserve ResponsiveRow children’s widget state when switching between Row and Wrap layouts by stabilizing their identity-based keys.

Bug Fixes:
- Prevent loss of state in ResponsiveRow children (e.g., scroll positions, media players) when layout flips between Row and Wrap at breakpoints.
- Fix a latent duplicate-key issue by no longer reusing the ResponsiveRowControl widget key for each child ControlWidget.

Enhancements:
- Key each ResponsiveRow child ControlWidget with a GlobalObjectKey derived from its Control model to maintain element identity across layout changes.