### PR TITLE
fix: run auto-update after generator event handlers complete

### DIFF
--- a/sdk/python/packages/flet/src/flet/controls/base_control.py
+++ b/sdk/python/packages/flet/src/flet/controls/base_control.py
@@ -510,7 +510,6 @@ class BaseControl:
                 else:
                     async for _ in event_handler(e):
                         await session.after_event(session.index.get(self._i))
-                return
 
             elif inspect.isgeneratorfunction(event_handler):
                 if get_param_count(event_handler) == 0:
@@ -519,7 +518,6 @@ class BaseControl:
                 else:
                     for _ in event_handler(e):
                         await session.after_event(session.index.get(self._i))
-                return
 
             elif callable(event_handler):
                 if get_param_count(event_handler) == 0:


### PR DESCRIPTION
## Description

Generator and async-generator event handlers returned immediately after iteration, skipping the shared `after_event()` processing.

As a result, control changes made after the final `yield` were not pushed to the client unless the handler explicitly called `.update()` or ended with another `yield`.

Remove the early returns from both generator branches so the shared `after_event()` processing also runs when the generator completes.

This preserves intermediate updates at each `yield` while restoring the expected final auto-update behavior.

Auto-update remains suppressed when disabled, and explicit `.update()` calls still prevent redundant automatic updates.

## Test code

```python
# Minimal test/reproduction code for reviewers, if applicable.
```

## Type of change

<!-- select only options relevant to your PR -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] I signed the CLA.
- [x] I have performed a self-review of my own code.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] New and existing tests pass locally with my changes.
- [ ] I have made corresponding documentation changes, if applicable.
- [ ] I have added changelog entries for user-facing changes, if applicable.
- [ ] I have updated release guide pages and `website/sidebars.yml` for breaking changes, removals, and deprecations, if applicable.

## Screenshots

<!-- Add screenshots here if applicable. -->

## Additional details

<!-- Any additional details to be known about this PR. -->

## Summary by Sourcery

Bug Fixes:
- Fix generator and async-generator event handlers skipping shared after-event processing on completion, which prevented final control updates from being pushed to the client.