### PR TITLE
Fix GestureDetector allowed_devices type cast error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * Fix the cryptic `shutil.ReadError: ... is not a zip file` failure in web apps when the app package download fails. The Pyodide worker piped the `pyfetch(app_package_url)` response straight into `unpack_archive()` without a status check, so any non-2xx response (transient server 500, expired auth 401, deleted app 404) wrote the JSON/HTML error body to a temp file and crashed while unpacking it. The worker now checks `response.ok` and raises a readable `Failed to download app package: HTTP <status> <url> — <body>` error, including the first 200 chars of the error body. Applied to both the Flet web client and the `flet build` template ([#6680](https://github.com/flet-dev/flet/pull/6680)) by @FeodorFitsner.
 * Remove unused `BasePage` return type and import from `BaseControl` and `ControlEvent` ([#6606](https://github.com/flet-dev/flet/pull/6606)) by @Iaw4tch.
+* Fix `GestureDetector.allowed_devices` crashing with `type 'List<dynamic>' is not a subtype of type 'List<String?>?'` and preventing the control from rendering. Property values are deserialized from JSON as `List<dynamic>`, but the value was read via `get<List<String?>>(...)`, whose reified cast fails because a `List<dynamic>` is not a `List<String?>`. It's now read as `List<dynamic>` and each entry is converted to a string before parsing, restoring `supportedDevices` filtering for Flutter's `GestureDetector` ([#6684](https://github.com/flet-dev/flet/pull/6684)) by @TURBODRIVER.
 
 ## 0.86.0
 

--- a/packages/flet/lib/src/controls/gesture_detector.dart
+++ b/packages/flet/lib/src/controls/gesture_detector.dart
@@ -295,10 +295,10 @@ class _GestureDetectorControlState extends State<GestureDetectorControl> {
             trackpadScrollCausesScale:
                 widget.control.getBool("trackpad_scroll_causes_scale", false)!,
             supportedDevices: () {
-              var supportedDevices =
-                  widget.control.get<List<String?>>("allowed_devices");
+              var supportedDevices = 
+                  widget.control.get<List<dynamic>>("allowed_devices");
               return supportedDevices
-                  ?.map((d) => parsePointerDeviceKind(d))
+                  ?.map((d) => parsePointerDeviceKind(d?.toString()))
                   .nonNulls
                   .toSet();
             }(),


### PR DESCRIPTION
## Description

Provided allowed_devices values were decoded as `List<dynamic>`, but allowed_devices was being read as `List<String?>`. That caused controls to not render and a runtime type error:
```text
type 'List<dynamic>' is not a subtype of type 'List<String?>?'
```

Changed it to read the value as `List<dynamic>` instead, then convert each entry to a string before passing it to parsePointerDeviceKind().

This fix restores the intended `supportedDevices` behavior for Flutter's `GestureDetector`, which is needed for filtering out specific gesture types.

In my case I needed to exclude trackpad devices as the panning gesture would cause gesture detector controls to get dragged/panned without first click and holding the primary mouse button. This collided when using the interactive viewer where panning is done with the same gesture, but gesture detector controls would prevent it.

## Test code

This is the scenario in which usage of allowed_devices was required. Dragging blocks is possible by holding the primary mouse button. Panning trackpad gestures will not cause blocks to be dragged when allowed_devices doesn't include `ft.PointerDeviceType.TRACKPAD`.

```python
import flet as ft

class DraggableBlock(ft.GestureDetector):
    def __init__(self, color: str, left: float, top: float):
        super().__init__(
            allowed_devices=[ft.PointerDeviceType.MOUSE],
            left=left, top=top
        )

        self.content = ft.Container(
            width=140, height=100,
            bgcolor=color, border_radius=12,
            alignment=ft.Alignment.CENTER,
            content=ft.Text(
                "Drag me", color=ft.Colors.WHITE,
            )
        )
        self.on_pan_update = self._on_pan_update

    def _on_pan_update(self, e: ft.DragUpdateEvent):
        self.left = max(0, self.left + e.local_delta.x)
        self.top = max(0, self.top + e.local_delta.y)
        self.update()

def main(page: ft.Page):
    scene = ft.Stack(
        width=1600, height=1000,
        controls=[
            ft.Container(
                width=1600, height=1000,
                bgcolor=ft.Colors.GREY_200,
            ),
            DraggableBlock(ft.Colors.RED_400, 80, 80),
            DraggableBlock(ft.Colors.GREEN_500, 320, 180),
            DraggableBlock(ft.Colors.BLUE_500, 620, 120),
        ]
    )

    viewer = ft.InteractiveViewer(
        min_scale=0.4,
        max_scale=2.5,
        boundary_margin=ft.Margin.all(200),
        content=scene
    )

    page.add(viewer)

ft.run(main)
```

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I signed the CLA.
- [X] I have performed a self-review of my own code.
- [X] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [X] My changes generate no new warnings.
- [X] New and existing tests pass locally with my changes.
- [ ] I have made corresponding documentation changes, if applicable.
- [ ] I have added changelog entries for user-facing changes, if applicable.
- [ ] I have updated release guide pages and `website/sidebars.yml` for breaking changes, removals, and deprecations, if applicable.

## Summary by Sourcery

Bug Fixes:
- Ensure supportedDevices reads allowed_devices as a dynamic list and converts entries to strings before parsing device kinds to prevent type cast errors.