### PR TITLE
fix(ci): patch flet-platform-assets version before publishing

### DIFF
--- a/.github/scripts/common.sh
+++ b/.github/scripts/common.sh
@@ -6,7 +6,7 @@ function patch_python_package_versions() (
     uv sync --no-default-groups || true
 
     # Update package versions in version.py and pyproject.toml files
-    for pkg in flet flet-cli flet-desktop flet-web; do
+    for pkg in flet flet-cli flet-desktop flet-platform-assets flet-web; do
       version_py="packages/$pkg/src/${pkg//-/_}/version.py"
       if [[ -f "$version_py" ]]; then
         sed -i -e "s/^flet_version = \"\"/flet_version = \"$PYPI_VER\"/g" "$version_py"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1038,5 +1038,5 @@ jobs:
             flet_video \
             flet_webview \
             flet_mcp; do
-            uv publish dist/**/${pkg}-*
+            uv publish --check-url https://pypi.org/simple dist/**/${pkg}-*
           done


### PR DESCRIPTION
## Problem

The tagged release run for `v1.0.0.dev1` [failed during PyPI publish](https://github.com/flet-dev/flet/actions/runs/34431135419/job/102729036448):

```
error: Failed to publish `dist/flet_platform_assets-0.1.0-py3-none-any.whl`
  Caused by: Server returned status code 400 Bad Request.
  Server says: 400 File already exists ('flet_platform_assets-0.1.0-py3-none-any.whl' ...)
```

`flet-platform-assets` was added to the workspace, to the build step (`.github/workflows/ci.yml`) and to the publish list, but never to the version-patch loop in `.github/scripts/common.sh`, which only covered `flet flet-cli flet-desktop flet-web`. It was therefore always built at its literal `version = "0.1.0"` from `pyproject.toml`, and PyPI rejects re-uploading a filename it already has.

Because the publish loop is a plain `for` over 27 packages, it aborted on package 4. `flet_web`, all 19 extensions and `flet_mcp` never shipped.

### Secondary breakage

`patch_toml_versions.py` pins internal deps, and `flet-cli` depends on `flet-platform-assets`. So the already-published `flet-cli 1.0.0.dev0` declares:

```
flet==1.0.0.dev0
flet-platform-assets==1.0.0.dev0
```

but PyPI only ever received `flet-platform-assets` `0.0.0` and `0.1.0`. That release of `flet-cli` is uninstallable today. The same one-line fix resolves it.

`flet-local-auth`, the other recently added package, is **not** affected: it is in the extensions `PACKAGES` array, and that loop calls `patch_toml_versions` per package.

## Changes

1. `common.sh` - add `flet-platform-assets` to the version-patch loop. It has no `version.py`, which the loop already handles by printing a skip message.
2. `ci.yml` - pass `--check-url https://pypi.org/simple` to `uv publish` so the loop skips files already on PyPI instead of erroring out. This makes a partially-completed release re-runnable rather than requiring a version bump.

## Verification

- `uv version --package flet-platform-assets` resolves it as a workspace member (returns `flet-platform-assets 0.1.0`), so `uv version --package ... $PYPI_VER` in the loop will work.
- Ran `patch_toml_versions.py` against temp copies of both pyprojects at `1.0.0.dev1`: `flet-platform-assets` version becomes `1.0.0.dev1`, and `flet-cli`'s dependency pins to `flet-platform-assets==1.0.0.dev1`.
- Confirmed all 19 extension directories under `sdk/python/packages/` are present in the extensions `PACKAGES` array, so no other package has this gap.

## Recovery for v1.0.0.dev1

After merging, re-run the **full** workflow on the `v1.0.0.dev1` tag. `PYPI_VER` derives deterministically from the tag name (`update_build_version.sh`), so the version is unchanged; `--check-url` skips the three packages already uploaded and the remaining 24 publish.

Re-running only the publish job will not work - the stored artifacts still contain the `0.1.0` wheel, so the build jobs must run again.

## Summary by Sourcery

Make tagged package releases recoverable by aligning flet-platform-assets versions and skipping artifacts that have already been published.

Bug Fixes:
- Include flet-platform-assets in release version patching so it is published with the tagged release version and its dependent packages remain installable.
- Make PyPI publishing skip already-uploaded artifacts so partially completed releases can be safely rerun.

CI:
- Update the release workflow to use PyPI availability checks when publishing packages.