### PR TITLE
Fix ink effects and doubled padding on an animated inked `Container`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.86.6
+
+### Bug fixes
+
+* Fix ink ripples and hover highlights not covering the whole `Container` when both `ink=True` and `animate` are set, and its `padding` being applied twice. In that combination `padding` and `alignment` were passed to the outer `AnimatedContainer` *and* to the inner `Container` that wraps the content inside the `InkWell`, so a `padding=10` container was laid out with 20 on each side. The duplicated `alignment` was the more visible half: it made the `Material`/`InkWell` shrink-wrap to the content, so splashes and the hover overlay stopped short of the container's edges while `bgcolor` on the same container still filled it - the two disagreed on where the control ended. Both properties now live only on the inner container, which becomes an `AnimatedContainer` when `animate` is set so that padding and alignment changes still animate; this is what the non-animated ink path already did. Inked, animated containers with padding will render tighter than before - by the padding they declare, instead of double by @FeodorFitsner.
+
 ## 0.86.5
 
 ### Bug fixes

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -359,7 +359,7 @@ packages:
       path: "../packages/flet"
       relative: true
     source: path
-    version: "0.86.4"
+    version: "0.86.6"
   flet_ads:
     dependency: "direct main"
     description:

--- a/packages/flet/CHANGELOG.md
+++ b/packages/flet/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.86.6
+
+* Fix `Container` applying its `padding` twice, and confining ink/hover effects to the size of its content, when `ink` is enabled together with `animate`. `padding` and `alignment` were passed both to the outer `AnimatedContainer` and to the inner `Container` under the `InkWell`, so the effective padding doubled; the duplicated `alignment` also made the `Material`/`InkWell` shrink-wrap to the content, so splashes and the hover overlay no longer reached the container's edges even though `bgcolor` filled it. Both properties now live only on the inner container - an `AnimatedContainer` when `animate` is set, so they still animate - matching the non-animated ink path.
+
 ## 0.86.5
 
 _No changes in the `flet` Dart package; version bumped for release coordination with configurable Android `gradle.properties` on the Python side ([#6733](https://github.com/flet-dev/flet/pull/6733))._

--- a/packages/flet/lib/src/controls/container.dart
+++ b/packages/flet/lib/src/controls/container.dart
@@ -71,6 +71,24 @@ class ContainerControl extends StatelessWidget with FletStoreMixin {
     if ((onClick || url != null || onLongPress || onHover || onTapDown) &&
         ink &&
         !control.disabled) {
+      // `padding` and `alignment` are applied inside the `InkWell` only, so that
+      // ink effects cover the entire area of this container.
+      var inkContent = animation == null
+          ? Container(
+              padding: padding,
+              alignment: alignment,
+              clipBehavior: Clip.none,
+              child: content,
+            )
+          : AnimatedContainer(
+              duration: animation.duration,
+              curve: animation.curve,
+              padding: padding,
+              alignment: alignment,
+              clipBehavior: Clip.none,
+              child: content,
+            );
+
       var ink = Material(
           color: Colors.transparent,
           borderRadius: boxDecoration!.borderRadius,
@@ -100,12 +118,7 @@ class ContainerControl extends StatelessWidget with FletStoreMixin {
                 : null,
             borderRadius: borderRadius,
             splashColor: control.getColor("ink_color", context),
-            child: Container(
-              padding: padding,
-              alignment: alignment,
-              clipBehavior: Clip.none,
-              child: content,
-            ),
+            child: inkContent,
           ));
 
       container = animation == null
@@ -124,8 +137,6 @@ class ContainerControl extends StatelessWidget with FletStoreMixin {
               width: width,
               height: height,
               margin: margin,
-              alignment: alignment,
-              padding: padding,
               decoration: boxDecoration,
               foregroundDecoration: boxForegroundDecoration,
               clipBehavior: clipBehavior,

--- a/packages/flet/pubspec.yaml
+++ b/packages/flet/pubspec.yaml
@@ -2,7 +2,7 @@ name: flet
 description: Write entire Flutter app in Python or add server-driven UI experience into existing Flutter app.
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/flet/tree/main/packages/flet
-version: 0.86.5
+version: 0.86.6
 
 # Supported platforms
 platforms:


### PR DESCRIPTION
## Problem

When a `Container` has both `ink=True` and `animate` set, `padding` and `alignment` are applied twice - once on the outer `AnimatedContainer` and once on the inner `Container` that wraps the content inside the `InkWell`. A container declaring `padding=10` is laid out with 20 on each side.

The duplicated `alignment` is the more visible half: it makes the `Material`/`InkWell` shrink-wrap to the content, so ripples and the hover overlay stop short of the container's edges while `bgcolor` on the same container still fills it - the two disagree on where the control ends.

Repro - the right box is twice as padded, and its ripple/hover highlight only covers the small centered area around the text:

```python
import flet as ft


def main(page: ft.Page):
    page.padding = 40

    def box(label: str, animate: bool):
        return ft.Container(
            content=ft.Text(label),
            padding=20,
            alignment=ft.Alignment.CENTER,
            bgcolor=ft.Colors.AMBER_100,
            ink=True,
            animate=ft.Animation(150) if animate else None,
            on_click=lambda: None,
        )

    page.add(
        ft.Row(
            [box("ink", animate=False), box("ink + animate", animate=True)],
            spacing=20,
            tight=True,
        )
    )


ft.run(main)
```

## Fix

`padding` and `alignment` now live only on the inner container, which becomes an `AnimatedContainer` when `animate` is set so those properties still animate. This is what the non-animated ink path already did.

## Verification

Measured with `on_size_change` on a locally built macOS client - an inked container with `padding=ft.Padding.symmetric(horizontal=20, vertical=10)` now renders identically with and without `animate`:

```
SIZES: {'ink': (110.67, 40.0), 'ink+animate': (110.67, 40.0)}
MATCH: True
```

`dart analyze` is clean on the file and `flutter test` in `packages/flet` passes (31 tests).

## Note

Inked, animated containers with padding will render **tighter** than in 0.86.5 - by the padding they declare, instead of double.

Also bumps `packages/flet` to 0.86.6 with both changelog entries, since 0.86.5 is already tagged.

## Summary by Sourcery

Fix layout and ink coverage for Containers that are both ink-enabled and animated, and bump the flet package version for release.

Bug Fixes:
- Prevent Containers with both ink and animate enabled from applying padding twice and restricting ink/hover effects to the content area instead of the full container.

Build:
- Bump the flet Dart package version from 0.86.5 to 0.86.6.

Documentation:
- Document the ink + animate Container padding and ink-coverage fix in the main and package changelogs.