### PR TITLE
Bump flet package version to 0.86.3

### DIFF
--- a/packages/flet/pubspec.yaml
+++ b/packages/flet/pubspec.yaml
@@ -2,7 +2,7 @@ name: flet
 description: Write entire Flutter app in Python or add server-driven UI experience into existing Flutter app.
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/flet/tree/main/packages/flet
-version: 0.86.2
+version: 0.86.3
 
 # Supported platforms
 platforms:


### PR DESCRIPTION
## Summary by Sourcery

Bump the flet package version metadata from 0.86.2 to 0.86.3.