### PR TITLE
Pass the app's bundle id to serious_python's darwin packaging

### DIFF
--- a/sdk/python/packages/flet-cli/src/flet_cli/commands/build_base.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/commands/build_base.py
@@ -2290,6 +2290,13 @@ class BaseBuildCommand(BaseFlutterCommand):
             # app here (no app.zip on native); the platform native build copies
             # it into the bundle (Android zips it as a stored asset).
             package_env["SERIOUS_PYTHON_APP"] = str(self.build_dir / "python-app")
+            # app bundle id: serious_python (>= 4.4.2) namespaces the generated
+            # iOS framework bundle identifiers under it. Without it they keep a
+            # shared `org.python.*` default that is byte-identical in every Flet
+            # app — see flet-dev/flet#6724.
+            bundle_id = (self.template_data or {}).get("bundle_id")
+            if bundle_id:
+                package_env["SERIOUS_PYTHON_BUNDLE_ID"] = bundle_id
 
         # Swift Package Manager (darwin): tell serious_python's package command to
         # do the host-side SPM staging (the podspec prepare_command doesn't run
@@ -2564,6 +2571,15 @@ class BaseBuildCommand(BaseFlutterCommand):
             # / Android Gradle) at `flutter build` time to place the unpacked app
             # into the bundle.
             env["SERIOUS_PYTHON_APP"] = str(build_dir / "python-app")
+
+        # app bundle id: the CocoaPods `prepare_command` re-runs the darwin sync
+        # at `flutter build` time, so it needs the same value the package step
+        # got or the framework identifiers fall back to `org.python.*`. Read
+        # defensively — this method is documented as safe to call before the
+        # pipeline has populated every attribute.
+        bundle_id = (getattr(self, "template_data", None) or {}).get("bundle_id")
+        if bundle_id:
+            env["SERIOUS_PYTHON_BUNDLE_ID"] = bundle_id
 
         # Swift Package Manager (darwin): export the cache-bust key the package
         # step computed so the plugin's Package.swift re-resolves when the staged


### PR DESCRIPTION
Exports `SERIOUS_PYTHON_BUNDLE_ID` to serious_python's darwin packaging, from both the `package` step and `_serious_python_build_env`.

## Why

serious_python builds every Python C-extension into its own iOS framework. Those frameworks carry a fixed `org.python.<module>` `CFBundleIdentifier` — `org.python.ssl`, `org.python.hashlib`, … — **byte-identical in every Flet app ever shipped**. That value also becomes the framework's *code signing identifier*, which is the one field that survives the `codesign -f` Xcode applies at embed and again at `exportArchive`.

serious_python 4.4.2 namespaces them under the host app's bundle id instead (`com.example.app.-ssl`), mirroring what CPython's own iOS support does in `Platforms/Apple/testbed/Python.xcframework/build/utils.sh`. It needs the value passed in — python-build and serious_python have no idea which app their frameworks will end up in.

This is the leading hypothesis for the `ITMS-91065: Missing signature` rejection in #6724, where Apple flags `_ssl.framework` and `_hashlib.framework` as containing BoringSSL / openssl_grpc on new App Store submissions. **Not a confirmed fix** — confirming it needs a new-app submission, since the check doesn't fire for updates to already-published apps.

## Why two call sites

The `package` step stages the frameworks, but the CocoaPods `prepare_command` re-runs the darwin sync at `flutter build` time. Both need the same value or the identifiers silently fall back to the old defaults on the CocoaPods path.

## Safety

Both reads go through `(… or {}).get("bundle_id")`, and the serious_python side skips the rewrite entirely when the variable is unset or fails bundle-identifier validation. An app without a configured bundle id builds exactly as before.

`setup_template_data()` is invoked immediately before `package_python_app()` in all three entry points (`build.py:77-79`, `debug.py:114-116`, `test.py:42-44`), so `self.template_data` is populated by the time either site reads it.

Requires serious_python >= 4.4.2 to have any effect; older versions ignore the variable.

## Summary by Sourcery

Export the app bundle identifier to serious_python’s Darwin packaging so its generated iOS frameworks can be namespaced per host app rather than using shared defaults.

Enhancements:
- Propagate the app bundle identifier into the serious_python packaging environment during the main package step.
- Ensure the same bundle identifier is exported in the CocoaPods-driven serious_python build environment to keep framework identifiers consistent across build paths.