### PR TITLE
Prepare 0.86.2 release: fix stale code under `flet debug android` (serious_python 4.3.4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref_name }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: zizmor-${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.86.2
+
+### Bug fixes
+
+* Fix code edits not taking effect under `flet debug android`: after re-running the command, the app kept executing the previously-unpacked, stale code instead of your changes. `flet debug` rebuilds and reinstalls the same-version APK on each iteration (`flutter run` does an update install that preserves app data), and `serious_python`'s on-device extraction cache — keyed only on `versionName+versionCode` — never saw the version change, so it skipped re-unpacking the new `app.zip`. Bumps `serious_python` to 4.3.4, which folds the APK's `lastUpdateTime` into that cache key so every (re)install re-extracts the current code while ordinary relaunches still hit the cache. `flet build apk` was never affected ([#6682](https://github.com/flet-dev/flet/issues/6682)) by @FeodorFitsner.
+
 ## 0.86.1
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug fixes
 
 * Fix code edits not taking effect under `flet debug android`: after re-running the command, the app kept executing the previously-unpacked, stale code instead of your changes. `flet debug` rebuilds and reinstalls the same-version APK on each iteration (`flutter run` does an update install that preserves app data), and `serious_python`'s on-device extraction cache — keyed only on `versionName+versionCode` — never saw the version change, so it skipped re-unpacking the new `app.zip`. Bumps `serious_python` to 4.3.4, which folds the APK's `lastUpdateTime` into that cache key so every (re)install re-extracts the current code while ordinary relaunches still hit the cache. `flet build apk` was never affected ([#6682](https://github.com/flet-dev/flet/issues/6682)) by @FeodorFitsner.
+* Fix `flet_video.Video` resetting its `volume` (and `pitch`, `playback_rate`, `shuffle_playlist`, `playlist_mode`, `subtitle_track`) to the player's defaults after toggling `visible` off then on — e.g. `volume` jumped back to `100`. Hiding a `Video` disposes its native `media_kit` player and showing it recreates a fresh one at default settings; the "last-applied" tracking now lives with the player (not the persistent control model) and is reset on recreation, so `build()` re-applies every setting to the new player ([#6683](https://github.com/flet-dev/flet/issues/6683), [#6694](https://github.com/flet-dev/flet/pull/6694)) by @ndonkoHenri.
 
 ## 0.86.1
 

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -213,10 +213,10 @@ packages:
     dependency: transitive
     description:
       name: connectivity_plus
-      sha256: "62ffa266d9a23b79fb3fcbc206afc00bb979417ba57b1324c546b5aab95ba057"
+      sha256: "25cebb79dfe304022550e0c3c893ae051ded07183d2607f7b88473cb3ade33cb"
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.1"
+    version: "7.3.0"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
@@ -285,10 +285,10 @@ packages:
     dependency: transitive
     description:
       name: device_info_plus
-      sha256: b4fed1b2835da9d670d7bed7db79ae2a94b0f5ad6312268158a9b5479abbacdd
+      sha256: "4df8babf73058181227e18b08e6ea3520cf5fc5d796888d33b7cb0f33f984b7c"
       url: "https://pub.dev"
     source: hosted
-    version: "12.4.0"
+    version: "12.3.0"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -359,7 +359,7 @@ packages:
       path: "../packages/flet"
       relative: true
     source: path
-    version: "0.86.0"
+    version: "0.86.2"
   flet_ads:
     dependency: "direct main"
     description:
@@ -1370,13 +1370,13 @@ packages:
     source: hosted
     version: "2.0.4"
   screen_brightness:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
       name: screen_brightness
-      sha256: "5f70754028f169f059fdc61112a19dcbee152f8b293c42c848317854d650cba3"
+      sha256: e0edf92c08889e8f493cde291e7c687db2b4a1471f2371c074070b75d7c7d79b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.7"
+    version: "2.1.11"
   screen_brightness_android:
     dependency: transitive
     description:
@@ -1394,13 +1394,13 @@ packages:
     source: hosted
     version: "2.1.4"
   screen_brightness_macos:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
       name: screen_brightness_macos
-      sha256: "278712cf5288db57bd335968cbfb2ec5441028f1ee2fcbdc8d1582d8210a3442"
+      sha256: b0957237b842d846a84363b69f229b339a8f91faced55041e245b2ebff7b0142
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   screen_brightness_ohos:
     dependency: transitive
     description:

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -99,13 +99,6 @@ dependency_overrides:
     path: ../packages/flet
   screen_retriever: 0.2.1 # this one migrated to SPM, but 0.2.0 is used by some other packages
 
-  screen_brightness: 2.1.7
-  # screen_brightness_macos 2.1.3 ("Fix: swift package manager warning") ships a
-  # Package.swift declaring macOS 10.11, below FlutterFramework's 10.15 floor,
-  # which breaks Swift Package Manager resolution. Pin the last good impl until
-  # upstream fixes it: https://github.com/aaassseee/screen_brightness/issues/99
-  screen_brightness_macos: 2.1.2
-
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/packages/flet/CHANGELOG.md
+++ b/packages/flet/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.86.2
+
+_No changes in the `flet` Dart package; version bumped for release coordination with the `serious_python` 4.3.4 bump that fixes stale code under `flet debug android` ([#6682](https://github.com/flet-dev/flet/issues/6682))._
+
 ## 0.86.1
 
 _No changes in the `flet` Dart package; version bumped for release coordination with the web client's readable app-package download errors ([#6680](https://github.com/flet-dev/flet/pull/6680))._

--- a/packages/flet/pubspec.yaml
+++ b/packages/flet/pubspec.yaml
@@ -2,7 +2,7 @@ name: flet
 description: Write entire Flutter app in Python or add server-driven UI experience into existing Flutter app.
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/flet/tree/main/packages/flet
-version: 0.86.1
+version: 0.86.2
 
 # Supported platforms
 platforms:

--- a/sdk/python/packages/flet-cli/src/flet_cli/utils/python_versions.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/utils/python_versions.py
@@ -28,7 +28,7 @@ from flet_cli.utils.template_cache import get_cache_root
 # python-build release this flet pins. Keep in sync with serious_python's
 # `pythonReleaseDate` (lib/src/python_versions.dart) — both should track the
 # same python-build release.
-PYTHON_BUILD_RELEASE_DATE = "20260714"
+PYTHON_BUILD_RELEASE_DATE = "20260719"
 
 RELEASE_DATE_ENV = "FLET_PYTHON_BUILD_RELEASE_DATE"
 MANIFEST_PATH_ENV = "FLET_PYTHON_BUILD_MANIFEST"

--- a/sdk/python/packages/flet-secure-storage/src/flutter/flet_secure_storage/.gitignore
+++ b/sdk/python/packages/flet-secure-storage/src/flutter/flet_secure_storage/.gitignore
@@ -1,0 +1,34 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+migrate_working_dir/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+# Libraries should not include pubspec.lock, per https://dart.dev/guides/libraries/private-files#pubspeclock.
+/pubspec.lock
+**/doc/api/
+.dart_tool/
+build/
+.flutter-plugins
+.flutter-plugins-dependencies
+
+# override parent rules
+!lib/

--- a/sdk/python/packages/flet-video/CHANGELOG.md
+++ b/sdk/python/packages/flet-video/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 0.86.2
+
+### Fixed
+
+- `Video.volume` (and `pitch`, `playback_rate`, `shuffle_playlist`, `playlist_mode`, `subtitle_track`) resetting to the player's defaults after toggling `visible` off then on. Showing a hidden `Video` recreates its native player at default settings; the "last-applied" tracking now lives with the player and resets on recreation, so these settings are re-applied ([#6683](https://github.com/flet-dev/flet/issues/6683), [#6694](https://github.com/flet-dev/flet/pull/6694)) by @ndonkoHenri.
+
 ## 0.85.0
 
 ### Added

--- a/sdk/python/packages/flet-video/src/flutter/flet_video/lib/src/video.dart
+++ b/sdk/python/packages/flet-video/src/flutter/flet_video/lib/src/video.dart
@@ -29,6 +29,24 @@ class _VideoControlState extends State<VideoControl> with FletStoreMixin {
   bool _initialized = false;
   Future<void>? _openFuture;
 
+  /// Last values applied to the current [_player]. They share the player's
+  /// lifetime (both are (re)created in [_setup]), so [build] diffs against them
+  /// to avoid re-applying unchanged properties.
+  ///
+  /// [_setup] resets them to `null` whenever it creates a new player so [build]
+  /// re-applies every property to it. This is required on the `didUpdateWidget`
+  /// control-swap path, where the same State instance is reused with a fresh
+  /// player; on the `visible` off/on path the whole State (and these fields) is
+  /// recreated anyway, so they already start as `null`.
+  ///
+  /// Keep this list in lockstep with the property diffs in [build].
+  double? _volume;
+  double? _pitch;
+  double? _playbackRate;
+  bool? _shufflePlaylist;
+  PlaylistMode? _playlistMode;
+  SubtitleTrack? _subtitleTrack;
+
   /// Snapshot of the last-known playlist, used to diff against incoming
   /// updates so single add/remove changes can be applied without a full reload.
   dynamic _playlist;
@@ -151,6 +169,15 @@ class _VideoControlState extends State<VideoControl> with FletStoreMixin {
     );
 
     _player = Player(configuration: playerConfig);
+
+    // The new player starts with default settings, so forget what was applied
+    // to the previous one and let build() re-apply everything.
+    _volume = null;
+    _pitch = null;
+    _playbackRate = null;
+    _shufflePlaylist = null;
+    _playlistMode = null;
+    _subtitleTrack = null;
 
     final videoControllerConfiguration = parseControllerConfiguration(
         control.get("configuration"), const VideoControllerConfiguration())!;
@@ -344,14 +371,15 @@ class _VideoControlState extends State<VideoControl> with FletStoreMixin {
         parsePlaylistMode(widget.control.getString("playlist_mode"));
     var fullscreen = widget.control.getBool("fullscreen", false)!;
 
-    // previous values
-    final prevVolume = widget.control.getDouble("_volume");
-    final prevPitch = widget.control.getDouble("_pitch");
-    final prevPlaybackRate = widget.control.getDouble("_playback_rate");
-    final prevShufflePlaylist = widget.control.getBool("_shuffle_playlist");
-    final PlaylistMode? prevPlaylistMode = widget.control.get("_playlist_mode");
-    final SubtitleTrack? prevSubtitleTrack =
-        widget.control.get("_subtitle_track");
+    // previous values (tracked per-player; see field docs)
+    final prevVolume = _volume;
+    final prevPitch = _pitch;
+    final prevPlaybackRate = _playbackRate;
+    final prevShufflePlaylist = _shufflePlaylist;
+    final PlaylistMode? prevPlaylistMode = _playlistMode;
+    final SubtitleTrack? prevSubtitleTrack = _subtitleTrack;
+    // Fullscreen is Video-widget UI state (not a player property), so it stays
+    // on the control model and is intentionally not reset with the player.
     final prevFullscreen = widget.control.getBool("_fullscreen", false)!;
 
     Video video = Video(
@@ -382,20 +410,19 @@ class _VideoControlState extends State<VideoControl> with FletStoreMixin {
           volume != prevVolume &&
           volume >= 0 &&
           volume <= 100) {
-        widget.control.updateProperties({"_volume": volume}, python: false);
+        _volume = volume;
         await _player.setVolume(volume);
       }
 
       // pitch
       if (pitch != null && pitch != prevPitch) {
-        widget.control.updateProperties({"_pitch": pitch}, python: false);
+        _pitch = pitch;
         await _player.setPitch(pitch);
       }
 
       // playbackRate
       if (playbackRate != null && playbackRate != prevPlaybackRate) {
-        widget.control
-            .updateProperties({"_playback_rate": playbackRate}, python: false);
+        _playbackRate = playbackRate;
         await _player.setRate(playbackRate);
       }
 
@@ -406,15 +433,13 @@ class _VideoControlState extends State<VideoControl> with FletStoreMixin {
 
       // shufflePlaylist
       if (shufflePlaylist != null && shufflePlaylist != prevShufflePlaylist) {
-        widget.control.updateProperties({"_shuffle_playlist": shufflePlaylist},
-            python: false);
+        _shufflePlaylist = shufflePlaylist;
         await _player.setShuffle(shufflePlaylist);
       }
 
       // playlistMode
       if (playlistMode != null && playlistMode != prevPlaylistMode) {
-        widget.control
-            .updateProperties({"_playlist_mode": playlistMode}, python: false);
+        _playlistMode = playlistMode;
         await _player.setPlaylistMode(playlistMode);
       }
 
@@ -422,8 +447,7 @@ class _VideoControlState extends State<VideoControl> with FletStoreMixin {
       if (subtitleTrack != null && subtitleTrack != prevSubtitleTrack) {
         await _openFuture;
         if (!_initialized) return;
-        widget.control.updateProperties({"_subtitle_track": subtitleTrack},
-            python: false);
+        _subtitleTrack = subtitleTrack;
         await _player.setSubtitleTrack(subtitleTrack);
       }
 

--- a/sdk/python/templates/build/{{cookiecutter.out_dir}}/pubspec.yaml
+++ b/sdk/python/templates/build/{{cookiecutter.out_dir}}/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   flet:
     path: ../../../../../packages/flet
 
-  serious_python: 4.3.3
+  serious_python: 4.3.4
 
   # MsgPack codec used by the dart_bridge FletBackendChannel implementation
   # in lib/main.dart — matches the wire format flet's existing socket


### PR DESCRIPTION
## Summary

Fixes #6682 — code edits not taking effect under `flet debug android`.

`flet debug android` re-packages the app, rebuilds the APK, and `flutter run -d <device>` reinstalls it, so the new code **is** in the freshly installed APK's assets. But on Android, `serious_python` copies the app payload out of the APK to a writable dir **only when its cache key changes**, and that key was `versionName+versionCode`. `flet debug` never bumps the version between iterations, and `flutter run` does an *update* install that preserves app data (including the cache marker), so the key never changed → re-extraction was skipped → the app kept running **stale** code.

`flet build apk` was never affected (fresh/version-bumped install), which matched the reporter's observation. iOS/desktop are also unaffected — they run the app straight from the read-only app bundle, which `flutter run` fully replaces each reinstall.

## Change

Bump the `flet build` template's `serious_python` pin **4.3.3 → 4.3.4**. serious_python 4.3.4 folds the APK's `PackageManager.lastUpdateTime` into the extraction cache key, so every (re)install re-extracts the current code while ordinary relaunches still hit the cache.

Files, mirroring the 0.86.1 release-prep convention:
- `sdk/python/templates/build/.../pubspec.yaml` — pin bump.
- `CHANGELOG.md` — `## 0.86.2` bug-fix entry.
- `packages/flet/CHANGELOG.md` + `packages/flet/pubspec.yaml` — Dart package version bumped for release coordination (no code change).

## ⚠️ Merge/release ordering

This depends on **serious_python 4.3.4**, which is prepared in [flet-dev/serious-python#235](https://github.com/flet-dev/serious-python/pull/235) but **not yet published to pub.dev**. Do not merge/release this until 4.3.4 is live on pub.dev, or `flet build` will fail to resolve the pin.

## Verification

Not exercised on a device here. End-to-end check once 4.3.4 is published: `flet debug android` → confirm app shows → edit `main.py` → `flet debug android` again → confirm the edit now appears (previously it wouldn't).

## Summary by Sourcery

Prepare the 0.86.2 release to fix stale code when using `flet debug android` by updating the serious_python dependency and coordinating package versions.

Bug Fixes:
- Ensure code changes take effect under `flet debug android` by relying on serious_python 4.3.4’s improved on-device extraction cache behavior.

Enhancements:
- Bump the serious_python dependency from 4.3.3 to 4.3.4 in the Python build template to align with the new caching strategy.

Documentation:
- Add a 0.86.2 entry to the main CHANGELOG documenting the Android debug stale-code fix.

Chores:
- Bump the `flet` Dart package version to 0.86.2 for release coordination, without changing its code.