### PR TITLE
Migrate flet.app to studio.flet.dev

### DIFF
--- a/sdk/python/examples/gallery.yaml
+++ b/sdk/python/examples/gallery.yaml
@@ -191,7 +191,7 @@ categories:
     _icon: build
     _description: Gestures, drag/drop, screenshots
     BrowserContextMenu:
-    Clipboard: # Clipboard files gives 404 on https://flet.app/api/gallery/apps/services/clipboard/files/package.zip?v=0, warn about Safari and iOS
+    Clipboard: # Clipboard files gives 404 on https://studio.flet.dev/api/gallery/apps/services/clipboard/files/package.zip?v=0, warn about Safari and iOS
     Color pickers:
     Connectivity:
     Draggable:

--- a/sdk/python/packages/flet/src/flet/controls/core/icon.py
+++ b/sdk/python/packages/flet/src/flet/controls/core/icon.py
@@ -28,7 +28,7 @@ class Icon(LayoutControl):
     The icon to display, selected from a predefined icon set.
 
     You can explore available icons using the
-    [Flet Icons Browser](https://flet.app/gallery/run/apps/icons_browser/).
+    [Flet Icons Browser](https://studio.flet.dev/gallery/run/apps/icons_browser/).
     """
 
     color: Optional[ColorValue] = None

--- a/website/blog/2026-05-28-flet-studio.md
+++ b/website/blog/2026-05-28-flet-studio.md
@@ -14,7 +14,7 @@ It started life as a playground for Flet apps, but turned out to be much
 more: a place to prototype, a gallery of editable examples, and a way to send someone a
 working app as just a link.
 
-<a href="https://flet.app" target="_blank" rel="noopener noreferrer">
+<a href="https://studio.flet.dev" target="_blank" rel="noopener noreferrer">
   <img src="/img/pages/studio/flet-studio-light.png" className="screenshot-100" style={{borderRadius: '7px'}} />
 </a>
 
@@ -23,7 +23,7 @@ working app as just a link.
 ## What you can do
 
 - **Run.** The simplest thing is to just run a Flet example. Open any of the
-  [500+ apps in the gallery](https://flet.app/gallery), hit run, and watch it work — no
+  [500+ apps in the gallery](https://studio.flet.dev/gallery), hit run, and watch it work — no
   setup, nothing to install.
 - **Create.** When you find one you like, fork it and make it your own. Or start from a
   blank cross-platform template if you'd rather build from scratch. Either way you get a
@@ -78,7 +78,7 @@ we're headed.
 
 ## Try it
 
-Open [flet.app](https://flet.app), build something, and share it. We'd love
+Open [flet.app](https://studio.flet.dev), build something, and share it. We'd love
 your feedback — drop it in [GitHub Discussions](https://github.com/flet-dev/flet/discussions)
 or on [Discord](https://discord.gg/dzWXP8SHG8).
 

--- a/website/blog/2026-07-17-smarter-flet-studio-with-ai-agent.md
+++ b/website/blog/2026-07-17-smarter-flet-studio-with-ai-agent.md
@@ -5,7 +5,7 @@ authors: feodor
 tags: ["releases", "flet studio"]
 ---
 
-In case you missed it, we have [Flet Studio](https://flet.app) - an online tool for
+In case you missed it, we have [Flet Studio](https://studio.flet.dev) - an online tool for
 building Flet apps and sharing them with other users. What started as a quick "FletPad"
 experiment has already grown into a solid app - an online Flet IDE, if you will - with
 user accounts, a forkable gallery of examples, multiple apps per account, and version
@@ -19,15 +19,15 @@ your apps with other users.
 
 Today we are introducing a new member of the family - the AI agent!
 
-Go to https://flet.app and ask something like:
+Go to https://studio.flet.dev and ask something like:
 
-<a href="https://flet.app" target="_blank" rel="noopener noreferrer">
+<a href="https://studio.flet.dev" target="_blank" rel="noopener noreferrer">
   <img src="/img/blog/flet-studio-ai/flet-studio-ai-prompt.png" className="screenshot-100" />
 </a>
 
 ...and in a few moments you get code you can start working with:
 
-<a href="https://flet.app" target="_blank" rel="noopener noreferrer">
+<a href="https://studio.flet.dev" target="_blank" rel="noopener noreferrer">
   <img src="/img/blog/flet-studio-ai/flet-studio-ai-result-preview.png" className="screenshot-100" />
 </a>
 
@@ -38,7 +38,7 @@ Python developer. Maintainable code is an explicit goal for us, and we are build
 tools for the agent to achieve exactly that. It helps that Flet itself, with its minimal
 boilerplate, is a framework equally friendly to humans and AI.
 
-<a href="https://flet.app" target="_blank" rel="noopener noreferrer">
+<a href="https://studio.flet.dev" target="_blank" rel="noopener noreferrer">
   <img src="/img/blog/flet-studio-ai/flet-studio-ai-result-code.png" className="screenshot-100" />
 </a>
 
@@ -104,7 +104,7 @@ in some areas like routing/navigation or declarative apps.
 
 ## Try it
 
-Open [flet.app](https://flet.app), sign in, and ask the agent to build something - your
+Open [flet.app](https://studio.flet.dev), sign in, and ask the agent to build something - your
 free monthly credits are already waiting. If you'd rather stay with your local agent,
 plug in the [Flet MCP server](/docs/cookbook/flet-mcp/) and enjoy hallucination-free
 Flet coding right away.

--- a/website/docs/controls/icon.md
+++ b/website/docs/controls/icon.md
@@ -13,7 +13,7 @@ import {ClassMembers, ClassSummary, CodeExample, Image} from '@site/src/componen
 ## Examples
 
 To browse and visualize all available icons,
-visit our [icons browser](https://flet.app/gallery/run/apps/icons_browser/)
+visit our [icons browser](https://studio.flet.dev/gallery/run/apps/icons_browser/)
 
 <CodeExample path={frontMatter.examples + '/icon/main.py'} language="python" />
 

--- a/website/docs/studio/index.md
+++ b/website/docs/studio/index.md
@@ -4,7 +4,7 @@ title: "Introduction"
 
 # Flet Studio
 
-[Flet Studio](https://flet.app) is a browser-based editor for writing, running, saving and
+[Flet Studio](https://studio.flet.dev) is a browser-based editor for writing, running, saving and
 sharing Flet apps. Your Python code runs entirely in the browser via
 [Pyodide](https://pyodide.org/) — there is no Flet account required to try it, and no
 local install required to run something someone else built and shared with you.

--- a/website/docs/studio/privacy-policy.md
+++ b/website/docs/studio/privacy-policy.md
@@ -8,7 +8,7 @@ title: "Privacy Policy"
 
 This Privacy Policy explains how **Appveyor Systems Inc.** ("AppVeyor", "we", "us", or "our") collects, uses, shares, and protects personal information in connection with the Flet Studio service ("Flet Studio", "the Service"). Flet Studio is a hosted development environment and runtime for building applications with the Flet framework.
 
-This policy applies to information we collect from users of Flet Studio at https://flet.app (and any related domains we operate for the Service) and through the Flet Studio web application.
+This policy applies to information we collect from users of Flet Studio at https://studio.flet.dev (and any related domains we operate for the Service) and through the Flet Studio web application.
 
 ---
 

--- a/website/docs/studio/terms-of-service.md
+++ b/website/docs/studio/terms-of-service.md
@@ -128,7 +128,7 @@ Your use of AI features is subject to Section 4 (Acceptable Use); you may not us
 
 ### 7.1 Plans
 
-Flet Studio is offered under a free plan and one or more paid plans. The current plans, their features and limits, and their prices — together with the price of AI credit packs — are listed on our [pricing page](https://flet.app/pricing). We may change plan limits and pricing with reasonable advance notice; where we materially reduce a limit, we will provide notice through the Service or by email. A price change for a subscription takes effect at the start of a subsequent billing period.
+Flet Studio is offered under a free plan and one or more paid plans. The current plans, their features and limits, and their prices — together with the price of AI credit packs — are listed on our [pricing page](https://studio.flet.dev/pricing). We may change plan limits and pricing with reasonable advance notice; where we materially reduce a limit, we will provide notice through the Service or by email. A price change for a subscription takes effect at the start of a subsequent billing period.
 
 ### 7.2 AI credit packs
 

--- a/website/docs/tutorials/calculator.md
+++ b/website/docs/tutorials/calculator.md
@@ -13,7 +13,7 @@ similar to iPhone calculator app UI:
 
 <Image src="examples/tutorials/calculator/media/app.png" alt="calc-app" width="55%" />
 
-You can find a live demo [here](https://flet.app/gallery/run/apps/calculator/).
+You can find a live demo [here](https://studio.flet.dev/gallery/run/apps/calculator/).
 
 In this tutorial, we will cover all of the basic concepts for creating a Flet app:
 building a page layout, adding controls, making reusable UI components, handling

--- a/website/docs/tutorials/solitaire.md
+++ b/website/docs/tutorials/solitaire.md
@@ -8,7 +8,7 @@ In this tutorial we will show you step-by-step creation of a famous Klondike sol
 
 This tutorial is aimed at beginner/intermediate level Python developers who have basic knowledge of Python and object oriented programming.
 
-You can find a live demo [here](https://flet.app/gallery/run/tutorials/solitaire_declarative/solitaire_final/).
+You can find a live demo [here](https://studio.flet.dev/gallery/run/tutorials/solitaire_declarative/solitaire_final/).
 
 <Image src="examples/tutorials/solitaire/media/part1-final.gif" alt="solitaire" width="55%" />
 

--- a/website/docs/tutorials/todo.md
+++ b/website/docs/tutorials/todo.md
@@ -13,7 +13,7 @@ yet it is a multi-platform application with rich, responsive UI:
 
 <Image src="examples/tutorials/todo/media/complete-demo-web.gif" width="55%" />
 
-You can see the live demo [here](https://flet.app/gallery/run/apps/todo/).
+You can see the live demo [here](https://studio.flet.dev/gallery/run/apps/todo/).
 
 We chose a To-Do app for the tutorial, because it covers all of the basic concepts you
 would need to create a Flet app: building a page layout, adding controls, handling events,

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -77,7 +77,7 @@ module.exports = {
           position: 'left',
         },
         {
-          to: 'https://flet.app/gallery',
+          to: 'https://studio.flet.dev/gallery',
           label: 'Gallery',
           position: 'left',
         },
@@ -132,7 +132,7 @@ module.exports = {
           items: [
             {
               label: 'Flet Studio app',
-              href: 'https://flet.app',
+              href: 'https://studio.flet.dev',
             },
             {
               label: 'Docs',

--- a/website/src/components/crocodocs/CodeExample.js
+++ b/website/src/components/crocodocs/CodeExample.js
@@ -3,7 +3,7 @@ import CodeBlock from "@theme/CodeBlock";
 
 import {getExampleSource, getExampleWebSupported} from "./utils";
 
-const FLET_STUDIO_BASE = "https://flet.app/gallery/example";
+const FLET_STUDIO_BASE = "https://studio.flet.dev/gallery/example";
 
 /**
  * Renders a syntax-highlighted code block for a bundled example file.

--- a/website/src/pages/studio.js
+++ b/website/src/pages/studio.js
@@ -83,7 +83,7 @@ function Studio() {
             <div className={styles.heroCtas}>
               <a
                 className={styles.primaryCta}
-                href="https://flet.app"
+                href="https://studio.flet.dev"
                 target="_blank"
                 rel="noopener noreferrer">
                 Try Flet Studio
@@ -116,7 +116,7 @@ function Studio() {
             <div className={styles.closingCtas}>
               <a
                 className={styles.primaryCta}
-                href="https://flet.app"
+                href="https://studio.flet.dev"
                 target="_blank"
                 rel="noopener noreferrer">
                 Try Flet Studio

--- a/website/static/img/pages/studio/file-browser.svg
+++ b/website/static/img/pages/studio/file-browser.svg
@@ -58,7 +58,7 @@
        transform="matrix(0.69335364,0,0,0.69335364,256.16145,533.09794)"><tspan
          x="162.63674"
          y="438.52576"
-         id="tspan3">https://flet.app</tspan></text><rect
+         id="tspan3">https://studio.flet.dev</tspan></text><rect
        style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.817852;stroke-linecap:square;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
        id="rect22-4-6-5-9"
        width="961.01294"

--- a/website/static/img/pages/studio/fork-edit-share.svg
+++ b/website/static/img/pages/studio/fork-edit-share.svg
@@ -58,7 +58,7 @@
        transform="matrix(0.69335364,0,0,0.69335364,256.16145,533.09794)"><tspan
          x="162.63674"
          y="438.52576"
-         id="tspan3">https://flet.app</tspan></text><rect
+         id="tspan3">https://studio.flet.dev</tspan></text><rect
        style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.817852;stroke-linecap:square;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
        id="rect22-4-6-5-9"
        width="961.01294"

--- a/website/static/img/pages/studio/gallery.svg
+++ b/website/static/img/pages/studio/gallery.svg
@@ -58,7 +58,7 @@
        transform="matrix(0.69335364,0,0,0.69335364,256.16145,533.09794)"><tspan
          x="162.63674"
          y="438.52576"
-         id="tspan3">https://flet.app</tspan></text><rect
+         id="tspan3">https://studio.flet.dev</tspan></text><rect
        style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.817852;stroke-linecap:square;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
        id="rect22-4-6-5-9"
        width="961.01294"

--- a/website/static/img/pages/studio/live-preview.svg
+++ b/website/static/img/pages/studio/live-preview.svg
@@ -58,7 +58,7 @@
        transform="matrix(0.69335364,0,0,0.69335364,256.16145,533.09794)"><tspan
          x="162.63674"
          y="438.52576"
-         id="tspan3">https://flet.app</tspan></text><rect
+         id="tspan3">https://studio.flet.dev</tspan></text><rect
        style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.817852;stroke-linecap:square;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
        id="rect22-4-6-5-9"
        width="961.01294"

--- a/website/static/img/pages/studio/package-deploy.svg
+++ b/website/static/img/pages/studio/package-deploy.svg
@@ -58,7 +58,7 @@
        transform="matrix(0.69335364,0,0,0.69335364,256.16145,533.09794)"><tspan
          x="162.63674"
          y="438.52576"
-         id="tspan3">https://flet.app</tspan></text><rect
+         id="tspan3">https://studio.flet.dev</tspan></text><rect
        style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.817852;stroke-linecap:square;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
        id="rect22-4-6-5-9"
        width="961.01294"

--- a/website/static/img/pages/studio/versions.svg
+++ b/website/static/img/pages/studio/versions.svg
@@ -58,7 +58,7 @@
        transform="matrix(0.69335364,0,0,0.69335364,256.16145,533.09794)"><tspan
          x="162.63674"
          y="438.52576"
-         id="tspan3">https://flet.app</tspan></text><rect
+         id="tspan3">https://studio.flet.dev</tspan></text><rect
        style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.817852;stroke-linecap:square;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
        id="rect22-4-6-5-9"
        width="961.01294"


### PR DESCRIPTION
## Summary by Sourcery

Align Flet Studio links and gallery/demo references throughout the website and SDK docs with the new studio.flet.dev domain.

Enhancements:
- Update all Flet Studio URLs and gallery/demo links from flet.app to studio.flet.dev across blog posts, docs, navigation, and SDK references to reflect the new domain.

Documentation:
- Refresh user-facing documentation, tutorials, and blog content to reference studio.flet.dev for Flet Studio, pricing, icons browser, and live demos.