### PR TITLE
Fix integration test failures caused by render overflow errors

### DIFF
--- a/.github/workflows/macos-integration-tests.yml
+++ b/.github/workflows/macos-integration-tests.yml
@@ -42,19 +42,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # TEMPORARY: only the tests affected by the overflow fixes; restore
+        # the full suite list below before merging.
+        # - apps
+        # - examples/apps
+        # - examples/controls/core
+        # - examples/controls/cupertino
+        # - examples/controls/material
+        # - examples/extensions
+        # - controls/core
+        # - controls/cupertino
+        # - controls/material
+        # - controls/services
+        # - controls/theme
+        # - extensions
         suite:
-        - apps
-        - examples/apps
-        - examples/controls/core
-        - examples/controls/cupertino
-        - examples/controls/material
-        - examples/extensions
-        - controls/core
-        - controls/cupertino
-        - controls/material
-        - controls/services
-        - controls/theme
-        - extensions
+        - controls/material/test_grid_view.py
+        - controls/material/test_markdown.py
+        - extensions/spinkit
+        - examples/controls/material/test_datatable.py
+        - examples/controls/core/test_row.py
 
     name: ${{ matrix.suite }} Integration Tests
     steps:

--- a/.github/workflows/macos-integration-tests.yml
+++ b/.github/workflows/macos-integration-tests.yml
@@ -42,26 +42,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TEMPORARY: only the tests affected by the overflow fixes; restore
-        # the full suite list below before merging.
-        # - apps
-        # - examples/apps
-        # - examples/controls/core
-        # - examples/controls/cupertino
-        # - examples/controls/material
-        # - examples/extensions
-        # - controls/core
-        # - controls/cupertino
-        # - controls/material
-        # - controls/services
-        # - controls/theme
-        # - extensions
         suite:
-        - controls/material/test_grid_view.py
-        - controls/material/test_markdown.py
-        - extensions/spinkit
-        - examples/controls/material/test_datatable.py
-        - examples/controls/core/test_row.py
+        - apps
+        - examples/apps
+        - examples/controls/core
+        - examples/controls/cupertino
+        - examples/controls/material
+        - examples/extensions
+        - controls/core
+        - controls/cupertino
+        - controls/material
+        - controls/services
+        - controls/theme
+        - extensions
 
     name: ${{ matrix.suite }} Integration Tests
     steps:

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -430,6 +430,13 @@ packages:
       relative: true
     source: path
     version: "0.1.0"
+  flet_integration_test:
+    dependency: "direct dev"
+    description:
+      path: "../packages/flet_integration_test"
+      relative: true
+    source: path
+    version: "0.86.0"
   flet_lottie:
     dependency: "direct main"
     description:
@@ -1363,13 +1370,13 @@ packages:
     source: hosted
     version: "2.0.4"
   screen_brightness:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: screen_brightness
-      sha256: e0edf92c08889e8f493cde291e7c687db2b4a1471f2371c074070b75d7c7d79b
+      sha256: "5f70754028f169f059fdc61112a19dcbee152f8b293c42c848317854d650cba3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.11"
+    version: "2.1.7"
   screen_brightness_android:
     dependency: transitive
     description:
@@ -1387,13 +1394,13 @@ packages:
     source: hosted
     version: "2.1.4"
   screen_brightness_macos:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: screen_brightness_macos
-      sha256: b0957237b842d846a84363b69f229b339a8f91faced55041e245b2ebff7b0142
+      sha256: "278712cf5288db57bd335968cbfb2ec5441028f1ee2fcbdc8d1582d8210a3442"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.2"
   screen_brightness_ohos:
     dependency: transitive
     description:

--- a/packages/flet_integration_test/lib/src/host_test.dart
+++ b/packages/flet_integration_test/lib/src/host_test.dart
@@ -25,6 +25,26 @@ void runFletHostTest({
 }) {
   var binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
+  // With the integration_test binding `flutter test` prints only
+  // "Test failed. See exception logs above." without ever printing the
+  // exception that failed the test (e.g. a render overflow reported during a
+  // frame). Log it here so the failure reason is visible in the test process
+  // output.
+  final prevReportTestException = reportTestException;
+  reportTestException = (details, testDescription) {
+    debugPrint("Test exception ($testDescription): "
+        "${details.exceptionAsString()}\n${details.stack ?? ''}");
+    prevReportTestException(details, testDescription);
+  };
+  debugPrint("Flet host test: exception reporter installed");
+
+  tearDownAll(() async {
+    // Exceptions are reported when the test body completes, moments before
+    // the app process exits; give the device-log relay time to flush them so
+    // they are not lost from the `flutter test` output.
+    await Future.delayed(const Duration(seconds: 2));
+  });
+
   group('end-to-end test', () {
     testWidgets('test app', (tester) async {
       var dir = Directory.current.path;

--- a/sdk/python/examples/controls/material/data_table/sortable_and_selectable/main.py
+++ b/sdk/python/examples/controls/material/data_table/sortable_and_selectable/main.py
@@ -2,6 +2,7 @@ import flet as ft
 
 
 def main(page: ft.Page):
+    page.scroll = ft.ScrollMode.AUTO
     inventory_items = [
         {"id": 1, "name": "Alpha", "qty": 4},
         {"id": 2, "name": "Bravo", "qty": 9},

--- a/sdk/python/packages/flet/integration_tests/extensions/spinkit/test_spinkit.py
+++ b/sdk/python/packages/flet/integration_tests/extensions/spinkit/test_spinkit.py
@@ -138,10 +138,19 @@ async def test_all_controls_render(flet_app: ftt.FletTestApp):
     ]
     flet_app.page.clean()
     flet_app.page.add(
-        ft.Row(
-            wrap=True,
-            key="row",
-            controls=[cls(color=ft.Colors.BLUE, size=40) for cls in controls],
+        # The wrapped row of all spinners is much taller than the test window;
+        # host it in a scrollable column so the page doesn't overflow (an
+        # overflow error fails the Flutter test process).
+        ft.Column(
+            scroll=ft.ScrollMode.AUTO,
+            expand=True,
+            controls=[
+                ft.Row(
+                    wrap=True,
+                    key="row",
+                    controls=[cls(color=ft.Colors.BLUE, size=40) for cls in controls],
+                )
+            ],
         )
     )
     await flet_app.tester.pump(duration=ft.Duration(milliseconds=500))

--- a/sdk/python/packages/flet/src/flet/testing/flet_test_app.py
+++ b/sdk/python/packages/flet/src/flet/testing/flet_test_app.py
@@ -175,6 +175,8 @@ class FletTestApp:
         self.__assets_dir = assets_dir or "assets"
         self.__tcp_port = tcp_port
         self.__flutter_process: Optional[asyncio.subprocess.Process] = None
+        self.__flutter_output = bytearray()
+        self.__flutter_output_task: Optional[asyncio.Task] = None
         self.__page = None
         self.__tester: Union[Tester, RemoteTester, None] = None
 
@@ -256,15 +258,14 @@ class FletTestApp:
             print("Started Flet app")
 
         # Stream the Flutter test process output to the console when verbose
-        # (set by `flet test -v`) or when debug logging is on; otherwise hide it.
-        stdout = asyncio.subprocess.DEVNULL
-        stderr = asyncio.subprocess.DEVNULL
-        if (
+        # (set by `flet test -v`) or when debug logging is on; otherwise
+        # capture it into a buffer so it can be dumped if the process fails.
+        verbose = (
             get_bool_env_var("FLET_TEST_VERBOSE")
             or logging.getLogger().getEffectiveLevel() == logging.DEBUG
-        ):
-            stdout = None
-            stderr = None
+        )
+        stdout = None if verbose else asyncio.subprocess.PIPE
+        stderr = None if verbose else asyncio.subprocess.STDOUT
 
         # The resolved Flutter executable (full path, `flutter.bat` on Windows)
         # is passed by `flet test`; fall back to a bare "flutter" on PATH.
@@ -320,6 +321,11 @@ class FletTestApp:
             stderr=stderr,
         )
 
+        if self.__flutter_process.stdout is not None:
+            self.__flutter_output_task = asyncio.create_task(
+                self.__read_flutter_output(self.__flutter_process.stdout)
+            )
+
         print("Started Flutter test process.")
         print("Waiting for the Flutter app to connect...")
 
@@ -331,10 +337,53 @@ class FletTestApp:
         while not connected():
             await asyncio.sleep(0.2)
             if self.__flutter_process.returncode is not None:
+                self.__dump_flutter_output()
                 raise RuntimeError(
                     "Flutter process exited early with code "
                     f"{self.__flutter_process.returncode}"
                 )
+
+    async def __read_flutter_output(self, stream: asyncio.StreamReader):
+        # Read in chunks, not lines: the Flet client's debug output includes
+        # very long lines (e.g. screenshot bytes) that overflow StreamReader's
+        # per-line limit. Overlong lines are cut and only the output tail is
+        # kept to bound memory.
+        line = bytearray()
+        truncated = False
+        while True:
+            chunk = await stream.read(65536)
+            if not chunk:
+                break
+            for part in chunk.splitlines(keepends=True):
+                line.extend(part)
+                if line.endswith((b"\n", b"\r")):
+                    self.__append_flutter_output_line(line, truncated)
+                    line.clear()
+                    truncated = False
+                elif len(line) > self.__flutter_output_line_limit:
+                    del line[self.__flutter_output_line_limit :]
+                    truncated = True
+        if line:
+            self.__append_flutter_output_line(line, truncated)
+
+    def __append_flutter_output_line(self, line: bytearray, truncated: bool):
+        if len(line) > self.__flutter_output_line_limit:
+            line = line[: self.__flutter_output_line_limit]
+            truncated = True
+        self.__flutter_output.extend(line.rstrip(b"\r\n"))
+        if truncated:
+            self.__flutter_output.extend(b" ...<truncated>")
+        self.__flutter_output.extend(b"\n")
+        if len(self.__flutter_output) > self.__flutter_output_limit:
+            del self.__flutter_output[: -self.__flutter_output_limit]
+
+    def __dump_flutter_output(self):
+        if not self.__flutter_output:
+            return
+        output = self.__flutter_output.decode(errors="replace")
+        print("---------- Flutter test process output (tail) ----------")
+        print(output)
+        print("---------- End of Flutter test process output ----------")
 
     def __flutter_test_target(self) -> str:
         # In device mode the driver (`integration_test/app_test.dart`) is
@@ -383,6 +432,12 @@ class FletTestApp:
                     print("Force killing Flutter test process...")
                     self.__flutter_process.kill()
 
+        if self.__flutter_output_task:
+            try:
+                await asyncio.wait_for(self.__flutter_output_task, timeout=5)
+            except asyncio.TimeoutError:
+                self.__flutter_output_task.cancel()
+
         # Stop the RemoteTester socket server (device mode).
         if isinstance(self.__tester, RemoteTester):
             await self.__tester.stop()
@@ -392,6 +447,7 @@ class FletTestApp:
         # `testWidgets` body even though our find/tap assertions passed). Surface
         # that as a test failure — otherwise the run is falsely green.
         if flutter_returncode is not None and flutter_returncode != 0:
+            self.__dump_flutter_output()
             raise RuntimeError(
                 f"Flutter integration test process failed with exit code "
                 f"{flutter_returncode}. See the Flutter test output above."
@@ -420,8 +476,10 @@ class FletTestApp:
         """
         controls = list(self.page.controls)
         self.page.controls = [
-            scr := ft.Screenshot(
-                ft.Column(controls, margin=margin, intrinsic_width=True)
+            self.__scrollable_screenshot_host(
+                scr := ft.Screenshot(
+                    ft.Column(controls, margin=margin, intrinsic_width=True)
+                )
             )
         ]  # type: ignore
         self.page.update()
@@ -470,7 +528,11 @@ class FletTestApp:
 
         # add control and take screenshot
         screenshot = ft.Screenshot(control, expand=expand_screenshot)
-        self.page.add(screenshot)
+        self.page.add(
+            screenshot
+            if expand_screenshot
+            else self.__scrollable_screenshot_host(screenshot)
+        )
         await self.__pump_and_settle_with_timeout("assert_control_screenshot-add")
         for _ in range(0, pump_times):
             await self.tester.pump(duration=pump_duration)
@@ -478,6 +540,24 @@ class FletTestApp:
             name,
             await screenshot.capture(pixel_ratio=self.screenshots_pixel_ratio),
             similarity_threshold=similarity_threshold,
+        )
+
+    def __scrollable_screenshot_host(
+        self, screenshot: ft.Screenshot
+    ) -> Union[ft.Screenshot, ft.Column]:
+        # A scrollable page cannot overflow; an expanded host inside it would
+        # be flex-in-unbounded-height and fail layout instead.
+        if self.page.scroll is not None:
+            return screenshot
+        # Host the screenshot in a scrollable column: content taller than the
+        # window then scrolls instead of overflowing the page (an overflow
+        # error fails the Flutter test process). The child sees the same
+        # unbounded-height constraints as in the page column, so captures are
+        # unaffected.
+        return ft.Column(
+            expand=True,
+            scroll=ft.ScrollMode.HIDDEN,
+            controls=[screenshot],
         )
 
     async def __pump_and_settle_with_timeout(self, stage: str):
@@ -849,3 +929,5 @@ class FletTestApp:
             return min(similarities), None
 
     __pump_and_settle_timeout = 10.0
+    __flutter_output_limit = 262144
+    __flutter_output_line_limit = 2048


### PR DESCRIPTION
## Problem

Several macOS integration test suites were failing deterministically (`extensions`, `controls/material`, `examples/controls/material`, `examples/controls/core`) with:

```
RuntimeError: Flutter integration test process failed with exit code 1. See the Flutter test output above.
```

...while all host-side assertions and golden screenshots passed, and "the Flutter test output above" was empty.

**Root cause:** any `FlutterError` reported during a frame — typically a benign `RenderFlex overflowed` — fails the on-device `testWidgets` body, which the exit-code check from #6623 surfaces as a teardown error. Diagnosis was doubly hard because:

- CI discarded Flutter process output entirely (`DEVNULL` unless `FLET_TEST_VERBOSE=1`), and even locally `flutter test` never prints the failing exception — only "Test failed. See exception logs above."
- The module-scoped `flet_app` fixture blames the *last* test in the module; the real culprit can be any test in it (grid_view's culprit was `test_basic`, not `test_horizontal`; markdown's was `test_md_1`, not `test_md_3`).

The five deterministic failures were all layout overflows: grid_view `test_basic` (200px, page-wide 780×780 grid item), markdown `test_md_1` (48px), spinkit `test_all_controls_render` (867px, 30 spinners), row `test_vertical_alignment` (9px — caused by the screenshot wrapper's own margins), datatable `test_sortable_and_selectable` (2px — the example's table is 582px tall vs 580 available, overflowing on the very first frame at the default 800×600 window).

## Changes

**Test harness — diagnosability:**
- `FletTestApp` captures Flutter test process output (line-truncated, tail-bounded) and dumps it when the process exits non-zero, so CI failures show the actual reason.
- `host_test.dart` hooks `reportTestException` to print the exception and stack, and delays `tearDownAll` by 2s so end-of-run reports aren't lost in the process-exit race.

**Test harness — overflow prevention:**
- `assert_control_screenshot` / `wrap_page_controls_in_screenshot` host the `Screenshot` control in a hidden-scrollbar scrollable column, so content taller than the test window scrolls instead of overflowing. The child sees the same unbounded-height constraints as before, so captures — and all existing goldens — are unaffected. Skipped when the page is already scrollable (an expanded host inside a scrollable page would be flex-in-unbounded) and for `expand_screenshot=True`.

**Tests and examples:**
- `test_spinkit`: render the wrapped row of all spinners inside a scrollable column.
- `data_table/sortable_and_selectable` example: `page.scroll = AUTO` — the example genuinely overflowed by 2px on startup at the default window size (visible as debug stripes with `flet run`).
- Regenerated stale `client/pubspec.lock` (was missing `flet_integration_test`, wrong `screen_brightness`).

No golden images changed.

## Verification

All five previously failing modules pass locally on macOS against unchanged goldens, plus sanity checks for `test_slider::test_handling_events` (wrap + absolute-coordinate taps) and `test_tabs` (`expand_screenshot=True` path). Full CI matrix was green on this branch with the fixes; the temporarily trimmed matrix used during iteration has been restored.

## Notes

The intermittent "Flutter process exited early with code 1/79" startup flakes seen in some runs (range_slider, textfield) are a separate issue — the new output capture will reveal their cause the next time they occur.

## Summary by Sourcery

Improve integration test reliability by capturing Flutter test output and preventing layout overflows in screenshot hosts and examples.

New Features:
- Add buffered capture and tail-dump of Flutter integration test process output when the process exits with a non-zero code.

Bug Fixes:
- Prevent layout overflow errors from causing deterministic failures in integration tests by hosting screenshot content and spinner rows in scrollable containers.
- Fix the sortable-and-selectable data table example overflowing the default window size by enabling automatic page scrolling.

Enhancements:
- Install a custom exception reporter in the Flutter host test to log failing exceptions and stacks, and delay teardown to ensure logs are flushed.
- Make screenshot helpers wrap content in a hidden-scrollbar scrollable column when the page itself is not scrollable, keeping captures stable while avoiding overflows.

Build:
- Regenerate the client pubspec.lock to reflect current dependencies including flet_integration_test and correct screen_brightness versions.

Tests:
- Adjust the spinkit integration test to render all spinners inside a scrollable column instead of a tall wrapped row to avoid page overflow.