### PR TITLE
feat(android): use FlutterFragmentActivity and AppCompat LaunchTheme for biometrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Improvements
+
+* Android host apps now use `FlutterFragmentActivity` and an AppCompat `LaunchTheme` so biometric authentication dialogs work on API 24–27. A `biometric` cross-platform permission bundle adds `NSFaceIDUsageDescription` for iOS and macOS builds.
+
 ## 0.86.3
 
 ### Bug fixes

--- a/client/android/app/src/main/kotlin/com/appveyor/flet_client/MainActivity.kt
+++ b/client/android/app/src/main/kotlin/com/appveyor/flet_client/MainActivity.kt
@@ -1,5 +1,5 @@
 package com.appveyor.flet_client
 
-import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.android.FlutterFragmentActivity
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterFragmentActivity()

--- a/client/android/app/src/main/res/values-night/styles.xml
+++ b/client/android/app/src/main/res/values-night/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Theme applied to the Android Window while the process is starting when the OS's Dark Mode setting is on -->
-    <style name="LaunchTheme" parent="@android:style/Theme.Black.NoTitleBar">
+    <style name="LaunchTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
         <!-- Show a splash screen on the activity. Automatically removed when
              the Flutter engine draws its first frame -->
         <item name="android:windowBackground">@drawable/launch_background</item>

--- a/client/android/app/src/main/res/values/styles.xml
+++ b/client/android/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Theme applied to the Android Window while the process is starting when the OS's Dark Mode setting is off -->
-    <style name="LaunchTheme" parent="@android:style/Theme.Light.NoTitleBar">
+    <style name="LaunchTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
         <!-- Show a splash screen on the activity. Automatically removed when
              the Flutter engine draws its first frame -->
         <item name="android:windowBackground">@drawable/launch_background</item>

--- a/client/ios/Runner/Info.plist
+++ b/client/ios/Runner/Info.plist
@@ -37,6 +37,8 @@
 	</dict>
 	<key>NSCameraUsageDescription</key>
 	<string>This app uses the camera to capture photos and video.</string>
+	<key>NSFaceIDUsageDescription</key>
+	<string>This app uses biometrics to authenticate you.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>This app needs access to location.</string>
 	<key>NSMicrophoneUsageDescription</key>

--- a/sdk/python/packages/flet-cli/src/flet_cli/commands/build_base.py
+++ b/sdk/python/packages/flet-cli/src/flet_cli/commands/build_base.py
@@ -234,6 +234,17 @@ class BaseBuildCommand(BaseFlutterCommand):
                 },
                 "android_features": {},
             },
+            "biometric": {
+                "ios_info_plist": {
+                    "NSFaceIDUsageDescription": "This app uses biometrics to authenticate you."  # noqa: E501
+                },
+                "macos_info_plist": {
+                    "NSFaceIDUsageDescription": "This app uses biometrics to authenticate you."  # noqa: E501
+                },
+                "macos_entitlements": {},
+                "android_permissions": {},
+                "android_features": {},
+            },
         }
 
         # create and display build-platform-matrix table

--- a/sdk/python/templates/build/{{cookiecutter.out_dir}}/android/app/src/main/kotlin/{{ cookiecutter.kotlin_dir }}/MainActivity.kt
+++ b/sdk/python/templates/build/{{cookiecutter.out_dir}}/android/app/src/main/kotlin/{{ cookiecutter.kotlin_dir }}/MainActivity.kt
@@ -1,5 +1,5 @@
 package {{ cookiecutter.org_name_2 }}.{{ cookiecutter.package_name }}
 
-import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.android.FlutterFragmentActivity
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterFragmentActivity()

--- a/sdk/python/templates/build/{{cookiecutter.out_dir}}/android/app/src/main/res/values-night/styles.xml
+++ b/sdk/python/templates/build/{{cookiecutter.out_dir}}/android/app/src/main/res/values-night/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Theme applied to the Android Window while the process is starting when the OS's Dark Mode setting is on -->
-    <style name="LaunchTheme" parent="@android:style/Theme.Black.NoTitleBar">
+    <style name="LaunchTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
         <!-- Show a splash screen on the activity. Automatically removed when
              the Flutter engine draws its first frame -->
         <item name="android:windowBackground">@drawable/launch_background</item>

--- a/sdk/python/templates/build/{{cookiecutter.out_dir}}/android/app/src/main/res/values/styles.xml
+++ b/sdk/python/templates/build/{{cookiecutter.out_dir}}/android/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Theme applied to the Android Window while the process is starting when the OS's Dark Mode setting is off -->
-    <style name="LaunchTheme" parent="@android:style/Theme.Light.NoTitleBar">
+    <style name="LaunchTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
         <!-- Show a splash screen on the activity. Automatically removed when
              the Flutter engine draws its first frame -->
         <item name="android:windowBackground">@drawable/launch_background</item>

--- a/website/docs/publish/macos.md
+++ b/website/docs/publish/macos.md
@@ -57,6 +57,14 @@ macOS permissions are declared through [`Info.plist`](#infoplist) privacy usage 
 app [entitlements](#entitlements). You can also use the [cross-platform permission bundles](index.md#predefined-cross-platform-permission-bundles)
 to inject common entries, then override or extend them with platform-specific values.
 
+:::note Touch ID and Face ID
+`LocalAuthentication` (via the [`flet-local-auth`](../../services/localauthentication/index.md) extension) uses Apple's `LocalAuthentication` framework. No sandbox entitlement is required — `LAContext.evaluatePolicy` works inside a sandboxed app with the stock Flet entitlements. The `NSFaceIDUsageDescription` key is required on iOS and recommended on macOS; use the [`biometric` permission bundle](index.md#predefined-cross-platform-permission-bundles) or `[tool.flet.macos.info]`.
+
+Touch ID prompts require a **signed** app. Ad-hoc signing (the Flet build template's default `CODE_SIGN_IDENTITY = "-"`) is sufficient for local development.
+
+If you bind secrets to biometrics through [`SecureStorage`](../../services/securestorage/index.md) keychain access controls instead of a simple authentication prompt, you may need `keychain-access-groups` entitlements when sharing items across targets.
+:::
+
 ### Info.plist
 
 Add or override `Info.plist` entries for macOS builds.

--- a/website/docs/publish/macos.md
+++ b/website/docs/publish/macos.md
@@ -58,11 +58,11 @@ app [entitlements](#entitlements). You can also use the [cross-platform permissi
 to inject common entries, then override or extend them with platform-specific values.
 
 :::note Touch ID and Face ID
-`LocalAuthentication` (via the [`flet-local-auth`](../../services/localauthentication/index.md) extension) uses Apple's `LocalAuthentication` framework. No sandbox entitlement is required — `LAContext.evaluatePolicy` works inside a sandboxed app with the stock Flet entitlements. The `NSFaceIDUsageDescription` key is required on iOS and recommended on macOS; use the [`biometric` permission bundle](index.md#predefined-cross-platform-permission-bundles) or `[tool.flet.macos.info]`.
+`LocalAuthentication` (via the [`flet-local-auth`](../services/localauthentication/index.md) extension) uses Apple's `LocalAuthentication` framework. No sandbox entitlement is required — `LAContext.evaluatePolicy` works inside a sandboxed app with the stock Flet entitlements. The `NSFaceIDUsageDescription` key is required on iOS and recommended on macOS; use the [`biometric` permission bundle](index.md#predefined-cross-platform-permission-bundles) or `[tool.flet.macos.info]`.
 
 Touch ID prompts require a **signed** app. Ad-hoc signing (the Flet build template's default `CODE_SIGN_IDENTITY = "-"`) is sufficient for local development.
 
-If you bind secrets to biometrics through [`SecureStorage`](../../services/securestorage/index.md) keychain access controls instead of a simple authentication prompt, you may need `keychain-access-groups` entitlements when sharing items across targets.
+If you bind secrets to biometrics through [`SecureStorage`](../services/securestorage/index.md) keychain access controls instead of a simple authentication prompt, you may need `keychain-access-groups` entitlements when sharing items across targets.
 :::
 
 ### Info.plist

--- a/website/docs/publish/macos.md
+++ b/website/docs/publish/macos.md
@@ -57,12 +57,9 @@ macOS permissions are declared through [`Info.plist`](#infoplist) privacy usage 
 app [entitlements](#entitlements). You can also use the [cross-platform permission bundles](index.md#predefined-cross-platform-permission-bundles)
 to inject common entries, then override or extend them with platform-specific values.
 
-:::note Touch ID and Face ID
-`LocalAuthentication` (via the [`flet-local-auth`](../services/localauthentication/index.md) extension) uses Apple's `LocalAuthentication` framework. No sandbox entitlement is required — `LAContext.evaluatePolicy` works inside a sandboxed app with the stock Flet entitlements. The `NSFaceIDUsageDescription` key is required on iOS and recommended on macOS; use the [`biometric` permission bundle](index.md#predefined-cross-platform-permission-bundles) or `[tool.flet.macos.info]`.
-
-Touch ID prompts require a **signed** app. Ad-hoc signing (the Flet build template's default `CODE_SIGN_IDENTITY = "-"`) is sufficient for local development.
-
-If you bind secrets to biometrics through [`SecureStorage`](../services/securestorage/index.md) keychain access controls instead of a simple authentication prompt, you may need `keychain-access-groups` entitlements when sharing items across targets.
+:::note Biometric usage descriptions
+The `biometric` permission bundle injects `NSFaceIDUsageDescription` on iOS and macOS.
+Override the string via `[tool.flet.ios.info]`, `[tool.flet.macos.info]`, or `--info-plist`.
 :::
 
 ### Info.plist


### PR DESCRIPTION
## Description

Android host infrastructure required for biometric authentication and other plugins that need a `FragmentActivity` (e.g. `local_auth`).

Changes:
- `FlutterActivity` → `FlutterFragmentActivity` in the dev client and `flet build` template
- `LaunchTheme` parent → `Theme.AppCompat.DayNight.NoActionBar` (light + night) so biometric dialogs work on API 24–27
- `biometric` cross-platform permission bundle (`NSFaceIDUsageDescription` for iOS/macOS)
- Face ID usage string in dev client `Info.plist`
- macOS publish docs: Touch ID signing notes; fixed service doc links
- Changelog entry under `## Unreleased` → Improvements

This PR is intentionally separate from the `flet-local-auth` extension so the host-app blast radius can be reviewed and reverted independently. The extension PR stacks on this one.

Related: closes #3192 (supersedes closed #3682) and #5226.

> **Note:** `FlutterFragmentActivity` R8 keep-rule docs in `website/docs/publish/android.md` depend on the ProGuard/R8 docs section landing on `release/flet-1.0` (on `main` via #6741). Functional code does not depend on that docs section.

## Test code

```python
# No Python API in this PR — verify Android template builds and biometric permission bundle:

# flet build apk / aab with:
# [tool.flet]
# permissions = ["biometric"]

# Confirm generated Android project uses FlutterFragmentActivity and AppCompat LaunchTheme.
```
## Type of change

<!-- select only options relevant to your PR -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] I signed the CLA.
- [x] I have performed a self-review of my own code.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] New and existing tests pass locally with my changes.
- [x] I have made corresponding documentation changes, if applicable.
- [x] I have added changelog entries for user-facing changes, if applicable.
- [x] I have updated release guide pages and `website/sidebars.yml` for breaking changes, removals, and deprecations, if applicable.

## Screenshots
N/A — host/template change; no UI change beyond correct biometric dialog behavior on Android.

## Additional details

N/A

## Summary by Sourcery

Update Android host apps and templates to support biometric authentication and add a cross-platform biometric permission bundle with accompanying documentation and changelog entry.

New Features:
- Introduce a `biometric` cross-platform permission bundle that injects Face ID usage descriptions for iOS and macOS builds.

Enhancements:
- Switch Android dev client and template main activities to `FlutterFragmentActivity` to support plugins requiring a FragmentActivity, such as biometric authentication.
- Adopt an AppCompat `LaunchTheme` (`Theme.AppCompat.DayNight.NoActionBar`) for Android launch screens in the dev client and templates to ensure biometric dialogs work correctly on older API levels.

Documentation:
- Document the `biometric` permission bundle behavior for macOS, including how to override Face ID usage descriptions.
- Add an unreleased changelog entry describing the Android host and biometric permission changes.