### PR TITLE
Make Android gradle.properties configurable from pyproject.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.86.5
+
+### Improvements
+
+* Android Gradle properties can now be configured from `pyproject.toml` via `[tool.flet.android.gradle_properties]`. The generated project's `android/gradle.properties` was previously fixed, so its memory settings — `org.gradle.jvmargs=-Xmx8G` plus a 4 GB metaspace — could not be changed. That is larger than the total RAM of a standard GitHub-hosted runner (measured: 7.8 GB with 3 GB of swap), so release builds, which additionally run Dart AOT once per ABI and R8, could exhaust memory and stall with no error; the only workaround was to download the published build template, patch the file and pass `--template`. Entries in the table override the defaults or add new properties, e.g. `"org.gradle.jvmargs" = "-Xmx3G -XX:MaxMetaspaceSize=1G"` and `"org.gradle.workers.max" = 2`. Defaults are unchanged, so existing builds render exactly the same file by @FeodorFitsner.
+
 ## 0.86.4
 
 ### Bug fixes

--- a/packages/flet/CHANGELOG.md
+++ b/packages/flet/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.86.5
+
+_No changes in the `flet` Dart package; version bumped for release coordination with configurable Android `gradle.properties` on the Python side ([#6733](https://github.com/flet-dev/flet/pull/6733))._
+
 ## 0.86.4
 
 * Isolate per-service failures when building the page's service registry. `ServiceBinding` throws `Unknown service` for a control type no extension can build, and that exception escaping `ServiceRegistry._onServicesUpdated()` aborted the whole loop, so every service after the offending entry was silently never bound and later `invokeMethod` calls on them hung until they timed out. Each binding is now built independently and a failure is logged and skipped. Also rebuilds the registry when the `_services` control instance is replaced (not just when its uid changes), matching how the `window` service tracks its control by identity.

--- a/packages/flet/pubspec.yaml
+++ b/packages/flet/pubspec.yaml
@@ -2,7 +2,7 @@ name: flet
 description: Write entire Flutter app in Python or add server-driven UI experience into existing Flutter app.
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/flet/tree/main/packages/flet
-version: 0.86.4
+version: 0.86.5
 
 # Supported platforms
 platforms:

--- a/sdk/python/packages/flet-cli/src/flet_cli/commands/build_base.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/commands/build_base.py
@@ -956,6 +956,19 @@ class BaseBuildCommand(BaseFlutterCommand):
         }
         android_meta_data = {}
         android_providers = {}
+        # Gradle properties for the generated Android project. These were
+        # hardcoded in the template; the defaults below reproduce them exactly,
+        # and `[tool.flet.android.gradle_properties]` can override any entry or
+        # add new ones. The memory settings in particular are too large for some
+        # CI runners (a standard GitHub-hosted runner has ~7 GB of RAM, less
+        # than -Xmx8G alone), which previously could not be changed at all.
+        android_gradle_properties = {
+            "org.gradle.jvmargs": (
+                "-Xmx8G -XX:MaxMetaspaceSize=4G "
+                "-XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError"
+            ),
+            "android.useAndroidX": "true",
+        }
 
         # merge values from "--permissions" arg:
         for p in (
@@ -1035,6 +1048,11 @@ class BaseBuildCommand(BaseFlutterCommand):
         android_permissions = merge_dict(
             android_permissions,
             self.get_pyproject("tool.flet.android.permission") or {},
+        )
+
+        android_gradle_properties = merge_dict(
+            android_gradle_properties,
+            self.get_pyproject("tool.flet.android.gradle_properties") or {},
         )
 
         # parse --android-permissions
@@ -1386,6 +1404,7 @@ class BaseBuildCommand(BaseFlutterCommand):
                 "android_permissions": android_permissions,
                 "android_features": android_features,
                 "android_meta_data": android_meta_data,
+                "android_gradle_properties": android_gradle_properties,
                 "android_providers": android_providers,
                 "deep_linking": {
                     "scheme": deep_linking_scheme,

--- a/sdk/python/templates/build/{{cookiecutter.out_dir}}/android/gradle.properties
+++ b/sdk/python/templates/build/{{cookiecutter.out_dir}}/android/gradle.properties
@@ -1,2 +1,2 @@
-org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
-android.useAndroidX=true
+{% for k, v in cookiecutter.options.android_gradle_properties.items() %}{{ k }}={{ v }}
+{% endfor %}


### PR DESCRIPTION
Fixes #6732.

Makes the generated Android project's `gradle.properties` configurable from `pyproject.toml`:

```toml
[tool.flet.android.gradle_properties]
"org.gradle.jvmargs" = "-Xmx3G -XX:MaxMetaspaceSize=1G"
"org.gradle.workers.max" = 2
```

## Why

The file was a fixed template, so its memory settings couldn't be changed:

```properties
org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G ...
```

That's more than the **total RAM of a standard GitHub-hosted runner** — measured 7.8 GB with 3 GB of swap on a private-repo Ubuntu runner — before Dart AOT (one process per ABI) and R8, which only run in **release** builds.

Debug builds never approach the ceiling, so they pass; release builds go silent partway through Gradle and never finish, with no error to attribute it to. Capping the heap at 3 GB made the same release build complete in **10m40s**, ending with 1.7 GB available and 1.2 GB of swap in use — comfortably within budget in a way 8 GB never was.

The only workaround today is downloading the published build template, rewriting the file and passing `--template` — see the issue for the full recipe.

## Implementation

Follows the existing pattern for `[tool.flet.android.permission]` and `[tool.flet.android.meta_data]`:

- defaults defined in `setup_template_data()`
- merged with the pyproject table via `merge_dict`
- passed through `template_data["options"]["android_gradle_properties"]`
- rendered by the template with the same `{% for k, v in ... %}` idiom used by `android_meta_data` in `AndroidManifest.xml`

## Backwards compatibility

The defaults reproduce the previously hardcoded file **exactly**. Verified by rendering the template with the defaults and comparing to the old static file — byte-identical, so existing builds are unaffected.

Entries merge over the defaults, so a project can override just `org.gradle.jvmargs` or add new properties (`org.gradle.parallel`, `org.gradle.workers.max`, …) without restating the rest.

## Note

Whether `-Xmx8G` is the right *default* is a separate question worth considering — it exceeds every standard GitHub-hosted runner, and the failure it produces (silence, no error) is hard to diagnose. This PR only makes it overridable; it doesn't change the default.

## Summary by Sourcery

Make Android Gradle properties for generated projects configurable via pyproject.toml while preserving existing defaults.

New Features:
- Allow configuring Android Gradle properties from pyproject.toml using the [tool.flet.android.gradle_properties] table.

Enhancements:
- Refactor the Android gradle.properties template to render properties from template data instead of using a fixed file.

Documentation:
- Document the new Android Gradle properties configuration in the changelog, including usage examples and backward-compatibility notes.