### PR TITLE
fix(testing): prevent host Python env from leaking into Flutter tests

### DIFF
--- a/sdk/python/packages/flet/src/flet/testing/flet_test_app.py
+++ b/sdk/python/packages/flet/src/flet/testing/flet_test_app.py
@@ -314,11 +314,19 @@ class FletTestApp:
                         f"--dart-define=FLET_TEST_ASSETS_DIR={self.__assets_dir}"
                     ]
 
+        # Do not leak host-Python configuration into Flutter's embedded Python
+        # IDEs such as PyCharm add debugger/sitecustomize modules through
+        # PYTHONPATH, which can break the packaged integration-test app.
+        flutter_env = os.environ.copy()
+        flutter_env.pop("PYTHONPATH", None)
+        flutter_env.pop("PYTHONHOME", None)
+
         self.__flutter_process = await asyncio.create_subprocess_exec(
             *flutter_args,
             cwd=str(self.__flutter_app_dir),
             stdout=stdout,
             stderr=stderr,
+            env=flutter_env,
         )
 
         if self.__flutter_process.stdout is not None:


### PR DESCRIPTION
## Description

FletTestApp started the Flutter integration-test process with the complete environment inherited from the host Python process.

IDEs such as PyCharm add debugger and sitecustomize directories to PYTHONPATH. That value was inherited by `flutter test` and subsequently passed to the embedded Serious Python runtime.

As a result, the packaged test app could exit before connecting to RemoteTester. Flutter then reported exit code 79 with "No tests were found", while the flet_app fixture failed during setup.

Create an explicit environment for the Flutter subprocess and remove PYTHONPATH and PYTHONHOME before launching it.  All Flet, Flutter and SERIOUS_PYTHON_* variables remain unchanged.

This keeps host-only Python configuration out of the packaged runtime while preserving the environment required to build and execute integration tests.

Verified with the PyCharm TeamCity pytest plugin and PyCharm helper paths present in the host PYTHONPATH.

## Test code

```python
# Minimal test/reproduction code for reviewers, if applicable.
```

## Type of change

<!-- select only options relevant to your PR -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I signed the CLA.
- [x] I have performed a self-review of my own code.
- [ ] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] New and existing tests pass locally with my changes.
- [x] I have made corresponding documentation changes, if applicable.
- [ ] I have added changelog entries for user-facing changes, if applicable.
- [ ] I have updated release guide pages and `website/sidebars.yml` for breaking changes, removals, and deprecations, if applicable.

## Screenshots

<!-- Add screenshots here if applicable. -->

## Additional details

<!-- Any additional details to be known about this PR. -->

## Summary by Sourcery

Bug Fixes:
- Prevent host IDE and debugger Python configuration from causing packaged Flutter integration tests to exit prematurely by stripping PYTHONPATH and PYTHONHOME from the Flutter test environment.