### PR TITLE
Fix modal close crash: defer pop to post-frame, target own route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.86.3
+
+### Bug fixes
+
+* Fix modal controls (`AlertDialog`, `CupertinoAlertDialog`, `BottomSheet`, `CupertinoBottomSheet`) crashing to a black screen with "setState()/markNeedsBuild() called during build" when they close in the same frame that another route or overlay opens — e.g. dismissing a bottom sheet and showing a `SnackBar` from one handler. The close path popped the route synchronously during `build`, so the exit animation notified a listener that was mid-build. Each modal now tracks its own `ModalRoute` and closes it in a post-frame callback, popping *that* route (never the topmost one); `View`'s confirm-pop pops its own route too, so a modal dismissed in the same tick as a view pop can no longer dismiss the wrong one by @FeodorFitsner.
+
 ## 0.86.2
 
 ### Bug fixes

--- a/packages/flet/CHANGELOG.md
+++ b/packages/flet/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.86.3
+
+* Fix modal controls (`AlertDialog`, `CupertinoAlertDialog`, `BottomSheet`, `CupertinoBottomSheet`) throwing "setState()/markNeedsBuild() called during build" and blanking the screen when closed in the same frame another route/overlay opens (e.g. a `SnackBar`). Each modal now tracks its own `ModalRoute` and closes it via a post-frame `closeModalRoute()` that pops that specific route; `View`'s confirm-pop pops its own route too, removing the wrong-route race between a dismissing modal and a view pop.
+
 ## 0.86.2
 
 * Flutter updated to [3.44.7](https://github.com/flutter/flutter/blob/stable/CHANGELOG.md#3447).

--- a/packages/flet/lib/src/controls/alert_dialog.dart
+++ b/packages/flet/lib/src/controls/alert_dialog.dart
@@ -134,23 +134,20 @@ class _AlertDialogControlState extends State<AlertDialogControl> {
         });
       });
     } else if (!open && lastOpen) {
-      // Synchronous pop during build — Flutter schedules it for the end of
-      // the frame internally. Using `removeRoute` in a postFrame callback
-      // (the earlier sibling-host fix) raced with `View`'s on_confirm_pop
-      // path, which ALSO schedules a post-frame `Navigator.pop(context,
-      // true)`. Both callbacks fired in the same tick, and the view-pop
-      // callback ended up popping our just-finished-dismissing dialog
-      // instead of the target view — breaking the
-      // `test_pop_view_confirm` integration test.
+      // Mark closed now so this branch doesn't re-fire, then close this
+      // dialog's own route after the frame. Popping during build throws
+      // "setState() called during build" when the same frame opens another
+      // route/overlay (e.g. a SnackBar). Targeting `_dialogRoute` (not the
+      // topmost route) keeps this from racing `View`'s confirm-pop, which now
+      // also pops its own route — see `test_pop_view_confirm`. `_dialogRoute`
+      // is left set so the open path's `.then` still fires `dismiss` after the
+      // close animation completes.
       control.updateProperties({"_open": false}, python: false);
       final route = _dialogRoute;
-      if (route != null && route.isActive) {
-        debugPrint(
-            "AlertDialog(${control.id}): Closing dialog managed by this widget.");
-        Navigator.of(context).pop();
-      } else {
-        debugPrint(
-            "AlertDialog(${control.id}): Dialog was not opened by this widget, skipping pop.");
+      if (route != null) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          closeModalRoute(route);
+        });
       }
     }
     return const SizedBox.shrink();

--- a/packages/flet/lib/src/controls/bottom_sheet.dart
+++ b/packages/flet/lib/src/controls/bottom_sheet.dart
@@ -10,14 +10,24 @@ import '../utils/misc.dart';
 import '../utils/numbers.dart';
 import '../widgets/error.dart';
 
-class BottomSheetControl extends StatelessWidget {
+class BottomSheetControl extends StatefulWidget {
   final Control control;
 
   BottomSheetControl({Key? key, required this.control})
       : super(key: key ?? ValueKey("control_${control.id}"));
 
   @override
+  State<BottomSheetControl> createState() => _BottomSheetControlState();
+}
+
+class _BottomSheetControlState extends State<BottomSheetControl> {
+  // The modal route this control pushed, tracked so the close path can pop
+  // exactly this route (never whatever happens to be topmost) after the frame.
+  ModalRoute? _sheetRoute;
+
+  @override
   Widget build(BuildContext context) {
+    final control = widget.control;
     debugPrint("BottomSheet build: ${control.id}");
 
     bool lastOpen = control.getBool("_open", false)!;
@@ -33,11 +43,11 @@ class BottomSheetControl extends StatelessWidget {
       control.updateProperties({"_open": open}, python: false);
 
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        ModalRoute? sheetRoute;
+        if (!context.mounted) return;
         showModalBottomSheet<void>(
                 context: context,
                 builder: (context) {
-                  sheetRoute ??= ModalRoute.of(context);
+                  _sheetRoute = ModalRoute.of(context);
                   var content = control.buildWidget("content");
 
                   if (content == null) {
@@ -75,7 +85,8 @@ class BottomSheetControl extends StatelessWidget {
                 shape: control.getOutlinedBorder("shape", Theme.of(context)),
                 useSafeArea: control.getBool("use_safe_area", true)!)
             .then((value) {
-          (sheetRoute?.completed ?? Future.value()).then((_) {
+          (_sheetRoute?.completed ?? Future.value()).then((_) {
+            _sheetRoute = null;
             control.updateProperties({"_open": false}, python: false);
             control.updateProperties({"open": false});
             control.triggerEvent("dismiss");
@@ -83,7 +94,18 @@ class BottomSheetControl extends StatelessWidget {
         });
       });
     } else if (open != lastOpen && lastOpen) {
-      Navigator.of(context).pop();
+      // Mark closed now so this branch doesn't re-fire, then close after the
+      // frame. Popping during build throws "setState()/markNeedsBuild() called
+      // during build" when the same frame also opens another route/overlay
+      // (e.g. a SnackBar shown right after dismissing this sheet).
+      control.updateProperties({"_open": open}, python: false);
+      final route = _sheetRoute;
+      _sheetRoute = null;
+      if (route != null) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          closeModalRoute(route);
+        });
+      }
     }
 
     return const SizedBox.shrink();

--- a/packages/flet/lib/src/controls/cupertino_alert_dialog.dart
+++ b/packages/flet/lib/src/controls/cupertino_alert_dialog.dart
@@ -5,17 +5,30 @@ import '../extensions/control.dart';
 import '../models/control.dart';
 import '../utils/animations.dart';
 import '../utils/colors.dart';
+import '../utils/misc.dart';
 import '../utils/numbers.dart';
 import '../widgets/control_inherited_notifier.dart';
 import '../widgets/error.dart';
 import 'base_controls.dart';
 
-class CupertinoAlertDialogControl extends StatelessWidget {
+class CupertinoAlertDialogControl extends StatefulWidget {
   final Control control;
 
   const CupertinoAlertDialogControl({super.key, required this.control});
 
+  @override
+  State<CupertinoAlertDialogControl> createState() =>
+      _CupertinoAlertDialogControlState();
+}
+
+class _CupertinoAlertDialogControlState
+    extends State<CupertinoAlertDialogControl> {
+  // The dialog's own route, tracked so the close path can pop exactly this
+  // route (never whatever is topmost) after the frame.
+  ModalRoute? _dialogRoute;
+
   Widget _createCupertinoAlertDialog() {
+    final control = widget.control;
     return ControlInheritedNotifier(
       notifier: control,
       child: Builder(builder: (context) {
@@ -58,6 +71,7 @@ class CupertinoAlertDialogControl extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final control = widget.control;
     debugPrint("CupertinoAlertDialog build: ${control.id}");
 
     final lastOpen = control.getBool("_open", false)!;
@@ -75,7 +89,7 @@ class CupertinoAlertDialogControl extends StatelessWidget {
       control.updateProperties({"_open": open}, python: false);
 
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        ModalRoute? dialogRoute;
+        if (!context.mounted) return;
         showDialog(
             barrierDismissible: !modal,
             // Render the barrier in the dialog widget so it updates live.
@@ -84,11 +98,12 @@ class CupertinoAlertDialogControl extends StatelessWidget {
             useRootNavigator: false,
             context: context,
             builder: (context) {
-              dialogRoute ??= ModalRoute.of(context);
+              _dialogRoute = ModalRoute.of(context);
               return _createCupertinoAlertDialog();
             }).then((value) {
-          (dialogRoute?.completed ?? Future.value()).then((_) {
+          (_dialogRoute?.completed ?? Future.value()).then((_) {
             debugPrint("Dismissing CupertinoAlertDialog(${control.id})");
+            _dialogRoute = null;
             control.updateProperties({"_open": false}, python: false);
             control.updateProperties({"open": false});
             control.triggerEvent("dismiss");
@@ -96,14 +111,17 @@ class CupertinoAlertDialogControl extends StatelessWidget {
         });
       });
     } else if (!open && lastOpen) {
-      if (Navigator.of(context).canPop() == true) {
-        debugPrint(
-            "CupertinoAlertDialog(${control.id}): Closing dialog managed by this widget.");
-        Navigator.of(context).pop();
-        control.updateProperties({"_open": false}, python: false);
-      } else {
-        debugPrint(
-            "CupertinoAlertDialog(${control.id}): Dialog was not opened by this widget, skipping pop.");
+      // Mark closed now so this branch doesn't re-fire, then close this
+      // dialog's own route after the frame — popping during build throws
+      // "setState() called during build" when the same frame opens another
+      // route/overlay. Targeting `_dialogRoute` avoids racing `View`'s
+      // confirm-pop, which also pops its own route.
+      control.updateProperties({"_open": false}, python: false);
+      final route = _dialogRoute;
+      if (route != null) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          closeModalRoute(route);
+        });
       }
     }
     return const SizedBox.shrink();

--- a/packages/flet/lib/src/controls/cupertino_bottom_sheet.dart
+++ b/packages/flet/lib/src/controls/cupertino_bottom_sheet.dart
@@ -5,10 +5,11 @@ import '../controls/control_widget.dart';
 import '../models/control.dart';
 import '../utils/colors.dart';
 import '../utils/edge_insets.dart';
+import '../utils/misc.dart';
 import '../utils/numbers.dart';
 import '../widgets/error.dart';
 
-class CupertinoBottomSheetControl extends StatelessWidget {
+class CupertinoBottomSheetControl extends StatefulWidget {
   final Control control;
 
   const CupertinoBottomSheetControl({
@@ -16,7 +17,19 @@ class CupertinoBottomSheetControl extends StatelessWidget {
     required this.control,
   });
 
+  @override
+  State<CupertinoBottomSheetControl> createState() =>
+      _CupertinoBottomSheetControlState();
+}
+
+class _CupertinoBottomSheetControlState
+    extends State<CupertinoBottomSheetControl> {
+  // The modal route this control pushed, tracked so the close path can pop
+  // exactly this route (never whatever happens to be topmost) after the frame.
+  ModalRoute? _popupRoute;
+
   Widget _createDialog(BuildContext context) {
+    final control = widget.control;
     Control? content = control.child("content");
 
     if (content == null) {
@@ -49,6 +62,7 @@ class CupertinoBottomSheetControl extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final control = widget.control;
     debugPrint("CupertinoBottomSheet build: ${control.id}");
 
     bool lastOpen = control.getBool("_open", false)!;
@@ -64,24 +78,35 @@ class CupertinoBottomSheetControl extends StatelessWidget {
       control.updateProperties({"_open": open}, python: false);
 
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        ModalRoute? popupRoute;
+        if (!context.mounted) return;
         showCupertinoModalPopup(
             barrierDismissible: !control.getBool("modal", false)!,
             useRootNavigator: false,
             context: context,
             builder: (context) {
-              popupRoute ??= ModalRoute.of(context);
+              _popupRoute = ModalRoute.of(context);
               return dialog;
             }).then((value) {
-          (popupRoute?.completed ?? Future.value()).then((_) {
+          (_popupRoute?.completed ?? Future.value()).then((_) {
+            _popupRoute = null;
             control.updateProperties({"_open": false}, python: false);
             control.updateProperties({"open": false});
             control.triggerEvent("dismiss");
           });
         });
       });
-    } else if (open != lastOpen && lastOpen && Navigator.of(context).canPop()) {
-      Navigator.of(context).pop();
+    } else if (open != lastOpen && lastOpen) {
+      // Mark closed now so this branch doesn't re-fire, then close after the
+      // frame. Popping during build throws "setState() called during build"
+      // when the same frame also opens another route/overlay (e.g. a SnackBar).
+      control.updateProperties({"_open": open}, python: false);
+      final route = _popupRoute;
+      _popupRoute = null;
+      if (route != null) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          closeModalRoute(route);
+        });
+      }
     }
 
     return const SizedBox.shrink();

--- a/packages/flet/lib/src/controls/view.dart
+++ b/packages/flet/lib/src/controls/view.dart
@@ -15,6 +15,7 @@ import '../utils/box.dart';
 import '../utils/buttons.dart';
 import '../utils/colors.dart';
 import '../utils/edge_insets.dart';
+import '../utils/misc.dart';
 import '../utils/numbers.dart';
 import '../utils/theme.dart';
 import '../widgets/boot_screen.dart';
@@ -285,6 +286,11 @@ class _ViewControlState extends State<ViewControl> {
             return;
           }
           debugPrint("Page.onPopInvokedWithResult()");
+          // Capture THIS view's route now, so the deferred pop below targets
+          // exactly this view — not whatever is topmost when it runs. Without
+          // this, a modal (dialog/bottom sheet) dismissed in the same tick
+          // could be popped instead of the view.
+          final viewRoute = ModalRoute.of(context);
           if (_popCompleter != null && !_popCompleter!.isCompleted) {
             _popCompleter!.completeError("Aborted");
           }
@@ -308,7 +314,9 @@ class _ViewControlState extends State<ViewControl> {
                     if (!mounted) {
                       return;
                     }
-                    Navigator.pop(context, true);
+                    if (viewRoute != null) {
+                      closeModalRoute(viewRoute, true);
+                    }
                     if (mounted) {
                       setState(() {
                         _allowPop = false;

--- a/packages/flet/lib/src/utils/misc.dart
+++ b/packages/flet/lib/src/utils/misc.dart
@@ -234,3 +234,25 @@ extension MiscParsers on Control {
     return parseFloatingLabelBehavior(get(propertyName), defaultValue);
   }
 }
+
+/// Closes a modal [route] that a control pushed (bottom sheets, dialogs),
+/// targeting exactly that route rather than the topmost one.
+///
+/// Call this from a post-frame callback, never during `build` — popping a
+/// route during build throws "setState()/markNeedsBuild() called during build"
+/// if the same frame also opens another route or overlay (e.g. a SnackBar).
+///
+/// When the route is still the current (topmost) route it is popped with the
+/// normal exit animation (passing [result], if any); otherwise it is removed
+/// directly, so a route pushed on top of it (or a concurrent `Navigator.pop`
+/// targeting the topmost route) can't dismiss the wrong route.
+void closeModalRoute(ModalRoute route, [dynamic result]) {
+  if (!route.isActive) return;
+  final navigator = route.navigator;
+  if (navigator == null) return;
+  if (route.isCurrent) {
+    navigator.pop(result);
+  } else {
+    navigator.removeRoute(route);
+  }
+}

--- a/sdk/python/packages/flet/integration_tests/controls/material/test_bottom_sheet.py
+++ b/sdk/python/packages/flet/integration_tests/controls/material/test_bottom_sheet.py
@@ -35,6 +35,52 @@ async def test_basic(flet_app: ftt.FletTestApp, request):
 
 
 @pytest.mark.asyncio(loop_scope="module")
+async def test_close_with_snackbar(flet_app: ftt.FletTestApp):
+    # Exercises the fixed flow: dismissing the sheet and showing a SnackBar
+    # from the SAME handler. This used to pop the sheet's route synchronously
+    # during build (crashing with "setState() called during build" on-device);
+    # the close is now deferred to a post-frame callback. The exact crash is a
+    # device frame-timing race that `flutter test` doesn't reproduce, so this
+    # guards the close+SnackBar flow rather than the raw crash.
+    flet_app.resize_page(400, 600)
+
+    def close_and_snack(_):
+        flet_app.page.pop_dialog()
+        flet_app.page.show_dialog(ft.SnackBar(content=ft.Text("Item deleted")))
+
+    sheet = ft.BottomSheet(
+        content=ft.Container(
+            padding=50,
+            content=ft.Column(
+                tight=True,
+                controls=[
+                    ft.Text("Actions"),
+                    ft.Button("Delete", on_click=close_and_snack),
+                ],
+            ),
+        ),
+    )
+    flet_app.page.show_dialog(sheet)
+    flet_app.page.update()
+    await flet_app.tester.pump_and_settle()
+
+    delete_button = await flet_app.tester.find_by_text("Delete")
+    assert delete_button.count == 1
+    await flet_app.tester.tap(delete_button)
+    # A crash here (or a failure to render the SnackBar) means the regression
+    # is back.
+    await flet_app.tester.pump_and_settle()
+
+    snack = await flet_app.tester.find_by_text("Item deleted")
+    assert snack.count == 1
+
+    # Clean up so the module-scoped page doesn't leak the SnackBar.
+    flet_app.page.pop_dialog()
+    flet_app.page.update()
+    await flet_app.tester.pump_and_settle()
+
+
+@pytest.mark.asyncio(loop_scope="module")
 async def test_fullscreen(flet_app: ftt.FletTestApp, request):
     flet_app.page.enable_screenshots = True
     flet_app.resize_page(400, 600)


### PR DESCRIPTION
## Problem

`AlertDialog`, `CupertinoAlertDialog`, `BottomSheet` and `CupertinoBottomSheet` popped their route **synchronously during `build()`** in the close path. When the same frame also opened another route or overlay — e.g. dismissing a bottom sheet and showing a `SnackBar` from one handler (a project-actions "Delete" + "deleted" snackbar) — the exit animation notified a listener that was mid-build, throwing `setState()/markNeedsBuild() called during build` and blanking the screen.

A second, related hazard: `View`'s confirm-pop scheduled a post-frame `Navigator.pop(context, true)` targeting the **topmost** route, which could pop a modal dismissed in the same tick instead of the view (the reason `AlertDialog` had kept a synchronous pop, per its comment / `test_pop_view_confirm`).

## Fix

- Each modal now tracks its own `ModalRoute` and closes it in a **post-frame callback** via a shared `closeModalRoute()` helper (`utils/misc.dart`) that pops **that specific route** — animated `pop()` when it's topmost, `removeRoute()` when something's on top of it.
- `View`'s confirm-pop now pops **its own** route as well, so a modal dismissed in the same tick as a view pop can no longer dismiss the wrong route.
- `BottomSheet`, `CupertinoBottomSheet`, `CupertinoAlertDialog` converted `StatelessWidget` → `StatefulWidget` to persist their route (`AlertDialog` already was stateful).

## Testing

- `flutter analyze`: clean.
- Existing integration tests pass: **test_pop_view_confirm**, plus 11 material + 7 Cupertino dialog / bottom-sheet / banner / snack-bar tests.
- Adds `test_close_with_snackbar` (bottom sheet dismissed + SnackBar shown from one handler). Note: the raw crash is a real-device frame-timing race that `flutter test` doesn't reproduce (verified by reintroducing the exact bug), so this test guards the close+SnackBar flow rather than the raw crash.

## Summary by Sourcery

Prevent modal routes and views from popping synchronously during build and ensure each control closes its own route safely.

Bug Fixes:
- Resolve crashes and blank screen when closing modal controls in the same frame that another route or overlay is opened by deferring route closure to post-frame callbacks and targeting the correct route.
- Fix `View` confirm-pop so it reliably dismisses its own route instead of potentially popping a concurrently dismissed modal.
- Eliminate route mis-targeting when multiple pops occur in the same tick by introducing `closeModalRoute()` to close a specific modal route safely.

Enhancements:
- Convert bottom sheet and Cupertino dialog controls from stateless to stateful so they can track their own modal routes for robust open/close behavior.

Documentation:
- Update CHANGELOG entries for version 0.86.3 to document the modal close crash fix and routing behavior changes.

Tests:
- Add an integration test `test_close_with_snackbar` to cover dismissing a bottom sheet and showing a `SnackBar` from the same handler, guarding against regression of the modal close crash.