### PR TITLE
Stop requesting broad Android media/storage permissions

### DIFF
--- a/client/android/app/src/debug/AndroidManifest.xml
+++ b/client/android/app/src/debug/AndroidManifest.xml
@@ -4,14 +4,7 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET" />
-    <!-- Media access permissions.
-    Android 13 or higher.
-    https://developer.android.com/about/versions/13/behavior-changes-13#granular-media-permissions -->
-    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
-    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
-    <!-- Storage access permissions. Android 12 or lower. -->
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <!-- NOTE: no READ_MEDIA_*/*_EXTERNAL_STORAGE here — see the main manifest. -->
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />

--- a/client/android/app/src/main/AndroidManifest.xml
+++ b/client/android/app/src/main/AndroidManifest.xml
@@ -1,13 +1,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
-    <!-- Media access permissions.
-    Android 13 or higher.
-    https://developer.android.com/about/versions/13/behavior-changes-13#granular-media-permissions -->
-    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
-    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
-    <!-- Storage access permissions. Android 12 or lower. -->
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <!-- NOTE: no READ_MEDIA_IMAGES/READ_MEDIA_VIDEO/READ_MEDIA_AUDIO or
+    *_EXTERNAL_STORAGE here. Google Play's Photo and Video Permissions policy
+    rejects apps targeting API 33+ that request broad media access when the
+    system pickers suffice. File access goes through the storage access
+    framework (file_picker), which needs no permission. -->
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />

--- a/client/android/app/src/profile/AndroidManifest.xml
+++ b/client/android/app/src/profile/AndroidManifest.xml
@@ -4,14 +4,7 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET" />
-    <!-- Media access permissions.
-    Android 13 or higher.
-    https://developer.android.com/about/versions/13/behavior-changes-13#granular-media-permissions -->
-    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
-    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
-    <!-- Storage access permissions. Android 12 or lower. -->
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <!-- NOTE: no READ_MEDIA_*/*_EXTERNAL_STORAGE here — see the main manifest. -->
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />

--- a/sdk/python/examples/apps/flet_build_test/pyproject.toml
+++ b/sdk/python/examples/apps/flet_build_test/pyproject.toml
@@ -108,8 +108,8 @@ startup_message = "Starting up..."
 fade_out_duration = 200
 
 [tool.flet.android.permission]
-"android.permission.READ_EXTERNAL_STORAGE" = true
-"android.permission.WRITE_EXTERNAL_STORAGE" = true
+"android.permission.CAMERA" = true
+"android.permission.RECORD_AUDIO" = true
 "android.permission.ACCESS_FINE_LOCATION" = { maxSdkVersion = "30" }
 "android.permission.BLUETOOTH_SCAN" = { usesPermissionFlags = "neverForLocation" }
 

--- a/sdk/python/packages/flet-cli/src/flet_cli/commands/build_base.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/commands/build_base.py
@@ -212,11 +212,13 @@ class BaseBuildCommand(BaseFlutterCommand):
                     "NSMicrophoneUsageDescription": "This app uses microphone to record sounds.",  # noqa: E501
                 },
                 "macos_entitlements": {"com.apple.security.device.audio-input": True},
-                "android_permissions": {
-                    "android.permission.RECORD_AUDIO": True,
-                    "android.permission.WRITE_EXTERNAL_STORAGE": True,
-                    "android.permission.READ_EXTERNAL_STORAGE": True,
-                },
+                # Recording itself only needs RECORD_AUDIO: recordings are written
+                # to app-scoped storage, which requires no permission. Do not add
+                # READ/WRITE_EXTERNAL_STORAGE here — Google Play's Photo and Video
+                # Permissions policy rejects apps that request broad media/storage
+                # access without a qualifying use case, and this group is opt-in
+                # for the microphone, not for the user's media library.
+                "android_permissions": {"android.permission.RECORD_AUDIO": True},
                 "android_features": {},
             },
             "photo_library": {

--- a/website/docs/controls/video/index.md
+++ b/website/docs/controls/video/index.md
@@ -43,21 +43,35 @@ The below sections show the required configurations for each platform.
 
 ### Android
 
-You may need to declare and request file-system/storage permissions, depending on your use case:
+**No permissions are required** to play media from a URL, from a bundled asset, or
+from a file the user picked with [`FilePicker`](../../services/filepicker.md) — the
+system picker grants access to the picked file.
 
-- [`android.permission.READ_MEDIA_AUDIO`](https://developer.android.com/reference/android/Manifest.permission#READ_MEDIA_AUDIO) (optional): Allows to read audio files from external storage. Android 13 or higher.
-- [`android.permission.READ_MEDIA_VIDEO`](https://developer.android.com/reference/android/Manifest.permission#READ_MEDIA_VIDEO) (optional): Allows to read video files from external storage. Android 13 or higher.
-- [`android.permission.READ_EXTERNAL_STORAGE`](https://developer.android.com/reference/android/Manifest.permission#READ_EXTERNAL_STORAGE) (optional): Allows reading from external storage. Android 12 or lower.
-- [`android.permission.WRITE_EXTERNAL_STORAGE`](https://developer.android.com/reference/android/Manifest.permission#WRITE_EXTERNAL_STORAGE) (optional): Allows writing to external storage. Android 12 or lower.
+You only need media permissions if your app reads media **directly from the device's
+shared media library**, without the user picking each file:
+
+- [`android.permission.READ_MEDIA_AUDIO`](https://developer.android.com/reference/android/Manifest.permission#READ_MEDIA_AUDIO): Allows to read audio files from external storage. Android 13 or higher.
+- [`android.permission.READ_MEDIA_VIDEO`](https://developer.android.com/reference/android/Manifest.permission#READ_MEDIA_VIDEO): Allows to read video files from external storage. Android 13 or higher.
+- [`android.permission.READ_EXTERNAL_STORAGE`](https://developer.android.com/reference/android/Manifest.permission#READ_EXTERNAL_STORAGE): Allows reading from external storage. Android 12 or lower — bound with `maxSdkVersion` so that it is not requested on Android 13 or higher.
+
+:::danger[Google Play policy]
+Google Play's [Photo and Video Permissions policy](https://support.google.com/googleplay/android-developer/answer/14115180)
+**rejects** apps targeting Android 13 (API 33) or higher that declare
+`READ_MEDIA_IMAGES` or `READ_MEDIA_VIDEO` when the system pickers are sufficient.
+Declaring them in *any* active version code — including internal and closed testing
+tracks — is enough to block a release.
+
+Use [`FilePicker`](../../services/filepicker.md) unless you genuinely need
+library-wide access; in that case you must also submit the photo picker declaration
+form in the Play Console.
+:::
 
 <Tabs groupId="flet-build--pyproject-toml">
 <TabItem value="flet-build" label="flet build">
 ```bash
 flet build apk \
   --android-permissions android.permission.READ_MEDIA_AUDIO=true \
-  --android-permissions android.permission.READ_MEDIA_VIDEO=true \
-  --android-permissions android.permission.READ_EXTERNAL_STORAGE=true \
-  --android-permissions android.permission.WRITE_EXTERNAL_STORAGE=true
+  --android-permissions android.permission.READ_MEDIA_VIDEO=true
 ```
 </TabItem>
 <TabItem value="pyproject-toml" label="pyproject.toml">
@@ -65,8 +79,7 @@ flet build apk \
 [tool.flet.android.permission]
 "android.permission.READ_MEDIA_AUDIO" = true
 "android.permission.READ_MEDIA_VIDEO" = true
-"android.permission.READ_EXTERNAL_STORAGE" = true
-"android.permission.WRITE_EXTERNAL_STORAGE" = true
+"android.permission.READ_EXTERNAL_STORAGE" = { maxSdkVersion = "32" }
 ```
 </TabItem>
 </Tabs>

--- a/website/docs/publish/android.md
+++ b/website/docs/publish/android.md
@@ -741,6 +741,22 @@ the example above will be translated accordingly into this:
 Use cross-platform permissions from [Permissions](index.md#permissions) when possible,
 and add Android-specific permissions or features here.
 
+:::danger[Declare only what you use]
+Google Play rejects apps that request broad media or storage access they do not need.
+In particular, its [Photo and Video Permissions policy](https://support.google.com/googleplay/android-developer/answer/14115180)
+rejects apps targeting Android 13 (API 33) or higher that declare
+`READ_MEDIA_IMAGES` or `READ_MEDIA_VIDEO` when the system pickers are sufficient —
+and a single active version code carrying them, including on internal and closed
+testing tracks, is enough to block a release.
+
+[`FilePicker`](../services/filepicker.md) uses the storage access framework and needs
+no permission at all, and the app's own directories
+(see [`StoragePaths`](../services/storagepaths.md)) are always writable. Reach for
+`READ_MEDIA_*` or the legacy `*_EXTERNAL_STORAGE` permissions only when your app truly
+needs library-wide access, and bound the legacy ones with
+`{ maxSdkVersion = "32" }` so they are not requested on Android 13 or higher.
+:::
+
 See also:
 
 - [`Manifest.permission` constants](https://developer.android.com/reference/android/Manifest.permission)
@@ -779,15 +795,15 @@ A non-empty table is always emitted; an empty table `{}` is treated as `false`.
 <TabItem value="flet-build" label="flet build">
 ```bash
 flet build apk \
-  --android-permissions android.permission.READ_EXTERNAL_STORAGE=true \
-  --android-permissions android.permission.WRITE_EXTERNAL_STORAGE=true
+  --android-permissions android.permission.CAMERA=true \
+  --android-permissions android.permission.RECORD_AUDIO=true
 ```
 </TabItem>
 <TabItem value="pyproject-toml" label="pyproject.toml">
 ```toml
 [tool.flet.android.permission]
-"android.permission.READ_EXTERNAL_STORAGE" = true
-"android.permission.WRITE_EXTERNAL_STORAGE" = true
+"android.permission.CAMERA" = true
+"android.permission.RECORD_AUDIO" = true
 "android.permission.ACCESS_FINE_LOCATION" = { maxSdkVersion = "30" }
 "android.permission.BLUETOOTH_SCAN" = { usesPermissionFlags = "neverForLocation" }
 ```
@@ -801,8 +817,8 @@ the `pyproject.toml` example above will be translated accordingly into this:
 
 ```xml
 <manifest>
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:maxSdkVersion="30" />
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" />
 </manifest>

--- a/website/docs/services/audiorecorder/index.md
+++ b/website/docs/services/audiorecorder/index.md
@@ -48,7 +48,6 @@ The below sections show the required configurations for each platform.
 Configuration to be made to access the microphone:
 
 - [`android.permission.RECORD_AUDIO`](https://developer.android.com/reference/android/Manifest.permission#RECORD_AUDIO): Allows audio recording.
-- [`android.permission.WRITE_EXTERNAL_STORAGE`](https://developer.android.com/reference/android/Manifest.permission#WRITE_EXTERNAL_STORAGE) (optional): Allows saving your recordings in public folders.
 - [`android.permission.MODIFY_AUDIO_SETTINGS`](https://developer.android.com/reference/android/Manifest.permission#MODIFY_AUDIO_SETTINGS) (optional): Allows using bluetooth telephony device like headset/earbuds.
 
 <Tabs groupId="flet-build--pyproject-toml">
@@ -56,7 +55,6 @@ Configuration to be made to access the microphone:
 ```bash
 flet build apk \
   --android-permissions android.permission.RECORD_AUDIO=true \
-  --android-permissions android.permission.WRITE_EXTERNAL_STORAGE=true \
   --android-permissions android.permission.MODIFY_AUDIO_SETTINGS=true
 ```
 </TabItem>
@@ -64,11 +62,17 @@ flet build apk \
 ```toml
 [tool.flet.android.permission]
 "android.permission.RECORD_AUDIO" = true
-"android.permission.WRITE_EXTERNAL_STORAGE" = true
 "android.permission.MODIFY_AUDIO_SETTINGS" = true
 ```
 </TabItem>
 </Tabs>
+:::note
+No storage permission is needed to save recordings: writing to the app's own
+directories (see [`StoragePaths`](../storagepaths.md)) is always allowed, and
+saving elsewhere should go through [`FilePicker.save_file()`](../filepicker.md),
+which uses the system picker. Requesting `WRITE_EXTERNAL_STORAGE` or
+`READ_EXTERNAL_STORAGE` instead can get your app rejected from Google Play.
+:::
 See also:
 
 - [setting Android permissions](../../publish/android.md#permissions)


### PR DESCRIPTION
Google Play's Photo and Video Permissions policy rejects apps targeting API 33+ that declare `READ_MEDIA_IMAGES` / `READ_MEDIA_VIDEO` when the system pickers are sufficient, and it flags the legacy `*_EXTERNAL_STORAGE` permissions when they are unbounded. Flet was handing these out by default in three places.

## Changes

**flet-cli** — the `microphone` cross-platform permission bundle injected `READ_EXTERNAL_STORAGE` and `WRITE_EXTERNAL_STORAGE` alongside `RECORD_AUDIO`, so every app built with `--permissions microphone` got broad storage access it never asked for. Recording only needs `RECORD_AUDIO`; recordings go to app-scoped storage.

**client** — dropped `READ_MEDIA_AUDIO`, `READ_MEDIA_VIDEO` and both `*_EXTERNAL_STORAGE` from the Android manifests. File access goes through the storage access framework, which needs no permission.

**docs** — Video and AudioRecorder no longer hand out these permissions as a copy-paste block. They now explain when the permissions are actually needed, bound the legacy ones with `maxSdkVersion`, and the Android publishing guide warns about the Play policy.

## Why it matters

Apps that never touch the media store were shipping permissions that can get a release rejected at review. The fix is subtractive — nothing gains a capability it didn't have, and anything that genuinely needs media access can still declare it explicitly via `[tool.flet.android.permission]`.

## Summary by Sourcery

Remove default broad Android media/storage permissions and align manifests, CLI presets, and docs with Google Play’s Photo and Video permissions policy.

Bug Fixes:
- Stop bundling READ/WRITE_EXTERNAL_STORAGE with the cross-platform microphone permission group in flet-cli so apps don’t receive unintended storage access.

Enhancements:
- Drop media and legacy external storage permissions from Android client manifests so file access relies on the storage access framework without explicit permissions.
- Update Video and AudioRecorder docs to clarify when Android media/storage permissions are actually required and recommend system pickers and app-scoped storage.
- Adjust example permission configurations to use CAMERA/RECORD_AUDIO and bound READ_EXTERNAL_STORAGE with maxSdkVersion in docs and example pyproject.toml.

Documentation:
- Document Google Play’s Photo and Video Permissions policy impacts and advise declaring only necessary media/storage permissions, with concrete guidance on using FilePicker and maxSdkVersion bounds.