### PR TITLE
Add support for Android TV platform in permission handler

### DIFF
--- a/sdk/python/packages/flet-permission-handler/CHANGELOG.md
+++ b/sdk/python/packages/flet-permission-handler/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Bug fixes
 
-* Removed platform restriction - `PermissionHandler` can now be used on `PagePlatform.ANDROID_TV`. Not officially supported by the underlying flutter `permission_handler` package, but most functionality works reliably across a wide range of Android TV builds. ([#6667](https://github.com/flet-dev/flet/pull/6667)) by @bl1nch.
+* Removed platform restriction - `PermissionHandler` can now be used on `PagePlatform.ANDROID_TV`. Not officially supported by the underlying flutter `permission_handler` package, but most functionality works reliably across a wide range of Android TV builds. ([#6667](https://github.com/flet-dev/flet/pull/6667)).
 
 ## 0.80.0
 

--- a/sdk/python/packages/flet-permission-handler/CHANGELOG.md
+++ b/sdk/python/packages/flet-permission-handler/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 0.86.0
+
+### Bug fixes
+
+* Removed platform restriction - `PermissionHandler` can now be used on `PagePlatform.ANDROID_TV`. Not officially supported by the underlying flutter `permission_handler` package, but most functionality works reliably across a wide range of Android TV builds. ([#6667](https://github.com/flet-dev/flet/pull/6667)) by @bl1nch.
+
 ## 0.80.0
 
 ## Added

--- a/sdk/python/packages/flet-permission-handler/src/flet_permission_handler/permission_handler.py
+++ b/sdk/python/packages/flet-permission-handler/src/flet_permission_handler/permission_handler.py
@@ -27,6 +27,7 @@ class PermissionHandler(ft.Service):
             or self.page.platform
             in [
                 ft.PagePlatform.ANDROID,
+                ft.PagePlatform.ANDROID_TV,
                 ft.PagePlatform.IOS,
                 ft.PagePlatform.WINDOWS,
             ]


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change, relevant motivation, and context. -->

The underlying `flutter_permission_handler` package does not officially list Android TV as a supported platform. However, in practice it works reliably on many Android TV builds, since Android TV is fundamentally a variant of the Android platform and shares the same permission APIs.
Currently, Flet's `PermissionHandler` blocks this platform outright via a hardcoded check. This prevents developers from using the control on Android TV even when it works fine for their use case.

<!-- If this PR fixes an open issue, please link to the issue here. Ex: Fixes #4562 -->

## Test code

```python
# Minimal test/reproduction code for reviewers, if applicable.
```

## Type of change

<!-- select only options relevant to your PR -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I signed the CLA.
- [ ] I have performed a self-review of my own code.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] New and existing tests pass locally with my changes.
- [ ] I have made corresponding documentation changes, if applicable.
- [ ] I have added changelog entries for user-facing changes, if applicable.
- [ ] I have updated release guide pages and `website/sidebars.yml` for breaking changes, removals, and deprecations, if applicable.

## Screenshots

<!-- Add screenshots here if applicable. -->

## Additional details

<!-- Any additional details to be known about this PR. -->

## Summary by Sourcery

Bug Fixes:
- Remove the hardcoded platform restriction that prevented using the permission handler on Android TV.